### PR TITLE
auto install widevine drm when enabling in settings

### DIFF
--- a/plugin.video.vrt.nu/addon.py
+++ b/plugin.video.vrt.nu/addon.py
@@ -10,7 +10,7 @@ _handle = int(sys.argv[1])
 
 def router(params_string):
     addon = xbmcaddon.Addon()
-    kodi_wrapper = kodiwrapper.KodiWrapper(_handle, _url, addon)
+    kodi_wrapper = kodiwrapper.KodiWrapper(addon, _handle, _url)
     token_resolver = tokenresolver.TokenResolver(kodi_wrapper)
     stream_service = urltostreamservice.UrlToStreamService(vrtplayer.VRTPlayer._VRT_BASE,
                                                            vrtplayer.VRTPlayer._VRTNU_BASE_URL,

--- a/plugin.video.vrt.nu/addon.xml
+++ b/plugin.video.vrt.nu/addon.xml
@@ -8,12 +8,15 @@
         <import addon="xbmc.python" version="2.25.0"/>
         <import addon="script.module.requests" version="2.19.1"/>
         <import addon="script.module.beautifulsoup4" version="4.5.3"/>
+        <import addon="inputstream.adaptive" version="2.0.19" />
         <import addon="script.module.inputstreamhelper" version="0.3.3"/>
     </requires>
 
     <extension point="xbmc.python.pluginsource" library="addon.py">
         <provides>video</provides>
     </extension>
+
+    <extension point="xbmc.service" library="service.py" start="login" />
 
     <extension point="xbmc.addon.metadata">
     <summary lang="en_GB">Addon to watch vrt.nu</summary>

--- a/plugin.video.vrt.nu/service.py
+++ b/plugin.video.vrt.nu/service.py
@@ -1,0 +1,26 @@
+import xbmc
+import xbmcaddon
+import inputstreamhelper
+from resources.lib.kodiwrappers import kodiwrapper
+
+class DrmMonitor(xbmc.Monitor):
+
+    def __init__(self):
+        xbmc.Monitor.__init__(self)
+        addon = xbmcaddon.Addon()
+        self._kodi_wrapper = kodiwrapper.KodiWrapper(addon)
+        self._is_helper = inputstreamhelper.Helper('mpd', drm='com.widevine.alpha')
+
+    def onSettingsChanged(self):
+        self._kodi_wrapper.log_notice('VRT NU Addon: settings changed')
+        if self._kodi_wrapper.get_setting('usedrm') == 'true':
+            if self._is_helper.check_inputstream():
+                 self._kodi_wrapper.log_notice('VRT NU Addon: drm installed')
+
+if __name__ == '__main__':
+
+    monitor = DrmMonitor()
+    
+    while not monitor.abortRequested():
+        if monitor.waitForAbort(10):
+            break


### PR DESCRIPTION
In my opinion whether someone uses drm or not should be a free choice. This pull request implements this way if thinking. Only if the user has enabled drm in the addon settings, widevine is installed automatically.