### PR TITLE
Improve episode listing and sort order

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -33,7 +33,7 @@ def router(params_string):
     params = dict(parse_qsl(params_string))
     action = params.get('action')
     if action == actions.LISTING_AZ_TVSHOWS:
-        vrt_player.show_tvshow_menu_items('az')
+        vrt_player.show_tvshow_menu_items(path=None)
     elif action == actions.LISTING_CATEGORIES:
         vrt_player.show_category_menu_items()
     elif action == actions.LISTING_LIVE:
@@ -41,7 +41,7 @@ def router(params_string):
     elif action == actions.LISTING_EPISODES:
         vrt_player.show_episodes(params.get('video_url'))
     elif action == actions.LISTING_CATEGORY_TVSHOWS:
-        vrt_player.show_tvshow_menu_items(params.get('video_url'))
+        vrt_player.show_tvshow_menu_items(path=params.get('video_url'))
     elif action == actions.PLAY:
         video = dict(
             video_url=params.get('video_url'),

--- a/resources/lib/kodiwrappers/kodiwrapper.py
+++ b/resources/lib/kodiwrappers/kodiwrapper.py
@@ -21,10 +21,10 @@ sort_methods = {
     'dateadded': xbmcplugin.SORT_METHOD_DATEADDED,
     'duration': xbmcplugin.SORT_METHOD_DURATION,
     'episode': xbmcplugin.SORT_METHOD_EPISODE,
-    'genre': xbmcplugin.SORT_METHOD_GENRE,
+    # 'genre': xbmcplugin.SORT_METHOD_GENRE,
     'label': xbmcplugin.SORT_METHOD_LABEL_IGNORE_THE,
     'none': xbmcplugin.SORT_METHOD_NONE,
-    'title': xbmcplugin.SORT_METHOD_TITLE_IGNORE_THE,
+    # 'title': xbmcplugin.SORT_METHOD_TITLE_IGNORE_THE,
     'unsorted': xbmcplugin.SORT_METHOD_UNSORTED,
 }
 
@@ -56,15 +56,16 @@ class KodiWrapper:
 
         # Add all sort methods to GUI
         xbmcplugin.addSortMethod(handle=self._handle, sortMethod=sort_methods[sort])
-        for key in sorted(sort_methods):
-            if key not in ('none', sort):
+        for key in sort_methods:
+            if key != sort:
                 xbmcplugin.addSortMethod(handle=self._handle, sortMethod=sort_methods[key])
 
-        # NOTE: This does not appear to be working, we have to order it ourselves
+        # FIXME: This does not appear to be working, we have to order it ourselves
         xbmcplugin.setProperty(handle=self._handle, key='sort.ascending', value='true' if ascending else 'false')
         if ascending:
             xbmcplugin.setProperty(handle=self._handle, key='sort.order', value=str(sort_methods[sort]))
         else:
+            # NOTE: When descending, use unsorted
             xbmcplugin.setProperty(handle=self._handle, key='sort.order', value=str(sort_methods['none']))
 
         for title_item in list_items:
@@ -72,11 +73,12 @@ class KodiWrapper:
             url = self._url + '?' + urlencode(title_item.url_dict)
             list_item.setProperty(key='IsPlayable', value='true' if title_item.is_playable else 'false')
 
-            # NOTE: This does not appear to be working, we have to order it ourselves
+            # FIXME: This does not appear to be working, we have to order it ourselves
             list_item.setProperty(key='sort.ascending', value='true' if ascending else 'false')
             if ascending:
                 list_item.setProperty(key='sort.order', value=str(sort_methods[sort]))
             else:
+                # NOTE: When descending, use unsorted
                 list_item.setProperty(key='sort.order', value=str(sort_methods['none']))
 
             if title_item.art_dict:

--- a/resources/lib/kodiwrappers/kodiwrapper.py
+++ b/resources/lib/kodiwrappers/kodiwrapper.py
@@ -52,6 +52,8 @@ class KodiWrapper:
     def show_listing(self, list_items, sort='none', ascending=True, content_type='episodes'):
         listing = []
 
+        xbmcplugin.setContent(self._handle, content=content_type)
+
         # Add all sort methods to GUI
         xbmcplugin.addSortMethod(handle=self._handle, sortMethod=sort_methods[sort])
         for key in sorted(sort_methods):
@@ -64,7 +66,9 @@ class KodiWrapper:
         for title_item in list_items:
             list_item = xbmcgui.ListItem(label=title_item.title, thumbnailImage=title_item.art_dict.get('thumb'))
             url = self._url + '?' + urlencode(title_item.url_dict)
-            list_item.setProperty('IsPlayable', 'true' if title_item.is_playable else 'false')
+            list_item.setProperty(key='IsPlayable', value='true' if title_item.is_playable else 'false')
+            list_item.setProperty(key='sort.order', value=str(sort_methods[sort]))
+            list_item.setProperty(key='sort.ascending', value='true' if ascending else 'false')
 
             if title_item.art_dict:
                 list_item.setArt(title_item.art_dict)
@@ -75,8 +79,6 @@ class KodiWrapper:
             listing.append((url, list_item, not title_item.is_playable))
 
         ok = xbmcplugin.addDirectoryItems(self._handle, listing, len(listing))
-
-        xbmcplugin.setContent(self._handle, content=content_type)
         xbmcplugin.endOfDirectory(self._handle, ok)
 
     def play(self, video):

--- a/resources/lib/kodiwrappers/kodiwrapper.py
+++ b/resources/lib/kodiwrappers/kodiwrapper.py
@@ -60,15 +60,24 @@ class KodiWrapper:
             if key not in ('none', sort):
                 xbmcplugin.addSortMethod(handle=self._handle, sortMethod=sort_methods[key])
 
-        xbmcplugin.setProperty(handle=self._handle, key='sort.order', value=str(sort_methods[sort]))
+        # NOTE: This does not appear to be working, we have to order it ourselves
         xbmcplugin.setProperty(handle=self._handle, key='sort.ascending', value='true' if ascending else 'false')
+        if ascending:
+            xbmcplugin.setProperty(handle=self._handle, key='sort.order', value=str(sort_methods[sort]))
+        else:
+            xbmcplugin.setProperty(handle=self._handle, key='sort.order', value=str(sort_methods['none']))
 
         for title_item in list_items:
             list_item = xbmcgui.ListItem(label=title_item.title, thumbnailImage=title_item.art_dict.get('thumb'))
             url = self._url + '?' + urlencode(title_item.url_dict)
             list_item.setProperty(key='IsPlayable', value='true' if title_item.is_playable else 'false')
-            list_item.setProperty(key='sort.order', value=str(sort_methods[sort]))
+
+            # NOTE: This does not appear to be working, we have to order it ourselves
             list_item.setProperty(key='sort.ascending', value='true' if ascending else 'false')
+            if ascending:
+                list_item.setProperty(key='sort.order', value=str(sort_methods[sort]))
+            else:
+                list_item.setProperty(key='sort.order', value=str(sort_methods['none']))
 
             if title_item.art_dict:
                 list_item.setArt(title_item.art_dict)

--- a/resources/lib/kodiwrappers/sortmethod.py
+++ b/resources/lib/kodiwrappers/sortmethod.py
@@ -1,8 +1,0 @@
-# -*- coding: utf-8 -*-
-
-# GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-
-from __future__ import absolute_import, division, unicode_literals
-
-
-ALPHABET = 1

--- a/resources/lib/vrtplayer/metadatacreator.py
+++ b/resources/lib/vrtplayer/metadatacreator.py
@@ -182,10 +182,10 @@ class MetadataCreator:
 
         if self.datetime:
             video_dict['aired'] = self.datetime.strftime('%Y-%m-%d %H:%M:%S')
-            video_dict['date'] = self.datetime.strftime('%d.%m.%Y')
+            video_dict['date'] = self.datetime.strftime('%Y-%m-%d')
         elif self.ontime and self.ontime != datetime(1970, 1, 1):
             video_dict['aired'] = self.ontime.strftime('%Y-%m-%d %H:%M:%S')
-            video_dict['date'] = self.ontime.strftime('%d.%m.%Y')
+            video_dict['date'] = self.ontime.strftime('%Y-%m-%d')
 
         if self.ontime and self.ontime != datetime(1970, 1, 1):
             video_dict['dateadded'] = self.ontime.strftime('%Y-%m-%d %H:%M:%S')

--- a/resources/lib/vrtplayer/metadatacreator.py
+++ b/resources/lib/vrtplayer/metadatacreator.py
@@ -202,11 +202,8 @@ class MetadataCreator:
 #            video_dict['enddate'] = self.datetime.strftime('%Y-%m-%d %H:%M:%S')
 
         if self.brands:
-            #video_dict['channelname'] = self.brands[0] if isinstance(self.brands, list) else self.brands
             video_dict['studio'] = self.brands
-
-        # rating
-        # genre
+#            video_dict['channelname'] = self.brands[0] if isinstance(self.brands, list) else self.brands
 
         # if self.icon:
         #    video_dict['icon'] = self.icon

--- a/resources/lib/vrtplayer/metadatacreator.py
+++ b/resources/lib/vrtplayer/metadatacreator.py
@@ -181,20 +181,25 @@ class MetadataCreator:
             video_dict['mediatype'] = self.mediatype
 
         if self.datetime:
-            video_dict['aired'] = self.datetime.strftime('%d.%m.%Y')
+            video_dict['aired'] = self.datetime.strftime('%Y-%m-%d %H:%M:%S')
             video_dict['date'] = self.datetime.strftime('%d.%m.%Y')
         elif self.ontime and self.ontime != datetime(1970, 1, 1):
-            video_dict['aired'] = self.ontime.strftime('%d.%m.%Y')
+            video_dict['aired'] = self.ontime.strftime('%Y-%m-%d %H:%M:%S')
             video_dict['date'] = self.ontime.strftime('%d.%m.%Y')
 
-        # NOTE: Does not seem to have any effect
-        if self.ontime:
-            video_dict['dateadded'] = self.ontime.strftime('%d.%m.%Y')
-            video_dict['startdate'] = self.ontime.strftime('%d.%m.%Y')
+        if self.ontime and self.ontime != datetime(1970, 1, 1):
+            video_dict['dateadded'] = self.ontime.strftime('%Y-%m-%d %H:%M:%S')
+#            video_dict['startdate'] = self.ontime.strftime('%Y-%m-%d %H:%M:%S')
+        elif self.datetime:
+            video_dict['dateadded'] = self.datetime.strftime('%Y-%m-%d %H:%M:%S')
+#            video_dict['startdate'] = self.datetime.strftime('%Y-%m-%d %H:%M:%S')
 
-        # NOTE/ Does not seem to have any effect
-        if self.offtime:
-            video_dict['enddate'] = self.offtime.strftime('%d.%m.%Y')
+#        if self.offtime and self.offtime != datetime(1970, 1, 1):
+#            video_dict['enddate'] = self.offtime.strftime('%Y-%m-%d %H:%M:%S')
+#        elif self.ontime and self.ontime != datetime(1970, 1, 1):
+#            video_dict['enddate'] = self.ontime.strftime('%Y-%m-%d %H:%M:%S')
+#        elif self.datetime:
+#            video_dict['enddate'] = self.datetime.strftime('%Y-%m-%d %H:%M:%S')
 
         if self.brands:
             # NOTE: Does not seem to have any effect
@@ -202,7 +207,6 @@ class MetadataCreator:
             video_dict['studio'] = self.brands
 
         # rating
-        # episodename
         # genre
 
         # if self.icon:

--- a/resources/lib/vrtplayer/metadatacreator.py
+++ b/resources/lib/vrtplayer/metadatacreator.py
@@ -202,8 +202,7 @@ class MetadataCreator:
 #            video_dict['enddate'] = self.datetime.strftime('%Y-%m-%d %H:%M:%S')
 
         if self.brands:
-            # NOTE: Does not seem to have any effect
-            video_dict['channelname'] = self.brands[0] if isinstance(self.brands, list) else self.brands
+            #video_dict['channelname'] = self.brands[0] if isinstance(self.brands, list) else self.brands
             video_dict['studio'] = self.brands
 
         # rating

--- a/resources/lib/vrtplayer/streamservice.py
+++ b/resources/lib/vrtplayer/streamservice.py
@@ -65,16 +65,16 @@ class StreamService:
         header = ''
         if key_headers:
             for k, v in list(key_headers.items()):
-                header = ''.join((header, '&', k, '=', requests.utils.quote(v)))
+                header = header + '&' + k + '=' + requests.utils.quote(v)
 
         if key_type in ('A', 'R', 'B'):
-            key_value = ''.join((key_type, '{SSM}'))
+            key_value = key_type + '{SSM}'
         elif key_type == 'D':
             if 'D{SSM}' not in key_value:
                 raise ValueError('Missing D{SSM} placeholder')
             key_value = requests.utils.quote(key_value)
 
-        return ''.join((key_url, '|', header.strip('&'), '|', key_value, '|'))
+        return '%s|%s|%s|' % (key_url, header.strip('&'), key_value)
 
     def _get_api_data(self, video_url):
         html_page = requests.get(video_url, proxies=self._proxies).text
@@ -240,10 +240,10 @@ class StreamService:
             subtitle_regex = re.compile(r'#EXT-X-MEDIA:TYPE=SUBTITLES[\w\-=,\.\"\/]+URI=\"([\w\-=]+)\.m3u8\"')
             match_sub = re.search(subtitle_regex, m3u8)
             if match_sub and '/live/' not in master_hls_url:
-                direct_subtitle_url = ''.join((base_url, match_sub.group(1), '.webvtt'))
+                direct_subtitle_url = base_url + match_sub.group(1) + '.webvtt'
 
         # Merge audio and video uri
         if direct_audio_url is not None:
-            direct_video_url = ''.join((base_url, direct_audio_url, '-', direct_video_url.split('-')[-1]))
+            direct_video_url = base_url, direct_audio_url + '-' + direct_video_url.split('-')[-1]
 
         return direct_video_url, direct_subtitle_url

--- a/resources/lib/vrtplayer/streamservice.py
+++ b/resources/lib/vrtplayer/streamservice.py
@@ -11,6 +11,11 @@ import time
 
 from resources.lib.helperobjects import apidata, streamurls
 
+try:
+    from urllib.parse import urlencode
+except ImportError:
+    from urllib import urlencode
+
 
 class StreamService:
 
@@ -64,8 +69,7 @@ class StreamService:
         '''
         header = ''
         if key_headers:
-            for k, v in list(key_headers.items()):
-                header = header + '&' + k + '=' + requests.utils.quote(v)
+            header = urlencode(key_headers)
 
         if key_type in ('A', 'R', 'B'):
             key_value = key_type + '{SSM}'
@@ -74,7 +78,7 @@ class StreamService:
                 raise ValueError('Missing D{SSM} placeholder')
             key_value = requests.utils.quote(key_value)
 
-        return '%s|%s|%s|' % (key_url, header.strip('&'), key_value)
+        return '%s|%s|%s|' % (key_url, header, key_value)
 
     def _get_api_data(self, video_url):
         html_page = requests.get(video_url, proxies=self._proxies).text
@@ -244,6 +248,6 @@ class StreamService:
 
         # Merge audio and video uri
         if direct_audio_url is not None:
-            direct_video_url = base_url, direct_audio_url + '-' + direct_video_url.split('-')[-1]
+            direct_video_url = base_url + direct_audio_url + '-' + direct_video_url.split('-')[-1]
 
         return direct_video_url, direct_subtitle_url

--- a/resources/lib/vrtplayer/tokenresolver.py
+++ b/resources/lib/vrtplayer/tokenresolver.py
@@ -98,7 +98,7 @@ class TokenResolver:
         token = None
         if logon_json.get('errorCode') == 0:
             login_token = logon_json.get('sessionInfo', dict()).get('login_token')
-            login_cookie = ''.join(('glt_', self._API_KEY, '=', login_token))
+            login_cookie = 'glt_%s=%s' % (self._API_KEY, login_token)
             payload = dict(
                 uid=logon_json.get('UID'),
                 uidsig=logon_json.get('UIDSignature'),

--- a/resources/lib/vrtplayer/vrtapihelper.py
+++ b/resources/lib/vrtplayer/vrtapihelper.py
@@ -36,11 +36,12 @@ class VRTApiHelper:
             metadata_creator.tvshowtitle = tvshow.get('title')
             metadata_creator.plot = statichelper.unescape(tvshow.get('description'))
             metadata_creator.brands = tvshow.get('brands')
+            title = '%s  [LIGHT][COLOR yellow]%s[/COLOR][/LIGHT]' % (tvshow.get('title', '???'), tvshow.get('episode_count', '?'))
             thumbnail = statichelper.add_https_method(tvshow.get('thumbnail', 'DefaultAddonVideo.png'))
             # Cut vrtbase url off since it will be added again when searching for episodes
             # (with a-z we dont have the full url)
             video_url = statichelper.add_https_method(tvshow.get('targetUrl')).replace(self._VRT_BASE, '')
-            tvshow_items.append(helperobjects.TitleItem(title=tvshow.get('title'),
+            tvshow_items.append(helperobjects.TitleItem(title=title,
                                                         url_dict=dict(action=actions.LISTING_EPISODES, video_url=video_url),
                                                         is_playable=False,
                                                         art_dict=dict(thumb=thumbnail, icon='DefaultAddonVideo.png', fanart=thumbnail),
@@ -195,7 +196,7 @@ class VRTApiHelper:
 
         for season in seasons:
             season_key = season.get('key')
-            title = ''.join((self._kodi_wrapper.get_localized_string(32094), ' ', season_key))
+            title = '%s %s (%d)' % (self._kodi_wrapper.get_localized_string(32094), season_key, season.)
             season_facet = '&facets[seasonTitle]='
             path = ''.join((api_url, season_facet, season_key))
             season_items.append(helperobjects.TitleItem(

--- a/resources/lib/vrtplayer/vrtapihelper.py
+++ b/resources/lib/vrtplayer/vrtapihelper.py
@@ -97,6 +97,9 @@ class VRTApiHelper:
                 episode = dict()
             display_options = episode.get('displayOptions', dict())
 
+            # NOTE: Hard-code showing seasons because it is unreliable (i.e; Thuis or Down the Road have it disabled)
+            display_options['showSeason'] = True
+
             # Look for seasons items if not yet done
             season_key = None
             if 'facets[seasonTitle]' in path:
@@ -121,6 +124,9 @@ class VRTApiHelper:
                 continue
 
             display_options = episode.get('displayOptions', dict())
+
+            # NOTE: Hard-code showing seasons because it is unreliable (i.e; Thuis or Down the Road have it disabled)
+            display_options['showSeason'] = True
 
             if titletype is None:
                 titletype = episode.get('programType')
@@ -196,7 +202,7 @@ class VRTApiHelper:
 
         for season in seasons:
             season_key = season.get('key')
-            title = '%s %s (%d)' % (self._kodi_wrapper.get_localized_string(32094), season_key, season.)
+            title = '%s %s' % (self._kodi_wrapper.get_localized_string(32094), season_key)
             season_facet = '&facets[seasonTitle]='
             path = ''.join((api_url, season_facet, season_key))
             season_items.append(helperobjects.TitleItem(

--- a/resources/lib/vrtplayer/vrtplayer.py
+++ b/resources/lib/vrtplayer/vrtplayer.py
@@ -8,7 +8,6 @@ import os
 import requests
 
 from resources.lib.helperobjects import helperobjects
-from resources.lib.kodiwrappers import sortmethod
 from resources.lib.vrtplayer import actions, statichelper
 
 
@@ -52,16 +51,16 @@ class VRTPlayer:
                                     art_dict=dict(thumb='DefaultYear.png', icon='DefaultYear.png', fanart='DefaultYear.png'),
                                     video_dict=dict(plot=self._kodi_wrapper.get_localized_string(32087))),
         ]
-        self._kodi_wrapper.show_listing(main_items, content_type='files')
+        self._kodi_wrapper.show_listing(main_items, sort='none', content_type='files')
 
     def show_tvshow_menu_items(self, path):
         tvshow_items = self._api_helper.get_tvshow_items(path)
-        self._kodi_wrapper.show_listing(tvshow_items, sort=sortmethod.ALPHABET, content_type='tvshows')
+        self._kodi_wrapper.show_listing(tvshow_items, sort='label', content_type='tvshows')
 
     def show_category_menu_items(self):
         joined_url = ''.join((self.VRTNU_BASE_URL, '/categorieen/'))
         category_items = self.__get_category_menu_items(joined_url, {'class': 'nui-tile'}, actions.LISTING_CATEGORY_TVSHOWS)
-        self._kodi_wrapper.show_listing(category_items, sort=sortmethod.ALPHABET, content_type='files')
+        self._kodi_wrapper.show_listing(category_items, sort='label', content_type='files')
 
     def play(self, video):
         stream = self._stream_service.get_stream(video)
@@ -95,8 +94,8 @@ class VRTPlayer:
         self._kodi_wrapper.show_listing(livestream_items, content_type='videos')
 
     def show_episodes(self, path):
-        episode_items, sort = self._api_helper.get_episode_items(path)
-        self._kodi_wrapper.show_listing(episode_items, sort=sort, content_type='episodes')
+        episode_items, sort, ascending = self._api_helper.get_episode_items(path)
+        self._kodi_wrapper.show_listing(episode_items, sort=sort, ascending=ascending, content_type='episodes')
 
     def __get_media(self, file_name):
         return os.path.join(self._addon_path, 'resources', 'media', file_name)

--- a/resources/lib/vrtplayer/vrtplayer.py
+++ b/resources/lib/vrtplayer/vrtplayer.py
@@ -19,7 +19,7 @@ class VRTPlayer:
     _KETNET_LIVESTREAM = 'https://www.vrt.be/vrtnu/kanalen/ketnet/'
 
     VRT_BASE = 'https://www.vrt.be/'
-    VRTNU_BASE_URL = ''.join((VRT_BASE, '/vrtnu'))
+    VRTNU_BASE_URL = VRT_BASE + '/vrtnu'
 
     def __init__(self, addon_path, kodi_wrapper, stream_service, api_helper):
         self._addon_path = addon_path
@@ -58,7 +58,7 @@ class VRTPlayer:
         self._kodi_wrapper.show_listing(tvshow_items, sort='label', content_type='tvshows')
 
     def show_category_menu_items(self):
-        joined_url = ''.join((self.VRTNU_BASE_URL, '/categorieen/'))
+        joined_url = self.VRTNU_BASE_URL + '/categorieen/'
         category_items = self.__get_category_menu_items(joined_url, {'class': 'nui-tile'}, actions.LISTING_CATEGORY_TVSHOWS)
         self._kodi_wrapper.show_listing(category_items, sort='label', content_type='files')
 


### PR DESCRIPTION
This implements more sensible episode names and sort order based on program displayOptions.

This PR includes:
- ~Implementation of *showSeason* (so don't show seasons if this is set to False)~
- Using *broadcast date* when *showBroadcastDate* was set
- ~Using *S0XE0Y* format when *showSeason* is disabled~
- Add sorting methods in GUI listing options
- ~Implementation of sort order (ascending/descending) in GUI based on programType *reeksaflopend*/*reeksoplopend*~
- Implementation of sort by *date added* for recent items
- Implementation for programType *daily* and *oneoff*
- Cleanup related to sort method's.

This fixes #126 as good as can be.