### PR TITLE
support for drm livestreams

### DIFF
--- a/plugin.video.vrt.nu/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.vrt.nu/resources/language/resource.language.en_gb/strings.po
@@ -32,6 +32,14 @@ msgctxt "#32011"
 msgid "Show subtitles if available"
 msgstr "Show subtitles if available"
 
+msgctxt "#32020"
+msgid "DRM"
+msgstr "DRM"
+
+msgctxt "#32021"
+msgid "Use DRM for 720p HD-quality livestreams"
+msgstr "Use DRM for 720p HD-quality livestreams"
+
 msgctxt "#32051"
 msgid "Could not login!"
 msgstr "could not login"

--- a/plugin.video.vrt.nu/resources/lib/kodiwrappers/kodiwrapper.py
+++ b/plugin.video.vrt.nu/resources/lib/kodiwrappers/kodiwrapper.py
@@ -41,8 +41,15 @@ class KodiWrapper:
                 play_item.setSubtitles([stream.subtitle_url])
             xbmcplugin.setResolvedUrl(self._handle, True, listitem=play_item)
 
-    def play_livestream(self, path):
+    def play_livestream(self, path,  license_key):
         play_item = xbmcgui.ListItem(path=path)
+        if license_key is not None:            
+            play_item.setProperty('inputstreamaddon', 'inputstream.adaptive')
+            play_item.setProperty('inputstream.adaptive.license_type', 'com.widevine.alpha')
+            play_item.setProperty('inputstream.adaptive.manifest_type', 'mpd')
+            play_item.setProperty('inputstream.adaptive.license_key', license_key)
+            play_item.setMimeType('application/dash+xml')
+            play_item.setContentLookup(False)
         xbmcplugin.setResolvedUrl(self._handle, True, listitem=play_item)
 
     def show_ok_dialog(self, title, message):

--- a/plugin.video.vrt.nu/resources/lib/vrtplayer/streamservice.py
+++ b/plugin.video.vrt.nu/resources/lib/vrtplayer/streamservice.py
@@ -13,6 +13,10 @@ class StreamService:
     def __init__(self, kodi_wrapper):
         self._kodi_wrapper = kodi_wrapper
 
+    def _get_token_from_(self):
+        token = requests.post(self._TOKEN_URL, headers={'Content-Type': 'application/json'}).json()['vrtPlayerToken']
+        return token
+
     def _get_session_and_token_from_(self):
         session = requests.session()
         token = None

--- a/plugin.video.vrt.nu/resources/lib/vrtplayer/urltolivestreamservice.py
+++ b/plugin.video.vrt.nu/resources/lib/vrtplayer/urltolivestreamservice.py
@@ -9,16 +9,60 @@ class UrlToLivestreamService(streamservice.StreamService):
 
     _TOKEN_URL = "https://media-services-public.vrt.be/vualto-video-aggregator-web/rest/external/v1/tokens"
 
+    def get_license_key(self, keyUrl, keyType="R", keyHeaders=None, keyValue=None):
+            """ Generates a propery license key value
+
+            # A{SSM} -> not implemented
+            # R{SSM} -> raw format
+            # B{SSM} -> base64 format
+            # D{SSM} -> decimal format
+
+            The generic format for a LicenseKey is:
+            |<url>|<headers>|<key with placeholders|
+
+            The Widevine Decryption Key Identifier (KID) can be inserted via the placeholder {KID}
+
+            @type keyUrl: str
+            @param keyUrl: the URL where the license key can be obtained
+
+            @type keyType: str
+            @param keyType: the key type (A, R, B or D)
+
+            @type keyHeaders: dict
+            @param keyHeaders: A dictionary that contains the HTTP headers to pass
+
+            @type keyValue: str
+            @param keyValue: i
+            @return:
+            """
+
+            header = ""
+            if keyHeaders:
+                for k, v in list(keyHeaders.items()):
+                    header = "{0}&{1}={2}".format(header, k, requests.utils.quote(v))
+
+            if keyType in ("A", "R", "B"):
+                keyValue = "{0}{{SSM}}".format(keyType)
+            elif keyType == "D":
+                if "D{SSM}" not in keyValue:
+                    raise ValueError("Missing D{SSM} placeholder")
+                keyValue = requests.utils.quote(keyValue)
+
+            return "{0}|{1}|{2}|".format(keyUrl, header.strip("&"), keyValue)
+
     def get_stream_from_url(self, url):
-        (session, token) = super(UrlToLivestreamService, self)._get_session_and_token_from_()
+        (token) = super(UrlToLivestreamService, self)._get_token_from_()
 
         stream_response = requests.get(url, {'vrtPlayerToken': token, 'client':'vrtvideo' }).json()
         target_urls = stream_response['targetUrls']
-        found_url = False
-        index = 0
-        while not found_url and index < len(target_urls):
-          item = target_urls[index]
-          found_url = item['type'] == 'hls_aes'
-          stream = item['url']
-          index +=1
-        return stream
+        stream_dict = {}
+        for stream in target_urls:
+            stream_dict[stream['type']] = stream['url']
+        if self._kodi_wrapper.get_setting('usedrm') == 'true':
+            vudrm_token = stream_response['drm']
+            license_url = requests.get('https://api.vuplay.co.uk').json()['drm_providers']['widevine']['la_url']
+            encryption_json = '{{"token":"{0}","drm_info":[D{{SSM}}],"kid":"{{KID}}"}}'.format(vudrm_token)
+            license_key = self.get_license_key(keyUrl=license_url, keyType="D", keyValue=encryption_json, keyHeaders={"Content-Type": "text/plain;charset=UTF-8"})
+            return stream_dict['mpeg_dash'], license_key
+        else:
+            return stream_dict['hls_aes'], None

--- a/plugin.video.vrt.nu/resources/lib/vrtplayer/vrtplayer.py
+++ b/plugin.video.vrt.nu/resources/lib/vrtplayer/vrtplayer.py
@@ -80,8 +80,8 @@ class VRTPlayer:
         self._kodi_wrapper.play_video(stream)
 
     def play_livestream(self, url):
-        stream = self.url_to_livestream_service.get_stream_from_url(url)
-        self._kodi_wrapper.play_livestream(stream)
+        stream, license_key = self.url_to_livestream_service.get_stream_from_url(url)
+        self._kodi_wrapper.play_livestream(stream, license_key)
 
     def show_livestream_items(self):
         livestream_items = {helperobjects.TitleItem(self._kodi_wrapper.get_localized_string(32101),

--- a/plugin.video.vrt.nu/resources/settings.xml
+++ b/plugin.video.vrt.nu/resources/settings.xml
@@ -7,4 +7,7 @@
     <category label="32010">
         <setting label="32011" type="bool" id="showsubtitles" default="true" />
     </category>
+    <category label="32020">
+        <setting label="32021" type="bool" id="usedrm" default="false" />
+    </category>
 </settings>


### PR DESCRIPTION
Hello,

I added support for the DRM-protected 720p livestreams. You can switch DRM on in the addon settings.
You need the latest Kodi 18 and inputstream.adaptive with libwidevinecdm.