### PR TITLE
Fixes #4 Name of channel "Eén" should capitalized

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -53,8 +53,8 @@ msgid "Livestreams"
 msgstr "Livestreams"
 
 msgctxt "#32101"
-msgid "één"
-msgstr "één"
+msgid "Eén"
+msgstr "Eén"
 
 msgctxt "#32102"
 msgid "Canvas"


### PR DESCRIPTION
Fixes issue #4 .