### PR TITLE
Restore the channel thumbnail to text-based thumbnail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,5 @@ install:
 script:
 - tox
 - pylint plugin.video.vrt.nu/*.py
-- pylint plugin.video.vrt.nu/resources/**/*.py
+- pylint plugin.video.vrt.nu/resources/lib/*/*.py
 - python plugin.video.vrt.nu/vrtnutests/vrtplayertests.py

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ clean:
 test: unittest
 	@echo -e "\e[1;37m=\e[1;34m Starting tests\e[0m"
 	pylint $(name)/*.py
-	pylint $(name)/resources/**/*.py
+	pylint $(name)/resources/lib/*/*.py
 	tox -e $(ENVS)
 	@echo -e "\e[1;37m=\e[1;34m Tests finished successfully.\e[0m"
 

--- a/plugin.video.vrt.nu/addon.py
+++ b/plugin.video.vrt.nu/addon.py
@@ -30,7 +30,7 @@ def router(params_string):
                                                  vrtplayer.VRTPlayer.VRTNU_BASE_URL,
                                                  kodi_wrapper, token_resolver)
     api_helper = vrtapihelper.VRTApiHelper(kodi_wrapper)
-    vrt_player = vrtplayer.VRTPlayer(kodi_wrapper, stream_service, api_helper)
+    vrt_player = vrtplayer.VRTPlayer(addon.getAddonInfo('path'), kodi_wrapper, stream_service, api_helper)
     params = dict(parse_qsl(params_string))
     if params:
         if params['action'] == actions.LISTING_AZ_TVSHOWS:

--- a/plugin.video.vrt.nu/resources/lib/helperobjects/helperobjects.py
+++ b/plugin.video.vrt.nu/resources/lib/helperobjects/helperobjects.py
@@ -11,7 +11,7 @@ class TitleItem:
         self.thumbnail = thumbnail
         self.video_dictionary = video_dictionary
         self.icon = icon
-        self.fanart = self.fanart if self.fanart else self.thumbnail
+        self.fanart = fanart if fanart else thumbnail
 
 
 class Credentials:

--- a/plugin.video.vrt.nu/resources/lib/vrtplayer/statichelper.py
+++ b/plugin.video.vrt.nu/resources/lib/vrtplayer/statichelper.py
@@ -2,6 +2,7 @@
 
 # GNU General Public License v2.0 (see COPYING or https://www.gnu.org/licenses/gpl-2.0.txt)
 
+# pylint: disable=unused-import
 try:
     from html import unescape
 except ImportError:

--- a/plugin.video.vrt.nu/resources/lib/vrtplayer/vrtplayer.py
+++ b/plugin.video.vrt.nu/resources/lib/vrtplayer/vrtplayer.py
@@ -2,6 +2,7 @@
 
 # GNU General Public License v2.0 (see COPYING or https://www.gnu.org/licenses/gpl-2.0.txt)
 
+import os
 import requests
 from bs4 import BeautifulSoup, SoupStrainer
 from resources.lib.helperobjects import helperobjects
@@ -19,7 +20,8 @@ class VRTPlayer:
     VRT_BASE = 'https://www.vrt.be/'
     VRTNU_BASE_URL = ''.join((VRT_BASE, '/vrtnu'))
 
-    def __init__(self, kodi_wrapper, stream_service, api_helper):
+    def __init__(self, addon_path, kodi_wrapper, stream_service, api_helper):
+        self._addon_path = addon_path
         self._kodi_wrapper = kodi_wrapper
         self._api_helper = api_helper
         self._stream_service = stream_service
@@ -29,7 +31,7 @@ class VRTPlayer:
             helperobjects.TitleItem(self._kodi_wrapper.get_localized_string(32080),
                                     dict(action=actions.LISTING_AZ_TVSHOWS),
                                     is_playable=False,
-                                    thumb='DefaultMovieTitle.png',
+                                    thumbnail='DefaultMovieTitle.png',
                                     video_dictionary=dict(plot=self._kodi_wrapper.get_localized_string(32081)),
                                     icon='DefaultMovieTitle.png'),
             helperobjects.TitleItem(self._kodi_wrapper.get_localized_string(32082),
@@ -72,27 +74,33 @@ class VRTPlayer:
             helperobjects.TitleItem(self._kodi_wrapper.get_localized_string(32101),
                                     dict(action=actions.PLAY, video_url=self._EEN_LIVESTREAM),
                                     is_playable=True,
-                                    thumbnail=self._api_helper.get_live_screenshot('een'),
+                                    thumbnail=self.__get_media('een.png'),
                                     video_dictionary=dict(plot=self._kodi_wrapper.get_localized_string(32101)),
-                                    icon='DefaultAddonPVRClient.png'),
+                                    icon='DefaultAddonPVRClient.png',
+                                    fanart=self._api_helper.get_live_screenshot('een')),
             helperobjects.TitleItem(self._kodi_wrapper.get_localized_string(32102),
                                     dict(action=actions.PLAY, video_url=self._CANVAS_LIVESTREAM),
                                     is_playable=True,
-                                    thumbnail=self._api_helper.get_live_screenshot('canvas'),
+                                    thumbnail=self.__get_media('canvas.png'),
                                     video_dictionary=dict(plot=self._kodi_wrapper.get_localized_string(32102)),
-                                    icon='DefaultAddonPVRClient.png'),
+                                    icon='DefaultAddonPVRClient.png',
+                                    fanart=self._api_helper.get_live_screenshot('canvas')),
             helperobjects.TitleItem(self._kodi_wrapper.get_localized_string(32103),
                                     dict(action=actions.PLAY, video_url=self._KETNET_LIVESTREAM),
                                     is_playable=True,
-                                    thumbnail=self._api_helper.get_live_screenshot('ketnet'),
+                                    thumbnail=self.__get_media('ketnet.png'),
                                     video_dictionary=dict(plot=self._kodi_wrapper.get_localized_string(32103)),
-                                    icon='DefaultAddonPVRClient.png'),
+                                    icon='DefaultAddonPVRClient.png',
+                                    fanart=self._api_helper.get_live_screenshot('ketnet')),
         ]
         self._kodi_wrapper.show_listing(livestream_items, content_type='videos')
 
     def show_episodes(self, path):
         title_items, sort = self._api_helper.get_episode_items(path)
         self._kodi_wrapper.show_listing(title_items, sort=sort, content_type='episodes')
+
+    def __get_media(self, file_name):
+        return os.path.join(self._addon_path, 'resources', 'media', file_name)
 
     def __get_category_menu_items(self, url, soupstrainer_parser_selector, routing_action, video_dictionary_action=None):
         response = requests.get(url)

--- a/plugin.video.vrt.nu/vrtnutests/vrtplayertests.py
+++ b/plugin.video.vrt.nu/vrtnutests/vrtplayertests.py
@@ -13,28 +13,28 @@ class TestVRTPlayer(unittest.TestCase):
     def test_show_videos_single_episode_shows_videos(self):
         mock = MagicMock()
         mock.show_listing()
-        player = vrtplayer.VRTPlayer(mock, None, vrtapihelper.VRTApiHelper(mock))
+        player = vrtplayer.VRTPlayer(None, mock, None, vrtapihelper.VRTApiHelper(mock))
         player.show_episodes('/vrtnu/a-z/tussen-nu-en-morgen/2018/tussen-nu-en-morgen.relevant/')
         self.assertTrue(mock.show_listing.called)
 
     def test_show_videos_single_season_shows_videos(self):
         mock = MagicMock()
         mock.show_listing()
-        player = vrtplayer.VRTPlayer(mock, None, vrtapihelper.VRTApiHelper(mock))
+        player = vrtplayer.VRTPlayer(None, mock, None, vrtapihelper.VRTApiHelper(mock))
         player.show_episodes('/vrtnu/a-z/apocalyps--de-eerste-wereldoorlog/1/apocalyps--de-eerste-wereldoorlog-s1a3.relevant/')
         self.assertTrue(mock.show_listing.called)
 
     def test_show_videos_multiple_seasons_shows_videos(self):
         mock = MagicMock()
         mock.show_listing()
-        player = vrtplayer.VRTPlayer(mock, None, vrtapihelper.VRTApiHelper(mock))
+        player = vrtplayer.VRTPlayer(None, mock, None, vrtapihelper.VRTApiHelper(mock))
         player.show_episodes('vrtnu/a-z/animal-babies.relevant/')
         self.assertTrue(mock.show_listing.called)
 
     def test_show_videos_specific_seasons_shows_videos(self):
         mock = MagicMock()
         mock.show_listing()
-        player = vrtplayer.VRTPlayer(mock, None, vrtapihelper.VRTApiHelper(mock))
+        player = vrtplayer.VRTPlayer(None, mock, None, vrtapihelper.VRTApiHelper(mock))
         player.show_episodes('/vrtnu/a-z/thuis/24.lists.all-episodes.relevant/')
         self.assertTrue(mock.show_listing.called)
 


### PR DESCRIPTION
Since we now have the live stream screenshot as fanart, we can safely turn back to text-based icons for channels, so that adding it to favourites works properly again.