### PR TITLE
hls streams: support virtual subclips (vbegin and vend parameters)

### DIFF
--- a/plugin.video.vrt.nu/resources/lib/vrtplayer/streamservice.py
+++ b/plugin.video.vrt.nu/resources/lib/vrtplayer/streamservice.py
@@ -200,7 +200,7 @@ class StreamService:
             direct_audio_url = match_audio[len(match_audio)-1]
 
         # Get video uri
-        video_regex = re.compile(r'#EXT-X-STREAM-INF:[\w\-=,\.\"]+[\r\n]{1}([\w\-=]+\.m3u8)[\r\n]{2}')
+        video_regex = re.compile(r'#EXT-X-STREAM-INF:[\w\-=,\.\"]+[\r\n]{1}([\w\-=]+\.m3u8(\?vbegin=[0-9]{10})?(&vend=[0-9]{10})?)[\r\n]{2}')
         match_video = re.search(video_regex, m3u8)
         if match_video:
             direct_video_url = base_url + match_video.group(1)


### PR DESCRIPTION
VRT makes use of virtual subclips to provide live broadcast current affairs programs in an "on demand" context. For instance: "Het Journaal" in the "Most recent" menu uses this feature.
This fixes availability of current affair programs during and immediately after the live broadcast for users who don't use inputstream.adaptive 