### PR TITLE
Sanitize all HTML elements

### DIFF
--- a/resources/lib/vrtplayer/statichelper.py
+++ b/resources/lib/vrtplayer/statichelper.py
@@ -6,6 +6,26 @@ from __future__ import absolute_import, division, unicode_literals
 import re
 
 
+HTML_MAPPING = [
+    (re.compile(r'<i\s[^>]+>'), '[I]'),
+    (re.compile('<i>'), '[I]'),
+    (re.compile('</i>'), '[/I]'),
+    (re.compile(r'<b\s[^>]+>'), '[B]'),
+    (re.compile('<b>'), '[B]'),
+    (re.compile('</b>'), '[/B]'),
+    (re.compile(r'<p\s[^>]+>'), ''),
+    (re.compile('<p>'), '',),
+    (re.compile('</p>'), ''),
+    (re.compile(r'<div\s[^>]+>'), ''),
+    (re.compile('<div>'), ''),
+    (re.compile('</div>'), ''),
+    (re.compile(r'<span\s[^>]+>'), ''),
+    (re.compile('<span>'), ''),
+    (re.compile('</span>'), ''),
+    (re.compile('<br>\n'), ' '),  # This appears to be specific formatting for VRT.NU, but unwanted for us
+    (re.compile('<br>'), ' '),  # This appears to be specific formatting for VRT.NU, but unwanted for us
+]
+
 # pylint: disable=unused-import
 try:
     from html import unescape
@@ -17,10 +37,9 @@ except ImportError:
 
 
 def convert_html_to_kodilabel(text):
-    rep = {"<i>": "[I]", "</i>": "[/I]"}
-    rep = dict((re.escape(k), v) for k, v in rep.items())
-    pattern = re.compile("|".join(rep.keys()))
-    return pattern.sub(lambda m: rep[re.escape(m.group(0))], text)
+    for (k, v) in HTML_MAPPING:
+        text = k.sub(v, text)
+    return unescape(text).strip()
 
 
 def strip_newlines(text):

--- a/resources/lib/vrtplayer/vrtapihelper.py
+++ b/resources/lib/vrtplayer/vrtapihelper.py
@@ -3,14 +3,13 @@
 # GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, unicode_literals
-from bs4 import BeautifulSoup
 from datetime import datetime
 import requests
 import time
 
-from resources.lib.vrtplayer import statichelper, metadatacreator, actions
 from resources.lib.helperobjects import helperobjects
 from resources.lib.kodiwrappers import sortmethod
+from resources.lib.vrtplayer import actions, metadatacreator, statichelper
 
 
 class VRTApiHelper:
@@ -119,11 +118,11 @@ class VRTApiHelper:
                 metadata_creator.datetime = datetime.fromtimestamp(episode.get('broadcastDate', 0) / 1000)
 
             metadata_creator.duration = (episode.get('duration', 0) * 60)  # Minutes to seconds
-            metadata_creator.plot = BeautifulSoup(statichelper.convert_html_to_kodilabel(episode.get('description')), 'html.parser').text
+            metadata_creator.plot = statichelper.convert_html_to_kodilabel(episode.get('description'))
             metadata_creator.brands = episode.get('programBrands', episode.get('brands'))
             metadata_creator.geolocked = episode.get('allowedRegion') == 'BE'
             if display_options.get('showShortDescription'):
-                short_description = BeautifulSoup(episode.get('shortDescription'), 'html.parser').text
+                short_description = statichelper.convert_html_to_kodilabel(episode.get('shortDescription'))
                 metadata_creator.plotoutline = short_description
                 metadata_creator.subtitle = short_description
             else:
@@ -145,8 +144,7 @@ class VRTApiHelper:
             # Only display when a video disappears if it is within the next 3 months
             if metadata_creator.offtime is not None and (metadata_creator.offtime - datetime.utcnow()).days < 93:
                 # Show date when episode is removed
-                plot_meta += self._kodi_wrapper.get_localized_string(32202) \
-                             % metadata_creator.offtime.strftime(self._kodi_wrapper.get_localized_dateshort())
+                plot_meta += self._kodi_wrapper.get_localized_string(32202) % metadata_creator.offtime.strftime(self._kodi_wrapper.get_localized_dateshort())
                 # Show the remaining days/hours the episode is still available
                 if (metadata_creator.offtime - datetime.utcnow()).days > 0:
                     plot_meta += self._kodi_wrapper.get_localized_string(32203) % (metadata_creator.offtime - datetime.utcnow()).days
@@ -221,7 +219,7 @@ class VRTApiHelper:
         return '%08x' % crc
 
     def _make_title(self, result, titletype):
-        short_description = BeautifulSoup(result.get('shortDescription') or result.get('title'), 'html.parser').text
+        short_description = statichelper.convert_html_to_kodilabel(result.get('shortDescription') or result.get('title'))
 
         if titletype == 'recent':
             title = '%s - %s' % (result.get('program'), short_description)


### PR DESCRIPTION
This adds support for all (known) HTML elements and converts it to Kodi formatted text.
It includes very specific conversions that relate to VRT.NU formatting (wrt. newlines and paragraphs).

This relates to #129 
This fixes #128 

PS To verify proper output, look at the output of *"Winteruur met Fatma Taspinar"* or *"Winteruur met Abdelkader Benali"*.