### PR TITLE
 Add unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,10 @@ python:
 sudo: false
 
 install:
-- pip install tox-travis
-- pip install pylint
+- pip install -r requirements.txt
 
 script:
 - tox
-- pylint ./plugin.video.vrt.nu/*.py
-- pylint ./plugin.video.vrt.nu/resources/lib/*/*.py
-
+- pylint plugin.video.vrt.nu/*.py
+- pylint plugin.video.vrt.nu/resources/lib/*/*.py
+- make unittest

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,4 @@ script:
 - tox
 - pylint plugin.video.vrt.nu/*.py
 - pylint plugin.video.vrt.nu/resources/lib/*/*.py
-- python plugin.video.vrt.nu/vrtnutests/apihelpertests.py
-- python plugin.video.vrt.nu/vrtnutests/urltostreamservicetests.py
 - python plugin.video.vrt.nu/vrtnutests/vrtplayertests.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ python:
 
 sudo: false
 
+env:
+  PYTHONPATH: plugin.video.vrt.nu
+
 install:
 - pip install -r requirements.txt
 
@@ -14,4 +17,6 @@ script:
 - tox
 - pylint plugin.video.vrt.nu/*.py
 - pylint plugin.video.vrt.nu/resources/lib/*/*.py
-- make unittest
+- python plugin.video.vrt.nu/vrtnutests/apihelpertests.py
+- python plugin.video.vrt.nu/vrtnutests/urltostreamservicetests.py
+- python plugin.video.vrt.nu/vrtnutests/vrtplayertests.py

--- a/Makefile
+++ b/Makefile
@@ -12,15 +12,21 @@ zip_dir = $(name)/
 
 .PHONY: test
 
-
 package: zip
 
-test:
+test: unittest
 	@echo -e "\e[1;37m=\e[1;34m Starting tests\e[0m"
 	tox -e py27,py36
 	pylint $(name)/*.py
 	pylint $(name)/resources/lib/*/*.py
 	@echo -e "\e[1;37m=\e[1;34m Tests finished successfully.\e[0m"
+
+unittest:
+	@echo -e "\e[1;37m=\e[1;34m Starting unit tests\e[0m"
+	PYTHONPATH=$(name) python $(name)/vrtnutests/apihelpertests.py
+	PYTHONPATH=$(name) python $(name)/vrtnutests/urltostreamservicetests.py
+	PYTHONPATH=$(name) python $(name)/vrtnutests/vrtplayertests.py
+	@echo -e "\e[1;37m=\e[1;34m Unit tests finished successfully.\e[0m"
 
 zip:
 	@echo -e "\e[1;37m=\e[1;34m Building new package\e[0m"

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,11 @@ zip_dir = $(name)/
 
 package: zip
 
+clean:
+	@echo -e "\e[1;37m=\e[1;34m Clean up project directory\e[0m"
+	find . -name '*.pyc' -delete
+	@echo -e "\e[1;37m=\e[1;34m Finished cleaning up.\e[0m"
+
 test: unittest
 	@echo -e "\e[1;37m=\e[1;34m Starting tests\e[0m"
 	pylint $(name)/*.py
@@ -26,7 +31,7 @@ unittest:
 	PYTHONPATH=$(name) python $(name)/vrtnutests/vrtplayertests.py
 	@echo -e "\e[1;37m=\e[1;34m Unit tests finished successfully.\e[0m"
 
-zip:
+zip: clean
 	@echo -e "\e[1;37m=\e[1;34m Building new package\e[0m"
 	rm -f $(zip_name)
 	zip -r $(zip_name) $(zip_dir) -x $(exclude_paths)

--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,9 @@ package: zip
 
 test: unittest
 	@echo -e "\e[1;37m=\e[1;34m Starting tests\e[0m"
-	tox -e py27,py36
 	pylint $(name)/*.py
 	pylint $(name)/resources/lib/*/*.py
+	tox -e py27,py36
 	@echo -e "\e[1;37m=\e[1;34m Tests finished successfully.\e[0m"
 
 unittest:

--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,6 @@ test: unittest
 
 unittest:
 	@echo -e "\e[1;37m=\e[1;34m Starting unit tests\e[0m"
-	PYTHONPATH=$(name) python $(name)/vrtnutests/apihelpertests.py
-	PYTHONPATH=$(name) python $(name)/vrtnutests/urltostreamservicetests.py
 	PYTHONPATH=$(name) python $(name)/vrtnutests/vrtplayertests.py
 	@echo -e "\e[1;37m=\e[1;34m Unit tests finished successfully.\e[0m"
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/pietje666/plugin.video.vrt.nu.svg?branch=master)](https://travis-ci.org/pietje666/plugin.video.vrt.nu)
+
 # plugin.video.vrt.nu
 
 **plugin.video.vrt.nu** is a [Kodi][1] add-on used to watch all live video streams *and* all video-on-demand

--- a/plugin.video.vrt.nu/resources/lib/helperobjects/streamurls.py
+++ b/plugin.video.vrt.nu/resources/lib/helperobjects/streamurls.py
@@ -11,7 +11,7 @@ class StreamURLS:
         self._stream_url = stream_url
         self._subtitle_url = subtitle_url
         self._license_key = license_key
-        self.use_inputstream_adaptive = use_inputstream_adaptive
+        self._use_inputstream_adaptive = use_inputstream_adaptive
         self._video_id = None
 
     @property
@@ -32,4 +32,4 @@ class StreamURLS:
 
     @property
     def use_inputstream_adaptive(self):
-        return self.use_inputstream_adaptive
+        return self._use_inputstream_adaptive

--- a/plugin.video.vrt.nu/resources/lib/helperobjects/streamurls.py
+++ b/plugin.video.vrt.nu/resources/lib/helperobjects/streamurls.py
@@ -11,7 +11,7 @@ class StreamURLS:
         self._stream_url = stream_url
         self._subtitle_url = subtitle_url
         self._license_key = license_key
-        self._use_inputstream_adaptive = use_inputstream_adaptive
+        self.use_inputstream_adaptive = use_inputstream_adaptive
         self._video_id = None
 
     @property
@@ -31,5 +31,5 @@ class StreamURLS:
         return self._license_key
 
     @property
-    def _use_inputstream_adaptive(self):
-        return self._use_inputstream_adaptive
+    def use_inputstream_adaptive(self):
+        return self.use_inputstream_adaptive

--- a/plugin.video.vrt.nu/resources/lib/vrtplayer/vrtplayer.py
+++ b/plugin.video.vrt.nu/resources/lib/vrtplayer/vrtplayer.py
@@ -7,11 +7,15 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import os
 import requests
 from bs4 import BeautifulSoup, SoupStrainer
-from urlparse import urljoin
 
 from resources.lib.helperobjects import helperobjects
 from resources.lib.kodiwrappers import sortmethod
 from resources.lib.vrtplayer import actions, metadatacollector, metadatacreator, statichelper
+
+try:
+    from urllib.parse import urljoin
+except ImportError:
+    from urllib import urljoin
 
 
 class VRTPlayer:

--- a/plugin.video.vrt.nu/resources/lib/vrtplayer/vrtplayer.py
+++ b/plugin.video.vrt.nu/resources/lib/vrtplayer/vrtplayer.py
@@ -15,7 +15,7 @@ from resources.lib.vrtplayer import actions, metadatacollector, metadatacreator,
 try:
     from urllib.parse import urljoin
 except ImportError:
-    from urllib import urljoin
+    from urlparse import urljoin
 
 
 class VRTPlayer:

--- a/plugin.video.vrt.nu/vrtnutests/apihelpertests.py
+++ b/plugin.video.vrt.nu/vrtnutests/apihelpertests.py
@@ -31,3 +31,7 @@ class ApiHelperTests(unittest.TestCase):
         api_helper = vrtapihelper.VRTApiHelper()
         title_items = api_helper.get_video_items('/vrtnu/a-z/postbus-x.relevant/', '1')
         self.assertTrue(len(title_items) > 5)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/plugin.video.vrt.nu/vrtnutests/urltostreamservicetests.py
+++ b/plugin.video.vrt.nu/vrtnutests/urltostreamservicetests.py
@@ -32,7 +32,7 @@ class UrlToStreamServiceTests(unittest.TestCase):
         mock.make_dir.return_value = None
         mock.open_path.return_value = False
         mock.check_inputstream_adaptive.return_value = True
-        service = urltostreamservice.UrlToStreamService(vrtplayer.VRTPlayer._VRT_BASE, vrtplayer.VRTPlayer._VRTNU_BASE_URL, mock, token_resolver)
+        service = urltostreamservice.UrlToStreamService(vrtplayer.VRTPlayer.VRT_BASE, vrtplayer.VRTPlayer.VRTNU_BASE_URL, mock, token_resolver)
         stream = service.get_stream_from_url('/vrtnu/a-z/22-3-1-jaar-later---het-onderzoek/2017/22-3-1-jaar-later---het-onderzoek-s2017/')
         self.assertTrue(stream is not None)
 
@@ -46,7 +46,7 @@ class UrlToStreamServiceTests(unittest.TestCase):
         mock.make_dir.return_value = None
         mock.open_path.return_value = False
         mock.check_inputstream_adaptive.return_value = True
-        service = urltostreamservice.UrlToStreamService(vrtplayer.VRTPlayer._VRT_BASE, vrtplayer.VRTPlayer._VRTNU_BASE_URL, mock, token_resolver)
+        service = urltostreamservice.UrlToStreamService(vrtplayer.VRTPlayer.VRT_BASE, vrtplayer.VRTPlayer.VRTNU_BASE_URL, mock, token_resolver)
         stream = service.get_stream_from_url(vrtplayer.VRTPlayer._CANVAS_LIVESTREAM_)
         self.assertTrue(stream is not None)
         self.assertTrue(stream.license_key is not None)
@@ -60,7 +60,7 @@ class UrlToStreamServiceTests(unittest.TestCase):
         mock.make_dir.return_value = None
         mock.open_path.return_value = False
         mock.check_inputstream_adaptive.return_value = True
-        service = urltostreamservice.UrlToStreamService(vrtplayer.VRTPlayer._VRT_BASE, vrtplayer.VRTPlayer._VRTNU_BASE_URL, mock, token_resolver)
+        service = urltostreamservice.UrlToStreamService(vrtplayer.VRTPlayer.VRT_BASE, vrtplayer.VRTPlayer.VRTNU_BASE_URL, mock, token_resolver)
         stream = service.get_stream_from_url(vrtplayer.VRTPlayer._CANVAS_LIVESTREAM_)
         self.assertTrue(stream is not None)
 

--- a/plugin.video.vrt.nu/vrtnutests/urltostreamservicetests.py
+++ b/plugin.video.vrt.nu/vrtnutests/urltostreamservicetests.py
@@ -63,3 +63,7 @@ class UrlToStreamServiceTests(unittest.TestCase):
         service = urltostreamservice.UrlToStreamService(vrtplayer.VRTPlayer._VRT_BASE, vrtplayer.VRTPlayer._VRTNU_BASE_URL, mock, token_resolver)
         stream = service.get_stream_from_url(vrtplayer.VRTPlayer._CANVAS_LIVESTREAM_)
         self.assertTrue(stream is not None)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+bs4
+pylint
+tox

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 bs4
 pylint
 requests
-tox
+tox-travis

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 bs4
 pylint
+requests
 tox


### PR DESCRIPTION
This PR includes:
- Running unit tests from Travis
- Improvements to Makefile to add `make unittest`
- A requirements.txt file (this also makes GitHub make dependencies with other projects)
- A Travis badge on the README
- 2 fixes for Python 3 compatibility (wrt. urlencode and urljoin)
- A fix that broke the addon (related to use_inputstream_adaptive)