### PR TITLE
Add permalink to video plot

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -16,6 +16,7 @@ disable=
     too-many-branches,
     too-many-instance-attributes,
     too-many-locals,
+    too-many-statements,
     unnecessary-lambda,
     unused-argument,
     wrong-import-order,

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -32,12 +32,16 @@ msgid "Delete cookies"
 msgstr "Delete cookies"
 
 msgctxt "#32010"
-msgid "Subtitles"
-msgstr "Subtitles"
+msgid "Interface"
+msgstr "Interface"
 
 msgctxt "#32011"
-msgid "Show subtitles if available"
-msgstr "Show subtitles if available"
+msgid "Show subtitles when available"
+msgstr "Show subtitles when available"
+
+msgctxt "#32012"
+msgid "Show episode permalink in plot"
+msgstr "Show episode permalink in plot"
 
 msgctxt "#32020"
 msgid "DRM"

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -33,12 +33,16 @@ msgid "Delete cookies"
 msgstr "Verwijder cookies"
 
 msgctxt "#32010"
-msgid "Subtitles"
-msgstr "Ondertiteling"
+msgid "Interface"
+msgstr "Interface"
 
 msgctxt "#32011"
-msgid "Show subtitles if available"
+msgid "Show subtitles when available"
 msgstr "Toon ondertiteling indien beschikbaar"
+
+msgctxt "#32012"
+msgid "Show episode permalink in plot"
+msgstr "Toon aflevering permalink in beschrijving"
 
 msgctxt "#32020"
 msgid "DRM"

--- a/resources/lib/vrtplayer/metadatacreator.py
+++ b/resources/lib/vrtplayer/metadatacreator.py
@@ -17,6 +17,7 @@ class MetadataCreator:
         self._mediatype = None
         self._offtime = None
         self._ontime = None
+        self._permalink = None
         self._plot = None
         self._plotoutline = None
         self._season = None
@@ -88,6 +89,14 @@ class MetadataCreator:
     @ontime.setter
     def ontime(self, value):
         self._ontime = value
+
+    @property
+    def permalink(self):
+        return self._permalink
+
+    @permalink.setter
+    def permalink(self, value):
+        self._permalink = value
 
     @property
     def plot(self):
@@ -190,6 +199,10 @@ class MetadataCreator:
 
         if self.mediatype:
             video_dict['mediatype'] = self.mediatype
+
+        if self.permalink:
+            video_dict['path'] = self.permalink
+            video_dict['showlink'] = [self.permalink]
 
         if self.plot:
             video_dict['plot'] = self.plot

--- a/resources/lib/vrtplayer/statichelper.py
+++ b/resources/lib/vrtplayer/statichelper.py
@@ -42,6 +42,16 @@ def convert_html_to_kodilabel(text):
     return unescape(text).strip()
 
 
+def shorten_link(url):
+    if url is None:
+        return None
+    # As used in episode search result 'permalink'
+    url = url.replace('https://www.vrt.be/vrtnu/', 'vrtnu.be/')
+    # As used in program a-z listing 'targetUrl'
+    url = url.replace('//www.vrt.be/vrtnu/', 'vrtnu.be/')
+    return url
+
+
 def strip_newlines(text):
     return text.replace('\n', '').strip()
 

--- a/resources/lib/vrtplayer/vrtapihelper.py
+++ b/resources/lib/vrtplayer/vrtapihelper.py
@@ -27,6 +27,7 @@ class VRTApiHelper:
     def __init__(self, kodi_wrapper):
         self._kodi_wrapper = kodi_wrapper
         self._proxies = self._kodi_wrapper.get_proxies()
+        self._showpermalink = kodi_wrapper.get_setting('showpermalink') == 'true'
 
     def get_tvshow_items(self, path=None):
         if path:
@@ -182,7 +183,7 @@ class VRTApiHelper:
             if plot_meta:
                 metadata.plot = '%s\n%s' % (plot_meta, metadata.plot)
 
-            if metadata.permalink:
+            if self._showpermalink and metadata.permalink:
                 metadata.plot = '%s\n\n[COLOR yellow]%s[/COLOR]' % (metadata.plot, metadata.permalink)
 
             thumb = statichelper.add_https_method(episode.get('videoThumbnailUrl', 'DefaultAddonVideo.png'))

--- a/resources/lib/vrtplayer/vrtapihelper.py
+++ b/resources/lib/vrtplayer/vrtapihelper.py
@@ -42,6 +42,7 @@ class VRTApiHelper:
             metadata.tvshowtitle = tvshow.get('title', '???')
             metadata.plot = statichelper.unescape(tvshow.get('description', '???'))
             metadata.brands = tvshow.get('brands')
+            metadata.permalink = statichelper.shorten_link(tvshow.get('targetUrl'))
             # NOTE: This adds episode_count to title, would be better as metadata
             # title = '%s  [LIGHT][COLOR yellow]%s[/COLOR][/LIGHT]' % (tvshow.get('title', '???'), tvshow.get('episode_count', '?'))
             title = tvshow.get('title', '???')
@@ -158,6 +159,7 @@ class VRTApiHelper:
             metadata.season = episode.get('seasonName')
             metadata.episode = episode.get('episodeNumber')
             metadata.mediatype = episode.get('type', 'episode')
+            metadata.permalink = statichelper.shorten_link(episode.get('permalink')) or episode.get('externalPermalink')
             if episode.get('assetOnTime'):
                 metadata.ontime = datetime(*time.strptime(episode.get('assetOnTime'), '%Y-%m-%dT%H:%M:%S+0000')[0:6])
             if episode.get('assetOffTime'):
@@ -178,7 +180,10 @@ class VRTApiHelper:
                 else:
                     plot_meta += self._kodi_wrapper.get_localized_string(32204) % int((metadata.offtime - datetime.utcnow()).seconds / 3600)
             if plot_meta:
-                metadata.plot = plot_meta + '\n' + metadata.plot
+                metadata.plot = '%s\n%s' % (plot_meta, metadata.plot)
+
+            if metadata.permalink:
+                metadata.plot = '%s\n\n[COLOR yellow]%s[/COLOR]' % (metadata.plot, metadata.permalink)
 
             thumb = statichelper.add_https_method(episode.get('videoThumbnailUrl', 'DefaultAddonVideo.png'))
             fanart = statichelper.add_https_method(episode.get('programImageUrl', thumb))

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -6,6 +6,7 @@
     </category>
     <category label="32010">
         <setting label="32011" type="bool" id="showsubtitles" default="true"/>
+        <setting label="32012" type="bool" id="showpermalink" default="false"/>
     </category>
     <category label="32020">
         <setting label="32021" type="bool" id="usedrm" default="false"/>


### PR DESCRIPTION
There's no metadata in the video_dict for external URLs (there really should be though).

So I am adding the shortened permalink to the end of the plot, this could be useful if this episode/video needs to be played through another means (e.g. because Kodi has an issue or the addon fails somehow).