### PR TITLE
Add fanart to menus

### DIFF
--- a/plugin.video.vrt.nu/resources/lib/helperobjects/helperobjects.py
+++ b/plugin.video.vrt.nu/resources/lib/helperobjects/helperobjects.py
@@ -4,12 +4,14 @@
 
 class TitleItem:
 
-    def __init__(self, title, url_dictionary, is_playable, thumbnail=None, video_dictionary=None):
+    def __init__(self, title, url_dictionary, is_playable, thumbnail=None, video_dictionary=None, icon='', fanart=None):
         self.title = title
         self.url_dictionary = url_dictionary
         self.is_playable = is_playable
         self.thumbnail = thumbnail
         self.video_dictionary = video_dictionary
+        self.icon = icon
+        self.fanart = self.fanart if self.fanart else self.thumbnail
 
 
 class Credentials:

--- a/plugin.video.vrt.nu/resources/lib/kodiwrappers/kodiwrapper.py
+++ b/plugin.video.vrt.nu/resources/lib/kodiwrappers/kodiwrapper.py
@@ -28,12 +28,12 @@ class KodiWrapper:
     def show_listing(self, list_items, sort=None):
         listing = []
         for title_item in list_items:
-            list_item = xbmcgui.ListItem(label=title_item.title)
+            list_item = xbmcgui.ListItem(label=title_item.title, iconImage=title_item.icon)
             url = self._url + '?' + urlencode(title_item.url_dictionary)
             list_item.setProperty('IsPlayable', str(title_item.is_playable))
 
             if title_item.thumbnail is not None:
-                list_item.setArt({'thumb': title_item.thumbnail})
+                list_item.setArt({'thumb': title_item.thumbnail, 'fanart': title_item.fanart, 'icon': title_item.icon})
 
             list_item.setInfo('video', title_item.video_dictionary)
 

--- a/plugin.video.vrt.nu/resources/lib/vrtplayer/vrtplayer.py
+++ b/plugin.video.vrt.nu/resources/lib/vrtplayer/vrtplayer.py
@@ -13,7 +13,7 @@ class VRTPlayer:
 
     # URLs van https://services.vrt.be/videoplayer/r/live.json
     _EEN_LIVESTREAM = 'https://www.vrt.be/vrtnu/kanalen/een/'
-    _CANVAS_LIVESTREAM_ = 'https://www.vrt.be/vrtnu/kanalen/canvas/'
+    _CANVAS_LIVESTREAM = 'https://www.vrt.be/vrtnu/kanalen/canvas/'
     _KETNET_LIVESTREAM = 'https://www.vrt.be/vrtnu/kanalen/ketnet/'
 
     VRT_BASE = 'https://www.vrt.be/'
@@ -27,21 +27,29 @@ class VRTPlayer:
     def show_main_menu_items(self):
         menu_items = [
             helperobjects.TitleItem(self._kodi_wrapper.get_localized_string(32080),
-                                    dict(action=actions.LISTING_AZ_TVSHOWS), False,
-                                    'DefaultMovieTitle.png',
-                                    dict(plot=self._kodi_wrapper.get_localized_string(32081))),
+                                    dict(action=actions.LISTING_AZ_TVSHOWS),
+                                    is_playable=False,
+                                    thumb='DefaultMovieTitle.png',
+                                    video_dictionary=dict(plot=self._kodi_wrapper.get_localized_string(32081)),
+                                    icon='DefaultMovieTitle.png'),
             helperobjects.TitleItem(self._kodi_wrapper.get_localized_string(32082),
-                                    dict(action=actions.LISTING_CATEGORIES), False,
-                                    'DefaultGenre.png',
-                                    dict(plot=self._kodi_wrapper.get_localized_string(32083))),
+                                    dict(action=actions.LISTING_CATEGORIES),
+                                    is_playable=False,
+                                    thumbnail='DefaultGenre.png',
+                                    video_dictionary=dict(plot=self._kodi_wrapper.get_localized_string(32083)),
+                                    icon='DefaultGenre.png'),
             helperobjects.TitleItem(self._kodi_wrapper.get_localized_string(32084),
-                                    dict(action=actions.LISTING_LIVE), False,
-                                    'DefaultAddonPVRClient.png',
-                                    dict(plot=self._kodi_wrapper.get_localized_string(32085))),
+                                    dict(action=actions.LISTING_LIVE),
+                                    is_playable=False,
+                                    thumbnail='DefaultAddonPVRClient.png',
+                                    video_dictionary=dict(plot=self._kodi_wrapper.get_localized_string(32085)),
+                                    icon='DefaultAddonPVRClient.png'),
             helperobjects.TitleItem(self._kodi_wrapper.get_localized_string(32086),
-                                    dict(action=actions.LISTING_EPISODES, video_url='recent'), False,
-                                    'DefaultYear.png',
-                                    dict(plot=self._kodi_wrapper.get_localized_string(32087))),
+                                    dict(action=actions.LISTING_EPISODES, video_url='recent'),
+                                    is_playable=False,
+                                    thumbnail='DefaultYear.png',
+                                    video_dictionary=dict(plot=self._kodi_wrapper.get_localized_string(32087)),
+                                    icon='DefaultYear.png'),
         ]
         self._kodi_wrapper.show_listing(menu_items)
 
@@ -62,17 +70,23 @@ class VRTPlayer:
     def show_livestream_items(self):
         livestream_items = [
             helperobjects.TitleItem(self._kodi_wrapper.get_localized_string(32101),
-                                    {'action': actions.PLAY, 'video_url': self._EEN_LIVESTREAM},
-                                    True, self._api_helper.get_live_screenshot('een'),
-                                    dict(plot=self._kodi_wrapper.get_localized_string(32101))),
+                                    dict(action=actions.PLAY, video_url=self._EEN_LIVESTREAM),
+                                    is_playable=True,
+                                    thumbnail=self._api_helper.get_live_screenshot('een'),
+                                    video_dictionary=dict(plot=self._kodi_wrapper.get_localized_string(32101)),
+                                    icon='DefaultAddonPVRClient.png'),
             helperobjects.TitleItem(self._kodi_wrapper.get_localized_string(32102),
-                                    {'action': actions.PLAY, 'video_url': self._CANVAS_LIVESTREAM_},
-                                    True, self._api_helper.get_live_screenshot('canvas'),
-                                    dict(plot=self._kodi_wrapper.get_localized_string(32102))),
+                                    dict(action=actions.PLAY, video_url=self._CANVAS_LIVESTREAM),
+                                    is_playable=True,
+                                    thumbnail=self._api_helper.get_live_screenshot('canvas'),
+                                    video_dictionary=dict(plot=self._kodi_wrapper.get_localized_string(32102)),
+                                    icon='DefaultAddonPVRClient.png'),
             helperobjects.TitleItem(self._kodi_wrapper.get_localized_string(32103),
-                                    {'action': actions.PLAY, 'video_url': self._KETNET_LIVESTREAM},
-                                    True, self._api_helper.get_live_screenshot('ketnet'),
-                                    dict(plot=self._kodi_wrapper.get_localized_string(32103))),
+                                    dict(action=actions.PLAY, video_url=self._KETNET_LIVESTREAM),
+                                    is_playable=True,
+                                    thumbnail=self._api_helper.get_live_screenshot('ketnet'),
+                                    video_dictionary=dict(plot=self._kodi_wrapper.get_localized_string(32103)),
+                                    icon='DefaultAddonPVRClient.png'),
         ]
         self._kodi_wrapper.show_listing(livestream_items)
 

--- a/plugin.video.vrt.nu/vrtnutests/streamservicetests.py
+++ b/plugin.video.vrt.nu/vrtnutests/streamservicetests.py
@@ -44,7 +44,7 @@ class StreamServiceTests(unittest.TestCase):
         mock.open_path.return_value = False
         mock.check_inputstream_adaptive.return_value = True
         service = streamservice.StreamService(vrtplayer.VRTPlayer.VRT_BASE, vrtplayer.VRTPlayer.VRTNU_BASE_URL, mock, token_resolver)
-        video = {'video_url' : vrtplayer.VRTPlayer._CANVAS_LIVESTREAM_, 'video_id' : None, 'publication_id' : None}
+        video = {'video_url' : vrtplayer.VRTPlayer._CANVAS_LIVESTREAM, 'video_id' : None, 'publication_id' : None}
         stream = service.get_stream(video)
         self.assertTrue(stream is not None)
         self.assertTrue(stream.license_key is not None)
@@ -59,7 +59,7 @@ class StreamServiceTests(unittest.TestCase):
         mock.open_path.return_value = False
         mock.check_inputstream_adaptive.return_value = True
         service = streamservice.StreamService(vrtplayer.VRTPlayer.VRT_BASE, vrtplayer.VRTPlayer.VRTNU_BASE_URL, mock, token_resolver)
-        video = {'video_url' : vrtplayer.VRTPlayer._CANVAS_LIVESTREAM_, 'video_id' : None, 'publication_id' : None}
+        video = {'video_url' : vrtplayer.VRTPlayer._CANVAS_LIVESTREAM, 'video_id' : None, 'publication_id' : None}
         stream = service.get_stream(video)
         self.assertTrue(stream is not None)
 


### PR DESCRIPTION
This PR adds directory icons and fanart to all menus.

Beware that the fanart is the same as the thumbnail, which for categories, tvshows and main menu could be done better (by using the parent's thumbnail, or no fanart at all).

But even with the thumbnail as fanart, IMO it looks better.

Also the icons do not work at the moment...