### PR TITLE
let inputstreamhelper handle inputstream.adaptive status

### DIFF
--- a/plugin.video.vrt.nu/resources/lib/kodiwrappers/kodiwrapper.py
+++ b/plugin.video.vrt.nu/resources/lib/kodiwrappers/kodiwrapper.py
@@ -147,11 +147,11 @@ class KodiWrapper:
 
         return dict(http=proxy_address, https=proxy_address)
 
-    # NOTE: normally inputstream adaptive will always be installed, this only applies for people uninstalling inputstream adaptive while this addon is disabled
+    # Note: InputStream Adaptive is not pre-installed on Windows and in some cases users can uninstall it
     def has_inputstream_adaptive_installed(self):
         return xbmc.getCondVisibility('System.HasAddon("{0}")'.format('inputstream.adaptive')) == 1
 
-    def can_play_widevine(self):
+    def can_play_drm(self):
         kodi_version = int(xbmc.getInfoLabel('System.BuildVersion').split('.')[0])
         return kodi_version > 17
 

--- a/plugin.video.vrt.nu/resources/lib/vrtplayer/streamservice.py
+++ b/plugin.video.vrt.nu/resources/lib/vrtplayer/streamservice.py
@@ -23,7 +23,7 @@ class StreamService:
         self._vrt_base = vrt_base
         self._vrtnu_base_url = vrtnu_base_url
         self._create_settings_dir()
-        self._can_play_drm = self._kodi_wrapper.can_play_widevine() and self._kodi_wrapper.has_inputstream_adaptive_installed()
+        self._can_play_drm = self._kodi_wrapper.can_play_drm()
         self._license_url = self._get_license_url()
 
     def _get_license_url(self):


### PR DESCRIPTION
We don't have to check if inputstream.adaptive is installed when selecting the mpeg dash drm stream because inputstreamhelper is doing this and gives the user a message if it is not installed.
