### PR TITLE
Restore the "Default' sort order

### DIFF
--- a/resources/lib/kodiwrappers/kodiwrapper.py
+++ b/resources/lib/kodiwrappers/kodiwrapper.py
@@ -17,13 +17,14 @@ except ImportError:
     from urllib import urlencode
 
 sort_methods = {
-    'date': xbmcplugin.SORT_METHOD_DATE,
+    # 'date': xbmcplugin.SORT_METHOD_DATE,
     'dateadded': xbmcplugin.SORT_METHOD_DATEADDED,
     'duration': xbmcplugin.SORT_METHOD_DURATION,
     'episode': xbmcplugin.SORT_METHOD_EPISODE,
     # 'genre': xbmcplugin.SORT_METHOD_GENRE,
     'label': xbmcplugin.SORT_METHOD_LABEL_IGNORE_THE,
-    'none': xbmcplugin.SORT_METHOD_NONE,
+    # 'none': xbmcplugin.SORT_METHOD_UNSORTED,
+    # FIXME: We would like to be able to sort by unprefixed title (ignore date/episode prefix)
     # 'title': xbmcplugin.SORT_METHOD_TITLE_IGNORE_THE,
     'unsorted': xbmcplugin.SORT_METHOD_UNSORTED,
 }
@@ -49,24 +50,28 @@ class KodiWrapper:
         self._addon = addon
         self._addon_id = addon.getAddonInfo('id')
 
-    def show_listing(self, list_items, sort='none', ascending=True, content_type='episodes'):
+    def show_listing(self, list_items, sort='unsorted', ascending=True, content_type='episodes'):
         listing = []
 
         xbmcplugin.setContent(self._handle, content=content_type)
 
-        # Add all sort methods to GUI
+        # FIXME: Since there is no way to influence descending order, we force it here
+        if not ascending:
+            sort = 'unsorted'
+
+        # Add all sort methods to GUI (start with preferred)
         xbmcplugin.addSortMethod(handle=self._handle, sortMethod=sort_methods[sort])
-        for key in sort_methods:
+        for key in sorted(sort_methods):
             if key != sort:
                 xbmcplugin.addSortMethod(handle=self._handle, sortMethod=sort_methods[key])
 
         # FIXME: This does not appear to be working, we have to order it ourselves
-        xbmcplugin.setProperty(handle=self._handle, key='sort.ascending', value='true' if ascending else 'false')
-        if ascending:
-            xbmcplugin.setProperty(handle=self._handle, key='sort.order', value=str(sort_methods[sort]))
-        else:
-            # NOTE: When descending, use unsorted
-            xbmcplugin.setProperty(handle=self._handle, key='sort.order', value=str(sort_methods['none']))
+#        xbmcplugin.setProperty(handle=self._handle, key='sort.ascending', value='true' if ascending else 'false')
+#        if ascending:
+#            xbmcplugin.setProperty(handle=self._handle, key='sort.order', value=str(sort_methods[sort]))
+#        else:
+#            # NOTE: When descending, use unsorted
+#            xbmcplugin.setProperty(handle=self._handle, key='sort.order', value=str(sort_methods['unsorted']))
 
         for title_item in list_items:
             list_item = xbmcgui.ListItem(label=title_item.title, thumbnailImage=title_item.art_dict.get('thumb'))
@@ -74,12 +79,12 @@ class KodiWrapper:
             list_item.setProperty(key='IsPlayable', value='true' if title_item.is_playable else 'false')
 
             # FIXME: This does not appear to be working, we have to order it ourselves
-            list_item.setProperty(key='sort.ascending', value='true' if ascending else 'false')
-            if ascending:
-                list_item.setProperty(key='sort.order', value=str(sort_methods[sort]))
-            else:
-                # NOTE: When descending, use unsorted
-                list_item.setProperty(key='sort.order', value=str(sort_methods['none']))
+#            list_item.setProperty(key='sort.ascending', value='true' if ascending else 'false')
+#            if ascending:
+#                list_item.setProperty(key='sort.order', value=str(sort_methods[sort]))
+#            else:
+#                # NOTE: When descending, use unsorted
+#                list_item.setProperty(key='sort.order', value=str(sort_methods['unsorted']))
 
             if title_item.art_dict:
                 list_item.setArt(title_item.art_dict)

--- a/resources/lib/vrtplayer/vrtapihelper.py
+++ b/resources/lib/vrtplayer/vrtapihelper.py
@@ -262,7 +262,7 @@ class VRTApiHelper:
         else:
             title = statichelper.convert_html_to_kodilabel(result.get('shortDescription') or result.get('title'))
 
-        sort = 'none'
+        sort = 'unsorted'
         ascending = True
 
         if titletype == 'recent':

--- a/resources/lib/vrtplayer/vrtplayer.py
+++ b/resources/lib/vrtplayer/vrtplayer.py
@@ -51,7 +51,7 @@ class VRTPlayer:
                                     art_dict=dict(thumb='DefaultYear.png', icon='DefaultYear.png', fanart='DefaultYear.png'),
                                     video_dict=dict(plot=self._kodi_wrapper.get_localized_string(32087))),
         ]
-        self._kodi_wrapper.show_listing(main_items, sort='none', content_type='files')
+        self._kodi_wrapper.show_listing(main_items, sort='unsorted', content_type='files')
 
     def show_tvshow_menu_items(self, path):
         tvshow_items = self._api_helper.get_tvshow_items(path)


### PR DESCRIPTION
Using SORT_METHOD_UNSORTED is better than using SORT_METHOD_NONE as it appears in the sort order list as 'Default'. So this makes it a bit more consistent, people can go back to the original/preferred sort order.

Also comment out non-functional code.

I removed sort order "Date" as it doesn't work as people would expect, and is confusing as we also have "Date added". The only thing remaining is to make sort order "Name" and sort order "Title" do the right thing (Title should sort discarding the date/episode prefix we added ourselves).