### PR TITLE
Keep static order in main/live menu

### DIFF
--- a/plugin.video.vrt.nu/resources/lib/kodiwrappers/kodiwrapper.py
+++ b/plugin.video.vrt.nu/resources/lib/kodiwrappers/kodiwrapper.py
@@ -44,6 +44,8 @@ class KodiWrapper:
             kodi_sorts = {sortmethod.ALPHABET: xbmcplugin.SORT_METHOD_LABEL_IGNORE_THE}
             kodi_sortmethod = kodi_sorts.get(sort)
             xbmcplugin.addSortMethod(self._handle, kodi_sortmethod)
+        else:
+            xbmcplugin.addSortMethod(self._handle, xbmcplugin.SORT_METHOD_NONE)
 
         xbmcplugin.setContent(int(self._handle), "episodes")
         xbmcplugin.endOfDirectory(self._handle)

--- a/plugin.video.vrt.nu/resources/lib/vrtplayer/vrtplayer.py
+++ b/plugin.video.vrt.nu/resources/lib/vrtplayer/vrtplayer.py
@@ -25,7 +25,7 @@ class VRTPlayer:
         self._stream_service = stream_service
 
     def show_main_menu_items(self):
-        menu_items = {
+        menu_items = [
             helperobjects.TitleItem(self._kodi_wrapper.get_localized_string(32080),
                                     dict(action=actions.LISTING_AZ_TVSHOWS), False,
                                     'DefaultMovieTitle.png',
@@ -42,8 +42,8 @@ class VRTPlayer:
                                     dict(action=actions.LISTING_EPISODES, video_url='recent'), False,
                                     'DefaultYear.png',
                                     dict(plot=self._kodi_wrapper.get_localized_string(32087))),
-        }
-        self._kodi_wrapper.show_listing(menu_items, sortmethod.ALPHABET)
+        ]
+        self._kodi_wrapper.show_listing(menu_items)
 
     def show_tvshow_menu_items(self, path):
         menu_items = self._api_helper.get_tvshow_items(path)
@@ -60,7 +60,7 @@ class VRTPlayer:
             self._kodi_wrapper.play(stream)
 
     def show_livestream_items(self):
-        livestream_items = {
+        livestream_items = [
             helperobjects.TitleItem(self._kodi_wrapper.get_localized_string(32101),
                                     {'action': actions.PLAY, 'video_url': self._EEN_LIVESTREAM},
                                     True, self._api_helper.get_live_screenshot('een'),
@@ -73,8 +73,8 @@ class VRTPlayer:
                                     {'action': actions.PLAY, 'video_url': self._KETNET_LIVESTREAM},
                                     True, self._api_helper.get_live_screenshot('ketnet'),
                                     dict(plot=self._kodi_wrapper.get_localized_string(32103))),
-        }
-        self._kodi_wrapper.show_listing(livestream_items, sortmethod.ALPHABET)
+        ]
+        self._kodi_wrapper.show_listing(livestream_items)
 
     def show_episodes(self, path):
         title_items, sort = self._api_helper.get_episode_items(path)


### PR DESCRIPTION
This PR ensures that the order of the items on the main menu, and the live TV menu is static and not sorted alphabetically. This is important to ensure users can expect entries to be in the same location no matter what language was selected.

The order of the menu items is now listed very specifically, with the more important/used items at the top. (A bit like the Netflix plugin)