### PR TITLE
Add a TV guide menu entry

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -9,7 +9,7 @@ import sys
 
 import xbmcaddon
 from resources.lib.kodiwrappers import kodiwrapper
-from resources.lib.vrtplayer import actions, streamservice, tokenresolver, vrtapihelper, vrtplayer
+from resources.lib.vrtplayer import actions, streamservice, tokenresolver, tvguide, vrtapihelper, vrtplayer
 
 try:
     from urllib.parse import parse_qsl
@@ -42,6 +42,9 @@ def router(params_string):
         vrt_player.show_episodes(params.get('video_url'))
     elif action == actions.LISTING_CATEGORY_TVSHOWS:
         vrt_player.show_tvshow_menu_items(path=params.get('video_url'))
+    elif action == actions.LISTING_TVGUIDE:
+        tv_guide = tvguide.TVGuide(addon.getAddonInfo('path'), kodi_wrapper)
+        tv_guide.show_tvguide(params)
     elif action == actions.PLAY:
         video = dict(
             video_url=params.get('video_url'),

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -174,3 +174,28 @@ msgstr "[B][COLOR green](%s days left)[/COLOR][/B]\n"
 msgctxt "#32204"
 msgid "[B][COLOR green](%s hours left)[/COLOR][/B]\n"
 msgstr "[B][COLOR green](%s hours left)[/COLOR][/B]\n"
+
+msgctxt "#32301"
+msgid "[B]TV guide for channel %s[/B]"
+msgstr "[B]TV guide for channel %s[/B]"
+
+msgctxt "#32330"
+msgid "2 days ago"
+msgstr "2 days ago"
+
+msgctxt "#32331"
+msgid "Yesterday"
+msgstr "Yesterday"
+
+msgctxt "#32332"
+msgid "Today"
+msgstr "Today"
+
+msgctxt "#32333"
+msgid "Tomorrow"
+msgstr "Tomorrow"
+
+msgctxt "#32334"
+msgid "In 2 days"
+msgstr "In 2 days"
+

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -111,6 +111,14 @@ msgctxt "#32087"
 msgid "Recently published episodes of TV programs"
 msgstr "Recently published episodes of TV programs"
 
+msgctxt "#32088"
+msgid "TV guide"
+msgstr "TV guide"
+
+msgctxt "#32089"
+msgid "Browse channel TV guides"
+msgstr "Browse channel TV guides"
+
 msgctxt "#32094"
 msgid "Season"
 msgstr "Season"

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -98,7 +98,7 @@ msgstr "Lijst van tv-programma's per categorie"
 
 msgctxt "#32084"
 msgid "Live TV"
-msgstr "Live tv"
+msgstr "Live kijken"
 
 msgctxt "#32085"
 msgid "Watch TV channels live (using Internet streaming)"
@@ -111,6 +111,14 @@ msgstr "Meest recent"
 msgctxt "#32087"
 msgid "Recently published episodes of TV programs"
 msgstr "Recent gepubliceerde afleveringen van tv-programma's"
+
+msgctxt "#32088"
+msgid "TV guide"
+msgstr "TV-gids"
+
+msgctxt "#32089"
+msgid "Browse channel TV guides"
+msgstr "Doorzoek de TV-gids per kanaal"
 
 msgctxt "#32094"
 msgid "Season"

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -175,3 +175,27 @@ msgstr "[B][COLOR green](nog %s dagen)[/COLOR][/B]\n"
 msgctxt "#32204"
 msgid "[B][COLOR green](%s hours left)[/COLOR][/B]\n"
 msgstr "[B][COLOR green](nog %s uur)[/COLOR][/B]\n"
+
+msgctxt "#32301"
+msgid "[B]TV guide for channel %s[/B]"
+msgstr "[B]TV-gids for kanaal %s[/B]"
+
+msgctxt "#32330"
+msgid "2 days ago"
+msgstr "Eergisteren"
+
+msgctxt "#32331"
+msgid "Yesterday"
+msgstr "Gisteren"
+
+msgctxt "#32332"
+msgid "Today"
+msgstr "Vandaag"
+
+msgctxt "#32333"
+msgid "Tomorrow"
+msgstr "Morgen"
+
+msgctxt "#32334"
+msgid "In 2 days"
+msgstr "Overmorgen"

--- a/resources/lib/kodiwrappers/kodiwrapper.py
+++ b/resources/lib/kodiwrappers/kodiwrapper.py
@@ -130,6 +130,9 @@ class KodiWrapper:
     def get_localized_dateshort(self):
         return xbmc.getRegion('dateshort')
 
+    def get_localized_datelong(self):
+        return xbmc.getRegion('datelong')
+
     def get_setting(self, setting_id):
         return self._addon.getSetting(setting_id)
 

--- a/resources/lib/vrtplayer/actions.py
+++ b/resources/lib/vrtplayer/actions.py
@@ -11,6 +11,6 @@ LISTING_LIVE = 'listinglive'
 
 LISTING_CATEGORY_TVSHOWS = 'listingcategorytvshows'
 LISTING_EPISODES = 'listingepisodes'
+LISTING_TVGUIDE = 'listingtvguide'
 
 PLAY = 'play'
-CREDENTIALS = 'credentials'

--- a/resources/lib/vrtplayer/metadatacreator.py
+++ b/resources/lib/vrtplayer/metadatacreator.py
@@ -192,6 +192,8 @@ class MetadataCreator:
         if self.geolocked:
             video_dict['overlay'] = 7
             # video_dict['overlay'] = 'OverlayLocked.png'
+        else:
+            video_dict['overlay'] = 3
 
         # if self.icon:
         #    video_dict['icon'] = self.icon

--- a/resources/lib/vrtplayer/statichelper.py
+++ b/resources/lib/vrtplayer/statichelper.py
@@ -59,6 +59,8 @@ def strip_newlines(text):
 def add_https_method(url):
     if url.startswith('//'):
         return 'https:' + url
+    if url.startswith('/'):
+        return 'https://vrt.be' + url
     return url
 
 

--- a/resources/lib/vrtplayer/statichelper.py
+++ b/resources/lib/vrtplayer/statichelper.py
@@ -3,6 +3,9 @@
 # GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, unicode_literals
+
+from datetime import datetime
+import time
 import re
 
 
@@ -70,3 +73,10 @@ def distinct(sequence):
         if s not in seen:
             seen.add(s)
             yield s
+
+
+def strptime(date_string, fmt):
+    try:
+        return datetime.strptime(date_string, fmt)
+    except TypeError:
+        return datetime(*(time.strptime(date_string, fmt)[0:6]))

--- a/resources/lib/vrtplayer/tvguide.py
+++ b/resources/lib/vrtplayer/tvguide.py
@@ -25,10 +25,12 @@ CHANNELS = dict(
     ),
 )
 
-DATES = {
-    '1': 'Tomorrow',
-    '0': 'Today',
-    '-1': 'Yesterday',
+DATE_STRINGS = {
+    '-2': 32330,  # 2 days ago
+    '-1': 32331,  # Yesterday
+    '0': 32332,  # Today
+    '1': 32333,  # Tomorrow
+    '2': 32334,  # In 2 days
 }
 
 
@@ -51,11 +53,11 @@ class TVGuide:
             for i in range(7, -31, -1):
                 day = today + timedelta(days=i)
                 title = day.strftime(self._kodi_wrapper.get_localized_datelong())
-                if str(i) in DATES:
+                if str(i) in DATE_STRINGS:
                     if i == 0:
-                        title = '[COLOR yellow][B]%s[/B], %s[/COLOR]' % (DATES[str(i)], title)
+                        title = '[COLOR yellow][B]%s[/B], %s[/COLOR]' % (self._kodi_wrapper.get_localized_string(DATE_STRINGS[str(i)]), title)
                     else:
-                        title = '[B]%s[/B], %s' % (DATES[str(i)], title)
+                        title = '[B]%s[/B], %s' % (self._kodi_wrapper.get_localized_string(DATE_STRINGS[str(i)]), title)
                 date_items.append(
                     helperobjects.TitleItem(title=title,
                                             url_dict=dict(action=actions.LISTING_TVGUIDE, date=day.strftime('%Y-%m-%d')),
@@ -66,15 +68,18 @@ class TVGuide:
             self._kodi_wrapper.show_listing(date_items, sort='unsorted', content_type='files')
 
         elif not channel:
+            dateobj = statichelper.strptime(date, '%Y-%m-%d')
+            datelong = dateobj.strftime(self._kodi_wrapper.get_localized_datelong())
             channel_items = []
             for channel in ('een', 'canvas', 'ketnet'):
+                plot = self._kodi_wrapper.get_localized_string(32301) % CHANNELS[channel]['name'] + '\n' + datelong
                 channel_items.append(
                     helperobjects.TitleItem(
                         title=CHANNELS[channel]['name'],
                         url_dict=dict(action=actions.LISTING_TVGUIDE, date=date, channel=channel),
                         is_playable=False,
                         art_dict=dict(thumb=self.__get_media(channel + '.png'), icon='DefaultAddonPVRClient.png', fanart='DefaultAddonPVRClient.png'),
-                        video_dict=dict(plot='TV guide for channel %s' % CHANNELS[channel]['name']),
+                        video_dict=dict(plot=plot),
                     ),
                 )
             self._kodi_wrapper.show_listing(channel_items, content_type='files')
@@ -96,7 +101,7 @@ class TVGuide:
                 metadata.tvshowtitle = title
                 metadata.datetime = dateobj
                 metadata.duration = (statichelper.strptime(end, '%H:%M') - statichelper.strptime(start, '%H:%M')).total_seconds()
-                metadata.plot = '[B]%s[/B]\n%s\n%s - %s\n[I]%s[/I]' % (title, datelong, start, end, channel)
+                metadata.plot = '[B]%s[/B]\n%s\n%s - %s\n[I]%s[/I]' % (title, datelong, start, end, CHANNELS[channel]['name'])
                 metadata.brands = [channel]
                 metadata.mediatype = 'episode'
                 thumb = episode.get('image', 'DefaultAddonVideo.png')

--- a/resources/lib/vrtplayer/tvguide.py
+++ b/resources/lib/vrtplayer/tvguide.py
@@ -80,7 +80,7 @@ class TVGuide:
             self._kodi_wrapper.show_listing(channel_items, content_type='files')
 
         else:
-            dateobj = datetime.strptime(date, '%Y-%m-%d')
+            dateobj = statichelper.strptime(date, '%Y-%m-%d')
             datelong = dateobj.strftime(self._kodi_wrapper.get_localized_datelong())
             api_url = dateobj.strftime(self.VRT_TVGUIDE)
             schedule = requests.get(api_url, proxies=self._proxies).json()
@@ -95,7 +95,7 @@ class TVGuide:
                 metadata.title = '%s - %s' % (start, title)
                 metadata.tvshowtitle = title
                 metadata.datetime = dateobj
-                metadata.duration = (datetime.strptime(end, '%H:%M') - datetime.strptime(start, '%H:%M')).total_seconds()
+                metadata.duration = (statichelper.strptime(end, '%H:%M') - statichelper.strptime(start, '%H:%M')).total_seconds()
                 metadata.plot = '[B]%s[/B]\n%s\n%s - %s\n[I]%s[/I]' % (title, datelong, start, end, channel)
                 metadata.brands = [channel]
                 metadata.mediatype = 'episode'

--- a/resources/lib/vrtplayer/tvguide.py
+++ b/resources/lib/vrtplayer/tvguide.py
@@ -1,0 +1,122 @@
+# -*- coding: utf-8 -*-
+
+# GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, unicode_literals
+from datetime import datetime, timedelta
+import os
+import requests
+
+from resources.lib.helperobjects import helperobjects
+from resources.lib.vrtplayer import actions, metadatacreator, statichelper
+
+CHANNELS = dict(
+    een=dict(
+        id='O8',
+        name='Eén',
+    ),
+    canvas=dict(
+        id='1H',
+        name='Canvas',
+    ),
+    ketnet=dict(
+        id='O9',
+        name='Ketnet',
+    ),
+)
+
+DATES = {
+    '1': 'Tomorrow',
+    '0': 'Today',
+    '-1': 'Yesterday',
+}
+
+
+class TVGuide:
+
+    VRT_TVGUIDE = 'https://www.vrt.be/bin/epg/schedule.%Y-%m-%d.json'
+
+    def __init__(self, addon_path, kodi_wrapper):
+        self._addon_path = addon_path
+        self._kodi_wrapper = kodi_wrapper
+        self._proxies = self._kodi_wrapper.get_proxies()
+
+    def show_tvguide(self, params):
+        date = params.get('date')
+        channel = params.get('channel')
+
+        if not date:
+            today = datetime.today()
+            date_items = []
+            for i in range(7, -31, -1):
+                day = today + timedelta(days=i)
+                title = day.strftime(self._kodi_wrapper.get_localized_datelong())
+                if str(i) in DATES:
+                    if i == 0:
+                        title = '[COLOR yellow][B]%s[/B], %s[/COLOR]' % (DATES[str(i)], title)
+                    else:
+                        title = '[B]%s[/B], %s' % (DATES[str(i)], title)
+                date_items.append(
+                    helperobjects.TitleItem(title=title,
+                                            url_dict=dict(action=actions.LISTING_TVGUIDE, date=day.strftime('%Y-%m-%d')),
+                                            is_playable=False,
+                                            art_dict=dict(thumb='DefaultYear.png', icon='DefaultYear.png', fanart='DefaultYear.png'),
+                                            video_dict=dict(plot=day.strftime(self._kodi_wrapper.get_localized_datelong()))),
+                )
+            self._kodi_wrapper.show_listing(date_items, sort='unsorted', content_type='files')
+
+        elif not channel:
+            channel_items = []
+            for channel in ('een', 'canvas', 'ketnet'):
+                channel_items.append(
+                    helperobjects.TitleItem(
+                        title=CHANNELS[channel]['name'],
+                        url_dict=dict(action=actions.LISTING_TVGUIDE, date=date, channel=channel),
+                        is_playable=False,
+                        art_dict=dict(thumb=self.__get_media(channel + '.png'), icon='DefaultAddonPVRClient.png', fanart='DefaultAddonPVRClient.png'),
+                        video_dict=dict(plot='TV guide for channel %s' % CHANNELS[channel]['name']),
+                    ),
+                )
+            self._kodi_wrapper.show_listing(channel_items, content_type='files')
+
+        else:
+            dateobj = datetime.strptime(date, '%Y-%m-%d')
+            datelong = dateobj.strftime(self._kodi_wrapper.get_localized_datelong())
+            api_url = dateobj.strftime(self.VRT_TVGUIDE)
+            schedule = requests.get(api_url, proxies=self._proxies).json()
+            episodes = schedule[CHANNELS[channel]['id']]
+            episode_items = []
+            for episode in episodes:
+                metadata = metadatacreator.MetadataCreator()
+                title = episode.get('title')
+                start = episode.get('start')
+                end = episode.get('end')
+                url = episode.get('url')
+                metadata.title = '%s - %s' % (start, title)
+                metadata.tvshowtitle = title
+                metadata.datetime = dateobj
+                metadata.duration = (datetime.strptime(end, '%H:%M') - datetime.strptime(start, '%H:%M')).total_seconds()
+                metadata.plot = '[B]%s[/B]\n%s\n%s - %s\n[I]%s[/I]' % (title, datelong, start, end, channel)
+                metadata.brands = [channel]
+                metadata.mediatype = 'episode'
+                thumb = episode.get('image', 'DefaultAddonVideo.png')
+                metadata.icon = thumb
+                if url:
+                    video_url = statichelper.add_https_method(url)
+                    url_dict = dict(action=actions.PLAY, video_url=video_url)
+                else:
+                    # FIXME: Find a better solution for non-actionable items
+                    url_dict = dict(action=actions.LISTING_TVGUIDE, date=date, channel=channel)
+                    metadata.title = '[COLOR gray]%s[/COLOR]' % metadata.title
+                    title = '[COLOR gray]%s[/COLOR]' % metadata.title
+                episode_items.append(helperobjects.TitleItem(
+                    title=title,
+                    url_dict=url_dict,
+                    is_playable=bool(url),
+                    art_dict=dict(thumb=thumb, icon='DefaultAddonVideo.png', fanart=thumb),
+                    video_dict=metadata.get_video_dict(),
+                ))
+            self._kodi_wrapper.show_listing(episode_items, sort='unsorted', content_type='episodes')
+
+    def __get_media(self, file_name):
+        return os.path.join(self._addon_path, 'resources', 'media', file_name)

--- a/resources/lib/vrtplayer/vrtapihelper.py
+++ b/resources/lib/vrtplayer/vrtapihelper.py
@@ -5,7 +5,6 @@
 from __future__ import absolute_import, division, unicode_literals
 from datetime import datetime
 import requests
-import time
 
 from resources.lib.helperobjects import helperobjects
 from resources.lib.vrtplayer import actions, metadatacreator, statichelper
@@ -162,9 +161,9 @@ class VRTApiHelper:
             metadata.mediatype = episode.get('type', 'episode')
             metadata.permalink = statichelper.shorten_link(episode.get('permalink')) or episode.get('externalPermalink')
             if episode.get('assetOnTime'):
-                metadata.ontime = datetime(*time.strptime(episode.get('assetOnTime'), '%Y-%m-%dT%H:%M:%S+0000')[0:6])
+                metadata.ontime = statichelper.strptime(episode.get('assetOnTime'), '%Y-%m-%dT%H:%M:%S+0000')
             if episode.get('assetOffTime'):
-                metadata.offtime = datetime(*time.strptime(episode.get('assetOffTime'), '%Y-%m-%dT%H:%M:%S+0000')[0:6])
+                metadata.offtime = statichelper.strptime(episode.get('assetOffTime'), '%Y-%m-%dT%H:%M:%S+0000')
 
             # Add additional metadata to plot
             plot_meta = ''

--- a/resources/lib/vrtplayer/vrtapihelper.py
+++ b/resources/lib/vrtplayer/vrtapihelper.py
@@ -148,7 +148,7 @@ class VRTApiHelper:
 
             metadata.duration = (episode.get('duration', 0) * 60)  # Minutes to seconds
             metadata.plot = statichelper.convert_html_to_kodilabel(episode.get('description'))
-            metadata.brands = episode.get('programBrands', episode.get('brands'))
+            metadata.brands = episode.get('programBrands') or episode.get('brands')
             metadata.geolocked = episode.get('allowedRegion') == 'BE'
             if display_options.get('showShortDescription'):
                 short_description = statichelper.convert_html_to_kodilabel(episode.get('shortDescription'))
@@ -209,6 +209,7 @@ class VRTApiHelper:
         program_type = episode.get('programType')
         metadata = metadatacreator.MetadataCreator()
         metadata.mediatype = 'season'
+        metadata.brands = episode.get('programBrands') or episode.get('brands')
 
         # Reverse sort seasons if program_type is 'reeksaflopend' or 'daily'
         if program_type in ('daily', 'reeksaflopend'):

--- a/resources/lib/vrtplayer/vrtplayer.py
+++ b/resources/lib/vrtplayer/vrtplayer.py
@@ -50,6 +50,11 @@ class VRTPlayer:
                                     is_playable=False,
                                     art_dict=dict(thumb='DefaultYear.png', icon='DefaultYear.png', fanart='DefaultYear.png'),
                                     video_dict=dict(plot=self._kodi_wrapper.get_localized_string(32087))),
+            helperobjects.TitleItem(title=self._kodi_wrapper.get_localized_string(32088),
+                                    url_dict=dict(action=actions.LISTING_TVGUIDE),
+                                    is_playable=False,
+                                    art_dict=dict(thumb='DefaultAddonTvInfo.png', icon='DefaultAddonTvInfo.png', fanart='DefaultAddonTvInfo.png'),
+                                    video_dict=dict(plot=self._kodi_wrapper.get_localized_string(32089))),
         ]
         self._kodi_wrapper.show_listing(main_items, sort='unsorted', content_type='files')
 


### PR DESCRIPTION
So the approach is this:
- You select the day (today, yesterday, ...)
  - We can go back 1 month, and forward 1 week
  - Giving a long list of 40 entries is not a good interface though
- You select the channel
- You get a TV listing for the whole day, with links to play available episodes from the TV-guide

TODO:
- Translate some strings, clean up the interface somewhat