### PR TITLE
Add Geo-locked to live streams

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -120,16 +120,32 @@ msgid "Eén"
 msgstr "Eén"
 
 msgctxt "#32102"
+msgid "Watch Eén live TV stream"
+msgstr "Watch Eén live TV stream"
+
+msgctxt "#32111"
 msgid "Canvas"
 msgstr "Canvas"
 
-msgctxt "#32103"
+msgctxt "#32112"
+msgid "Watch Canvas live TV stream"
+msgstr "Watch Canvas live TV stream"
+
+msgctxt "#32121"
 msgid "Ketnet"
 msgstr "Ketnet"
 
-msgctxt "#32104"
+msgctxt "#32122"
+msgid "Watch Ketnet live TV stream"
+msgstr "Watch Ketnet live TV stream"
+
+msgctxt "#32131"
 msgid "Sporza"
 msgstr "Sporza"
+
+msgctxt "#32132"
+msgid "Watch Sporza live TV stream"
+msgstr "Watch Sporza live TV stream"
 
 msgctxt "#32201"
 msgid "[B][COLOR red]Geo-blocked[/COLOR][/B]\n"

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -121,16 +121,32 @@ msgid "Eén"
 msgstr "Eén"
 
 msgctxt "#32102"
+msgid "Watch Eén live TV stream"
+msgstr "Bekijk Eén live tv stream"
+
+msgctxt "#32111"
 msgid "Canvas"
 msgstr "Canvas"
 
-msgctxt "#32103"
+msgctxt "#32112"
+msgid "Watch Canvas live TV stream"
+msgstr "Bekijk Canvas live tv stream"
+
+msgctxt "#32121"
 msgid "Ketnet"
 msgstr "Ketnet"
 
-msgctxt "#32104"
+msgctxt "#32122"
+msgid "Watch Ketnet live TV stream"
+msgstr "Bekijk Ketnet live tv stream"
+
+msgctxt "#32131"
 msgid "Sporza"
 msgstr "Sporza"
+
+msgctxt "#32132"
+msgid "Watch Sporza live TV stream"
+msgstr "Bekijk Sporza live tv stream"
 
 msgctxt "#32201"
 msgid "[B][COLOR red]Geo-blocked[/COLOR][/B]\n"

--- a/resources/lib/vrtplayer/vrtplayer.py
+++ b/resources/lib/vrtplayer/vrtplayer.py
@@ -75,21 +75,21 @@ class VRTPlayer:
                 url_dict=dict(action=actions.PLAY, video_url=self._EEN_LIVESTREAM),
                 is_playable=True,
                 art_dict=dict(thumb=self.__get_media('een.png'), icon='DefaultAddonPVRClient.png', fanart=self._api_helper.get_live_screenshot('een')),
-                video_dict=dict(plot=self._kodi_wrapper.get_localized_string(32101)),
+                video_dict=dict(plot=self._kodi_wrapper.get_localized_string(32201) + '\n' + self._kodi_wrapper.get_localized_string(32102)),
             ),
             helperobjects.TitleItem(
-                title=self._kodi_wrapper.get_localized_string(32102),
+                title=self._kodi_wrapper.get_localized_string(32111),
                 url_dict=dict(action=actions.PLAY, video_url=self._CANVAS_LIVESTREAM),
                 is_playable=True,
                 art_dict=dict(thumb=self.__get_media('canvas.png'), icon='DefaultAddonPVRClient.png', fanart=self._api_helper.get_live_screenshot('canvas')),
-                video_dict=dict(plot=self._kodi_wrapper.get_localized_string(32102)),
+                video_dict=dict(plot=self._kodi_wrapper.get_localized_string(32201) + '\n' + self._kodi_wrapper.get_localized_string(32112)),
             ),
             helperobjects.TitleItem(
-                title=self._kodi_wrapper.get_localized_string(32103),
+                title=self._kodi_wrapper.get_localized_string(32121),
                 url_dict=dict(action=actions.PLAY, video_url=self._KETNET_LIVESTREAM),
                 is_playable=True,
                 art_dict=dict(thumb=self.__get_media('ketnet.png'), icon='DefaultAddonPVRClient.png', fanart=self._api_helper.get_live_screenshot('ketnet')),
-                video_dict=dict(plot=self._kodi_wrapper.get_localized_string(32103)),
+                video_dict=dict(plot=self._kodi_wrapper.get_localized_string(32201) + '\n' + self._kodi_wrapper.get_localized_string(32122)),
             ),
         ]
         self._kodi_wrapper.show_listing(livestream_items, content_type='videos')


### PR DESCRIPTION
This adds "Geo-locked" to the Live streams plot description.
It also adds a different (translated) plot per channel, which we can improve on later too.

This implements a suggestion from #130 