### PR TITLE
Fix for tzlocal() on Windows

### DIFF
--- a/resources/lib/vrtplayer/metadatacreator.py
+++ b/resources/lib/vrtplayer/metadatacreator.py
@@ -156,7 +156,10 @@ class MetadataCreator:
         self._year = value
 
     def get_video_dict(self):
-        epoch = datetime.fromtimestamp(0, dateutil.tz.tzlocal())
+        try:
+            epoch = datetime.fromtimestamp(0, dateutil.tz.tzlocal())
+        except ValueError:
+            epoch = datetime.fromtimestamp(0, dateutil.tz.tzwinlocal())
 
         video_dict = dict()
 


### PR DESCRIPTION
This was required for the plugin to work again on Windows.
It is a quickfix, a better solution is needed.