### PR TITLE
Added video broadcast date to video items

### DIFF
--- a/resources/lib/vrtplayer/metadatacollector.py
+++ b/resources/lib/vrtplayer/metadatacollector.py
@@ -13,7 +13,7 @@ class MetadataCollector:
         metadata_creator = metadatacreator.MetadataCreator()
         metadata_creator.duration = self.__get_episode_duration(soup)
         metadata_creator.plot = self.get_plot(soup)
-        metadata_creator.date = self.get_broadcast_date(soup)
+        metadata_creator.datetime = self.get_broadcast_datetime(soup)
         return metadata_creator.get_video_dictionary()
 
     def get_multiple_layout_episode_metadata(self, soup):
@@ -22,7 +22,7 @@ class MetadataCollector:
         return metadata_creator.get_video_dictionary()
 
     @staticmethod
-    def __get_episode_duration( soup):
+    def __get_episode_duration(soup):
         duration = None
         duration_item = soup.find(class_="content__duration")
         if duration_item is not None:
@@ -52,20 +52,20 @@ class MetadataCollector:
         return description
 
     @staticmethod
-    def get_broadcast_date(soup):
-        broadcast_date_tag = soup.find(class_="content__broadcastdate")
+    def get_broadcast_datetime(soup):
+        broadcast_datetime = None
+        broadcast_date_element = soup.find(class_="content__broadcastdate")
         
-        if broadcast_date_tag is None:
-            return ""
+        if broadcast_date_element is None:
+            return broadcast_datetime
 
-        time_tag = broadcast_date_tag.find("time")
+        time_element = broadcast_date_element.find("time")
 
-        if time_tag is None:
-            return ""
+        if time_element is None:
+            return broadcast_datetime
         
-        datetime_string = time_tag["datetime"]
-        datetime = time.strptime(datetime_string[:18], "%Y-%m-%dT%H:%M:%S")
-        return time.strftime(("%d.%m.%Y"), datetime)
+        broadcast_datetime = time.strptime(time_element["datetime"][:18], "%Y-%m-%dT%H:%M:%S")
+        return broadcast_datetime
 
     @staticmethod
     def __get_multiple_layout_episode_duration(soup):

--- a/resources/lib/vrtplayer/metadatacollector.py
+++ b/resources/lib/vrtplayer/metadatacollector.py
@@ -13,7 +13,7 @@ class MetadataCollector:
         metadata_creator = metadatacreator.MetadataCreator()
         metadata_creator.duration = self.__get_episode_duration(soup)
         metadata_creator.plot = self.get_plot(soup)
-		metadata_creator.date = self.get_broadcast_date(soup)
+        metadata_creator.date = self.get_broadcast_date(soup)
         return metadata_creator.get_video_dictionary()
 
     def get_multiple_layout_episode_metadata(self, soup):
@@ -51,21 +51,21 @@ class MetadataCollector:
             description = description_item.text
         return description
 
-	@staticmethod
-	def get_broadcast_date(soup):
-		broadcast_date_tag = soup.find(class_="content__broadcastdate")
-		
-		if broadcast_date_tag is None:
-			return ""
+    @staticmethod
+    def get_broadcast_date(soup):
+        broadcast_date_tag = soup.find(class_="content__broadcastdate")
+        
+        if broadcast_date_tag is None:
+            return ""
 
-		time_tag = broadcast_date_tag.find("time")
+        time_tag = broadcast_date_tag.find("time")
 
-		if time_tag is None:
-			return ""
-		
-		datetime_string = time_tag["datetime"]
-		datetime = time.strptime(datetime_string[:18], "%Y-%m-%dT%H:%M:%S")
-		return time.strftime(("%d.%m.%Y"), datetime)
+        if time_tag is None:
+            return ""
+        
+        datetime_string = time_tag["datetime"]
+        datetime = time.strptime(datetime_string[:18], "%Y-%m-%dT%H:%M:%S")
+        return time.strftime(("%d.%m.%Y"), datetime)
 
     @staticmethod
     def __get_multiple_layout_episode_duration(soup):

--- a/resources/lib/vrtplayer/metadatacollector.py
+++ b/resources/lib/vrtplayer/metadatacollector.py
@@ -1,4 +1,5 @@
 import re
+import time
 from resources.lib.vrtplayer import metadatacreator
 from resources.lib.vrtplayer import statichelper
 
@@ -12,6 +13,7 @@ class MetadataCollector:
         metadata_creator = metadatacreator.MetadataCreator()
         metadata_creator.duration = self.__get_episode_duration(soup)
         metadata_creator.plot = self.get_plot(soup)
+		metadata_creator.date = self.get_broadcast_date(soup)
         return metadata_creator.get_video_dictionary()
 
     def get_multiple_layout_episode_metadata(self, soup):
@@ -48,6 +50,22 @@ class MetadataCollector:
         if description_item is not None:
             description = description_item.text
         return description
+
+	@staticmethod
+	def get_broadcast_date(soup):
+		broadcast_date_tag = soup.find(class_="content__broadcastdate")
+		
+		if broadcast_date_tag is None:
+			return ""
+
+		time_tag = broadcast_date_tag.find("time")
+
+		if time_tag is None:
+			return ""
+		
+		datetime_string = time_tag["datetime"]
+		datetime = time.strptime(datetime_string[:18], "%Y-%m-%dT%H:%M:%S")
+		return time.strftime(("%d.%m.%Y"), datetime)
 
     @staticmethod
     def __get_multiple_layout_episode_duration(soup):

--- a/resources/lib/vrtplayer/metadatacreator.py
+++ b/resources/lib/vrtplayer/metadatacreator.py
@@ -3,7 +3,7 @@ class MetadataCreator:
     def __init__(self):
         self._duration = None
         self._plot = None
-		self._date = None
+        self._date = None
 
     @property
     def duration(self):
@@ -21,12 +21,13 @@ class MetadataCreator:
     def plot(self, value):
         self._plot = value.strip()
 
-	@property
-	def date(self):
-		return self._date
+    @property
+    def date(self):
+        return self._date
 
-	@date.setter(self, value):
-		self._date = value
+    @date.setter
+    def date (self, value):
+        self._date = value
 
     def get_video_dictionary(self):
         video_dictionary = dict()
@@ -34,6 +35,6 @@ class MetadataCreator:
             video_dictionary["plot"] = self.plot
         if self.duration is not None:
             video_dictionary["duration"] = self.duration
-		if self.date is not None:
-			video_dictionary["date"] = self.date
+        if self.date is not None:
+            video_dictionary["date"] = self.date
         return video_dictionary

--- a/resources/lib/vrtplayer/metadatacreator.py
+++ b/resources/lib/vrtplayer/metadatacreator.py
@@ -3,6 +3,7 @@ class MetadataCreator:
     def __init__(self):
         self._duration = None
         self._plot = None
+		self._date = None
 
     @property
     def duration(self):
@@ -20,11 +21,19 @@ class MetadataCreator:
     def plot(self, value):
         self._plot = value.strip()
 
+	@property
+	def date(self):
+		return self._date
+
+	@date.setter(self, value):
+		self._date = value
+
     def get_video_dictionary(self):
         video_dictionary = dict()
         if self.plot is not None:
             video_dictionary["plot"] = self.plot
         if self.duration is not None:
             video_dictionary["duration"] = self.duration
+		if self.date is not None:
+			video_dictionary["date"] = self.date
         return video_dictionary
-

--- a/resources/lib/vrtplayer/metadatacreator.py
+++ b/resources/lib/vrtplayer/metadatacreator.py
@@ -1,9 +1,12 @@
+import time
+
+
 class MetadataCreator:
 
     def __init__(self):
         self._duration = None
         self._plot = None
-        self._date = None
+        self._datetime = None
 
     @property
     def duration(self):
@@ -22,19 +25,24 @@ class MetadataCreator:
         self._plot = value.strip()
 
     @property
-    def date(self):
-        return self._date
+    def datetime(self):
+        return self._datetime
 
-    @date.setter
-    def date (self, value):
-        self._date = value
+    @datetime.setter
+    def datetime (self, value):
+        self._datetime = value
 
     def get_video_dictionary(self):
         video_dictionary = dict()
+
         if self.plot is not None:
             video_dictionary["plot"] = self.plot
+
         if self.duration is not None:
             video_dictionary["duration"] = self.duration
-        if self.date is not None:
-            video_dictionary["date"] = self.date
+
+        if self.datetime is not None:
+            video_dictionary["date"] = time.strftime("%d.%m.%Y", self.datetime)
+            video_dictionary["shortdate"] = time.strftime("%d/%m", self.datetime)
+
         return video_dictionary

--- a/resources/lib/vrtplayer/vrtplayer.py
+++ b/resources/lib/vrtplayer/vrtplayer.py
@@ -162,13 +162,17 @@ class VRTPlayer:
         return items
 
     def get_single_video(self, path, soup):
+        video_dictionary = self.metadata_collector.get_single_layout_episode_metadata(soup)
+        list_item_title = soup.find(class_="content__title").text
+
+        if video_dictionary.date is not None:
+            list_item_title = video_dictionary.date + " " + list_item_title
+
         vrt_video = soup.find(class_="vrtvideo")
         thumbnail = VRTPlayer.format_image_url(vrt_video)
-        li = xbmcgui.ListItem(soup.find(class_="content__title").text)
+
+        li = xbmcgui.ListItem(list_item_title)
         li.setProperty('IsPlayable', 'true')
-
-        video_dictionary = self.metadata_collector.get_single_layout_episode_metadata(soup)
-
         li.setInfo('video', video_dictionary)
         li.setArt({'thumb': thumbnail})
         url = '{0}?action=play&video={1}'.format(self._url, path)
@@ -211,12 +215,16 @@ class VRTPlayer:
     def __get_item(element, is_playable):
         thumbnail = VRTPlayer.format_image_url(element)
         found_element = element.find(class_="tile__title")
+
         li = None
         if found_element is not None:
-            stripped = statichelper.replace_newlines_and_strip(found_element.contents[0])
-            li = xbmcgui.ListItem(stripped)
+            title = statichelper.replace_newlines_and_strip(found_element.contents[0])
+            broadcast_date_tag = element.find(class_="tile__broadcastdate--mobile")
+
+            if broadcast_date_tag is not None:
+                title = broadcast_date_tag.text + " " + title
+
+            li = xbmcgui.ListItem(title)
             li.setProperty('IsPlayable', is_playable)
             li.setArt({'thumb': thumbnail})
         return li
-
-

--- a/resources/lib/vrtplayer/vrtplayer.py
+++ b/resources/lib/vrtplayer/vrtplayer.py
@@ -104,7 +104,6 @@ class VRTPlayer:
             False, thumbnail, video_dictionary)
             listing.append(item)
         return listing
-    
 
     def get_main_menu_items(self):
         return {helperobjects.TitleItem(self._addon.getLocalizedString(32091), {'action': actions.LISTING_AZ}, False,
@@ -165,8 +164,8 @@ class VRTPlayer:
         video_dictionary = self.metadata_collector.get_single_layout_episode_metadata(soup)
         list_item_title = soup.find(class_="content__title").text
 
-        if video_dictionary.date is not None:
-            list_item_title = video_dictionary.date + " " + list_item_title
+        if "shortdate" in video_dictionary:
+            list_item_title = video_dictionary["shortdate"] + " " + list_item_title
 
         vrt_video = soup.find(class_="vrtvideo")
         thumbnail = VRTPlayer.format_image_url(vrt_video)


### PR DESCRIPTION
Fixes issue #1.

Prepended the title of each video item (Kodi list items) with the broadcast date (release date).

This makes videos much easier to identify, as it sometimes takes several hours before a new episode comes available online.

At the moment, I'm using the date format as it is displayed in the tag with the `tile__broadcastdate--mobile` class. As a further improvement, we can (should?) parse this date using [`datetime.strptime()`][1], and format it in another, less ambiguous format (e.g. "25 JUN 2017" or "2017-06-25" for today).

Hope you like my contribution!

[1]: https://docs.python.org/2/library/datetime.html#strftime-and-strptime-behavior