### PR TITLE
Make code more robust

### DIFF
--- a/plugin.video.vrt.nu/resources/lib/kodiwrappers/kodiwrapper.py
+++ b/plugin.video.vrt.nu/resources/lib/kodiwrappers/kodiwrapper.py
@@ -107,7 +107,7 @@ class KodiWrapper:
 
     def get_global_setting(self, setting):
         json_result = xbmc.executeJSONRPC('{"jsonrpc": "2.0", "method": "Settings.GetSettingValue", "params": {"setting": "%s"}, "id": 1}' % setting)
-        return json.loads(json_result)['result']['value']
+        return json.loads(json_result).get('result', dict()).get('value')
 
     def get_proxies(self):
         usehttpproxy = self.get_global_setting('network.usehttpproxy')

--- a/plugin.video.vrt.nu/resources/lib/vrtplayer/vrtplayer.py
+++ b/plugin.video.vrt.nu/resources/lib/vrtplayer/vrtplayer.py
@@ -99,7 +99,7 @@ class VRTPlayer:
         soup = BeautifulSoup(response.content, 'html.parser', parse_only=tiles)
         listing = []
         for tile in soup.find_all(class_='nui-tile'):
-            category = tile['href'].split('/')[-2]
+            category = tile.get('href').split('/')[-2]
             thumbnail, title = self.__get_category_thumbnail_and_title(tile)
             video_dict = None
             if video_dict_action is not None:
@@ -114,7 +114,7 @@ class VRTPlayer:
 
     @staticmethod
     def __format_category_image_url(element):
-        raw_thumbnail = element.find(class_='media')['data-responsive-image']
+        raw_thumbnail = element.find(class_='media').get('data-responsive-image')
         return statichelper.add_https_method(raw_thumbnail)
 
     @staticmethod


### PR DESCRIPTION
Make every dictionary lookup use get() which doesn't raise an exception
when missing. (If JSON returns something unexpected, or web scraping
fails unexpectedly)

We still have to look for each dictionary lookup what we should return
if the lookup fails. By default it returns None, which sometimes is
fine, but in some cases we better return an empty list or an empty dict.

Some parts now will undoubtedly fail because of None values where it
would have failed Kodi before.

In some cases a missing title would be better replaced with e.g. 'N/A'
or 'video #X' so the listing would still work. Either a complete review
is necessary, or future brokeness will guide us to make better decisions
;-)

This fixes #35 