### PR TITLE
Add Makefile to build zip files easily

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,6 @@ msbuild.wrn
 
 # Visual Studio 2015
 .vs/
+
+# Packages
+*.zip

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,19 @@
-ADDON_XML = plugin.video.vrt.nu/addon.xml
+addon_xml = plugin.video.vrt.nu/addon.xml
 
 # Collect information to build as sensible package name
-NAME = $(shell xmllint --xpath 'string(/addon/@id)' $(ADDON_XML))
-VERSION = $(shell xmllint --xpath 'string(/addon/@version)' $(ADDON_XML))
-GIT_HASH = $(shell git rev-parse --short HEAD)
+name = $(shell xmllint --xpath 'string(/addon/@id)' $(addon_xml))
+version = $(shell xmllint --xpath 'string(/addon/@version)' $(addon_xml))
+git_hash = $(shell git rev-parse --short HEAD)
 
-ZIP_NAME = $(NAME)-$(VERSION)-$(GIT_HASH).zip
-EXCLUDE_FILES = $(NAME).pyproj vrtnutests
-ZIP_DIR = $(NAME)
+zip_name = $(name)-$(version)-$(git_hash).zip
+exclude_files = $(name).pyproj vrtnutests
+zip_dir = $(name)
 
 all: zip
 package: zip
 
 zip:
 	@echo -e "\e[1;37m=\e[1;34m Building new package\e[0m"
-	rm -f $(ZIP_NAME)
-	zip -qr $(ZIP_NAME) $(ZIP_DIR) -x $(EXCLUDE_FILES)
-	@echo -e "\e[1;37m=\e[1;34m Successfully wrote package as \e[1;37m$(ZIP_NAME)\e[0m"
+	rm -f $(zip_name)
+	zip -qr $(zip_name) $(zip_dir) -x $(exclude_files)
+	@echo -e "\e[1;37m=\e[1;34m Successfully wrote package as \e[1;37m$(zip_name)\e[0m"

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,9 @@ version = $(shell xmllint --xpath 'string(/addon/@version)' $(addon_xml))
 git_hash = $(shell git rev-parse --short HEAD)
 
 zip_name = $(name)-$(version)-$(git_hash).zip
-exclude_files = $(name).pyproj vrtnutests
-zip_dir = $(name)
+exclude_files = $(name).pyproj vrtnutests/ vrtnutests/*
+exclude_paths = $(patsubst %,$(name)/%,$(exclude_files))
+zip_dir = $(name)/
 
 all: zip
 package: zip
@@ -15,5 +16,5 @@ package: zip
 zip:
 	@echo -e "\e[1;37m=\e[1;34m Building new package\e[0m"
 	rm -f $(zip_name)
-	zip -qr $(zip_name) $(zip_dir) -x $(exclude_files)
-	@echo -e "\e[1;37m=\e[1;34m Successfully wrote package as \e[1;37m$(zip_name)\e[0m"
+	zip -r $(zip_name) $(zip_dir) -x $(exclude_paths)
+	@echo -e "\e[1;37m=\e[1;34m Successfully wrote package as: \e[1;37m$(zip_name)\e[0m"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+ADDON_XML = plugin.video.vrt.nu/addon.xml
+
+# Collect information to build as sensible package name
+NAME = $(shell xmllint --xpath 'string(/addon/@id)' $(ADDON_XML))
+VERSION = $(shell xmllint --xpath 'string(/addon/@version)' $(ADDON_XML))
+GIT_HASH = $(shell git rev-parse --short HEAD)
+
+ZIP_NAME = $(NAME)-$(VERSION)-$(GIT_HASH).zip
+EXCLUDE_FILES = $(NAME).pyproj vrtnutests
+ZIP_DIR = $(NAME)
+
+all: zip
+package: zip
+
+zip:
+	@echo -e "\e[1;37m=\e[1;34m Building new package\e[0m"
+	rm -f $(ZIP_NAME)
+	zip -qr $(ZIP_NAME) $(ZIP_DIR) -x $(EXCLUDE_FILES)
+	@echo -e "\e[1;37m=\e[1;34m Successfully wrote package as \e[1;37m$(ZIP_NAME)\e[0m"


### PR DESCRIPTION
Since the addon files are one level deeper, we can't just use a GitHub ZIP file of the current branch to test any branch (like new PRs).

This Makefile makes it quite simple, just run 'make' and a new (unique) ZIP file is created. It can help to test-drive new PR's or bisect to find when an issue was introduced.

```bash
[dag@moria plugin.video.vrt.nu]$ make
= Building new package
rm -f plugin.video.vrt.nu-1.6.0-a25e4d8.zip
zip -qr plugin.video.vrt.nu-1.6.0-a25e4d8.zip plugin.video.vrt.nu -x plugin.video.vrt.nu.pyproj vrtnutests
= Successfully wrote package as plugin.video.vrt.nu-1.6.0-a25e4d8.zip
```