### PR TITLE
A few more PY3 fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+ENVS := py27,py36
+
 addon_xml = plugin.video.vrt.nu/addon.xml
 
 # Collect information to build as sensible package name
@@ -23,7 +25,7 @@ test: unittest
 	@echo -e "\e[1;37m=\e[1;34m Starting tests\e[0m"
 	pylint $(name)/*.py
 	pylint $(name)/resources/lib/*/*.py
-	tox -e py27,py36
+	tox -e $(ENVS)
 	@echo -e "\e[1;37m=\e[1;34m Tests finished successfully.\e[0m"
 
 unittest:
@@ -31,7 +33,7 @@ unittest:
 	PYTHONPATH=$(name) python $(name)/vrtnutests/vrtplayertests.py
 	@echo -e "\e[1;37m=\e[1;34m Unit tests finished successfully.\e[0m"
 
-zip: clean
+zip: test clean
 	@echo -e "\e[1;37m=\e[1;34m Building new package\e[0m"
 	rm -f $(zip_name)
 	zip -r $(zip_name) $(zip_dir) -x $(exclude_paths)

--- a/plugin.video.vrt.nu/addon.py
+++ b/plugin.video.vrt.nu/addon.py
@@ -7,11 +7,15 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import sys
-from urlparse import parse_qsl
 
 import xbmcaddon
 from resources.lib.kodiwrappers import kodiwrapper
 from resources.lib.vrtplayer import vrtplayer, urltostreamservice, tokenresolver, actions, vrtapihelper
+
+try:
+    from urllib.parse import parse_qsl
+except ImportError:
+    from urlparse import parse_qsl
 
 
 _url = sys.argv[0]

--- a/plugin.video.vrt.nu/resources/lib/helperobjects/apidata.py
+++ b/plugin.video.vrt.nu/resources/lib/helperobjects/apidata.py
@@ -13,7 +13,7 @@ class ApiData:
         self._video_id = video_id
         self._publication_id = publication_id
         self._xvrttoken = xvrttoken
-        self.is_live_stream = is_live_stream
+        self._is_live_stream = is_live_stream
 
     @property
     def client(self):
@@ -41,4 +41,8 @@ class ApiData:
 
     @property
     def is_live_stream(self):
-        return self.is_live_stream
+        return self._is_live_stream
+
+    @is_live_stream.setter
+    def is_live_stream(self, value):
+        self._is_live_stream = value

--- a/plugin.video.vrt.nu/resources/lib/kodiwrappers/kodiwrapper.py
+++ b/plugin.video.vrt.nu/resources/lib/kodiwrappers/kodiwrapper.py
@@ -94,7 +94,7 @@ class KodiWrapper:
         return kodi_version > 17
 
     def get_userdata_path(self):
-        return xbmc.translatePath(self._addon.getAddonInfo('profile')).decode('utf-8')
+        return xbmc.translatePath(self._addon.getAddonInfo('profile'))
 
     def make_dir(self, path):
         xbmcvfs.mkdir(path)

--- a/plugin.video.vrt.nu/resources/lib/vrtplayer/urltostreamservice.py
+++ b/plugin.video.vrt.nu/resources/lib/vrtplayer/urltostreamservice.py
@@ -7,9 +7,13 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import re
 import requests
 from bs4 import BeautifulSoup, SoupStrainer
-from urlparse import urljoin
 
 from resources.lib.helperobjects import apidata, streamurls
+
+try:
+    from urllib.parse import urljoin
+except ImportError:
+    from urlparse import urljoin
 
 
 class UrlToStreamService:


### PR DESCRIPTION
This PR also makes the following changes:
- Ensure we import either the Python3 or Python2 libraries for `urljoin()` and `parse_qsl`
- Make the tox environments configurable when using `make test`.
  One can now do: `make test ENVS=py26,py27,py36,py37`
- Fix issues I introduced when removing access to private variables
- Run the tests before building a ZIP file (to avoid future issues like the previous one)

With this PR, [a Python3 *BeautifulSoup* package](https://mirrors.kodi.tv/addons/migration/script.module.beautifulsoup4/) and a newer *inputstreamhelper* package (or some fixes) the VRT.NU addon works on Kodi 18.2 with native Python3 !

This fixes #66