### PR TITLE
Implement fallback for Categories web-scraping

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -25,9 +25,7 @@ def router(params_string):
     addon = xbmcaddon.Addon()
     kodi_wrapper = kodiwrapper.KodiWrapper(_ADDON_HANDLE, _ADDON_URL, addon)
     token_resolver = tokenresolver.TokenResolver(kodi_wrapper)
-    stream_service = streamservice.StreamService(vrtplayer.VRTPlayer.VRT_BASE,
-                                                 vrtplayer.VRTPlayer.VRTNU_BASE_URL,
-                                                 kodi_wrapper, token_resolver)
+    stream_service = streamservice.StreamService(kodi_wrapper, token_resolver)
     api_helper = vrtapihelper.VRTApiHelper(kodi_wrapper)
     vrt_player = vrtplayer.VRTPlayer(addon.getAddonInfo('path'), kodi_wrapper, stream_service, api_helper)
     params = dict(parse_qsl(params_string))
@@ -39,19 +37,14 @@ def router(params_string):
     elif action == actions.LISTING_LIVE:
         vrt_player.show_livestream_items()
     elif action == actions.LISTING_EPISODES:
-        vrt_player.show_episodes(params.get('video_url'))
+        vrt_player.show_episodes(path=params.get('video_url'))
     elif action == actions.LISTING_CATEGORY_TVSHOWS:
         vrt_player.show_tvshow_menu_items(path=params.get('video_url'))
     elif action == actions.LISTING_TVGUIDE:
         tv_guide = tvguide.TVGuide(addon.getAddonInfo('path'), kodi_wrapper)
         tv_guide.show_tvguide(params)
     elif action == actions.PLAY:
-        video = dict(
-            video_url=params.get('video_url'),
-            video_id=params.get('video_id'),
-            publication_id=params.get('publication_id'),
-        )
-        vrt_player.play(video)
+        vrt_player.play(params)
     else:
         vrt_player.show_main_menu_items()
 

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -132,52 +132,12 @@ msgid "Episode"
 msgstr "Episode"
 
 msgctxt "#32101"
-msgid "Eén live"
-msgstr "Eén live"
+msgid "%s live"
+msgstr "%s live"
 
 msgctxt "#32102"
-msgid "Watch Eén live TV stream (via Internet)"
-msgstr "Watch Eén live TV stream (via Internet)"
-
-msgctxt "#32111"
-msgid "Canvas live"
-msgstr "Canvas live"
-
-msgctxt "#32112"
-msgid "Watch Canvas live TV stream (via Internet)"
-msgstr "Watch Canvas live TV stream (via Internet)"
-
-msgctxt "#32121"
-msgid "Ketnet live"
-msgstr "Ketnet live"
-
-msgctxt "#32122"
-msgid "Watch Ketnet live TV stream (via Internet)"
-msgstr "Watch Ketnet live TV stream (via Internet)"
-
-msgctxt "#32131"
-msgid "Sporza live"
-msgstr "Sporza live"
-
-msgctxt "#32132"
-msgid "Watch Sporza live TV stream (via Internet)"
-msgstr "Watch Sporza live TV stream via (Internet)"
-
-msgctxt "#32141"
-msgid "Studio Brussel live"
-msgstr "Studio Brussel live"
-
-msgctxt "#32142"
-msgid "Watch Studio Brussel live TV stream (via Internet)"
-msgstr "Watch Studio Brussel live TV stream via (Internet)"
-
-msgctxt "#32151"
-msgid "MNM live"
-msgstr "MNM live"
-
-msgctxt "#32152"
-msgid "Watch MNM live TV stream (via Internet)"
-msgstr "Watch MNM live TV stream via (Internet)"
+msgid "Watch %s live TV stream (via Internet)"
+msgstr "Watch %s live TV stream (via Internet)"
 
 msgctxt "#32201"
 msgid "[B][COLOR red]Geo-blocked[/COLOR][/B]\n"

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -133,52 +133,12 @@ msgid "Episode"
 msgstr "Aflevering"
 
 msgctxt "#32101"
-msgid "Eén live"
-msgstr "Eén live"
+msgid "%s live"
+msgstr "%s live"
 
 msgctxt "#32102"
-msgid "Watch Eén live TV stream (via Internet)"
-msgstr "Bekijk Eén live tv stream (via Internet)"
-
-msgctxt "#32111"
-msgid "Canvas live"
-msgstr "Canvas live"
-
-msgctxt "#32112"
-msgid "Watch Canvas live TV stream (via Internet)"
-msgstr "Bekijk Canvas live tv stream (via Internet)"
-
-msgctxt "#32121"
-msgid "Ketnet live"
-msgstr "Ketnet live"
-
-msgctxt "#32122"
-msgid "Watch Ketnet live TV stream (via Internet)"
-msgstr "Bekijk Ketnet live tv stream (via Internet)"
-
-msgctxt "#32131"
-msgid "Sporza live"
-msgstr "Sporza live"
-
-msgctxt "#32132"
-msgid "Watch Sporza live TV stream (via Internet)"
-msgstr "Bekijk Sporza live tv stream (via Internet)"
-
-msgctxt "#32141"
-msgid "Studio Brussel live"
-msgstr "Studio Brussel live"
-
-msgctxt "#32142"
-msgid "Watch Studio Brussel live TV stream (via Internet)"
-msgstr "Watch Studio Brussel live TV stream via (Internet)"
-
-msgctxt "#32151"
-msgid "MNM live"
-msgstr "MNM live"
-
-msgctxt "#32152"
-msgid "Watch MNM live TV stream (via Internet)"
-msgstr "Watch MNM live TV stream via (Internet)"
+msgid "Watch %s live TV stream (via Internet)"
+msgstr "Bekijk %s live tv stream (via Internet)"
 
 msgctxt "#32201"
 msgid "[B][COLOR red]Geo-blocked[/COLOR][/B]\n"

--- a/resources/lib/kodiwrappers/kodiwrapper.py
+++ b/resources/lib/kodiwrappers/kodiwrapper.py
@@ -90,7 +90,7 @@ class KodiWrapper:
                 list_item.setArt(title_item.art_dict)
 
             if title_item.video_dict:
-                list_item.setInfo('video', infoLabels=title_item.video_dict)
+                list_item.setInfo(type='video', infoLabels=title_item.video_dict)
 
             listing.append((url, list_item, not title_item.is_playable))
 

--- a/resources/lib/vrtplayer/__init__.py
+++ b/resources/lib/vrtplayer/__init__.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+
+# GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, unicode_literals
+
+# Fallback list of categories so we don't depend on web scraping only
+CATEGORIES = [
+    dict(name='Audiodescriptie', id='met-audiodescriptie'),
+    dict(name='Cultuur', id='cultuur'),
+    dict(name='Docu', id='docu'),
+    dict(name='Entertainment', id='entertainment'),
+    dict(name='Films', id='films'),
+    dict(name='Human interest', id='human-interest'),
+    dict(name='Humor', id='humor'),
+    dict(name='Kinderen', id='voor-kinderen'),
+    dict(name='Koken', id='koken'),
+    dict(name='Lifestyle', id='lifestyle'),
+    dict(name='Muziek', id='muziek'),
+    dict(name='Nieuws en actua', id='nieuws-en-actua'),
+    dict(name='Series', id='series'),
+    dict(name='Sport', id='sport'),
+    dict(name='Talkshows', id='talkshows'),
+    dict(name='Vlaamse Gebarentaal', id='met-gebarentaal'),
+    dict(name='Wetenschap en natuur', id='wetenschap-en-natuur'),
+]
+
+CHANNELS = {
+    'een': dict(
+        id='O8',
+        type='tv',
+        name='Eén',
+        studio='Een',
+        live_stream='https://www.vrt.be/vrtnu/kanalen/een/',
+
+    ),
+    'canvas': dict(
+        id='1H',
+        type='tv',
+        name='Canvas',
+        studio='Canvas',
+        live_stream='https://www.vrt.be/vrtnu/kanalen/canvas/',
+    ),
+    'ketnet': dict(
+        id='O9',
+        type='tv',
+        name='Ketnet',
+        studio='Ketnet',
+        live_stream='https://www.vrt.be/vrtnu/kanalen/ketnet/',
+    ),
+    'ketnet-jr': dict(
+        id='1H',
+        type='tv',
+        name='Ketnet Junior',
+        studio='Ketnet Junior',
+    ),
+    'sporza': dict(
+        id='12',
+        type='radio+tv',
+        name='Sporza',
+        studio='Sporza',
+    ),
+    'vrtnxt': dict(
+        id='',
+        type='tv',
+        name='VRT NXT',
+        studio='VRT NXT',
+    ),
+    'radio1': dict(
+        id='11',
+        type='radio',
+        name='Radio 1',
+        studio='Radio 1',
+    ),
+    'radio2': dict(
+        id='24',
+        type='radio',
+        name='Radio 2',
+        studio='Radio 2',
+    ),
+    'klara': dict(
+        id='31',
+        type='radio',
+        name='Klara',
+        studio='Klara',
+    ),
+    'stubru': dict(
+        id='41',
+        type='radio+tv',
+        name='Studio Brussel',
+        studio='Studio Brussel',
+        # live_stream='https://stubru.be/live',
+        live_stream='https://live-radio-cf-vrt.akamaized.net/groupb/live/0f394a26-c87d-475e-8590-e9c6e79b28d9/live.isml/.mpd',
+    ),
+    'mnm': dict(
+        id='55',
+        type='radio+tv',
+        name='MNM',
+        studio='MNM',
+        # live_stream='https://mnm.be/kijk/live',
+        live_stream='https://live-radio-cf-vrt.akamaized.net/groupa/live/bac277a1-306d-44a0-8e2e-e5b9c07fa270/live.isml/.mpd',
+    ),
+    'vrtnws': dict(
+        id='13',
+        type='radio+tv',
+        name='VRT NWS',
+        studio='VRT NWS',
+    ),
+}

--- a/resources/lib/vrtplayer/metadatacreator.py
+++ b/resources/lib/vrtplayer/metadatacreator.py
@@ -6,6 +6,8 @@ from __future__ import absolute_import, division, unicode_literals
 from datetime import datetime
 import dateutil.tz
 
+from resources.lib.vrtplayer import CHANNELS
+
 
 class MetadataCreator:
 
@@ -160,8 +162,9 @@ class MetadataCreator:
         video_dict = dict()
 
         if self.brands:
-            video_dict['studio'] = self.brands
-#            video_dict['channelname'] = self.brands[0] if isinstance(self.brands, list) else self.brands
+            video_dict['studio'] = CHANNELS.get(self.brands[0], {'studio': 'VRT'}).get('studio')
+        else:
+            video_dict['studio'] = 'VRT'
 
         if self.datetime:
             video_dict['aired'] = self.datetime.strftime('%Y-%m-%d %H:%M:%S')

--- a/resources/lib/vrtplayer/streamservice.py
+++ b/resources/lib/vrtplayer/streamservice.py
@@ -23,12 +23,10 @@ class StreamService:
     _VUALTO_API_URL = 'https://media-services-public.vrt.be/vualto-video-aggregator-web/rest/external/v1'
     _CLIENT = 'vrtvideo'
 
-    def __init__(self, vrt_base, vrtnu_base_url, kodi_wrapper, token_resolver):
+    def __init__(self, kodi_wrapper, token_resolver):
         self._kodi_wrapper = kodi_wrapper
         self._proxies = self._kodi_wrapper.get_proxies()
         self.token_resolver = token_resolver
-        self._vrt_base = vrt_base
-        self._vrtnu_base_url = vrtnu_base_url
         self._create_settings_dir()
         self._can_play_drm = self._kodi_wrapper.can_play_drm()
         self._license_url = None

--- a/resources/lib/vrtplayer/tvguide.py
+++ b/resources/lib/vrtplayer/tvguide.py
@@ -10,22 +10,7 @@ import os
 import requests
 
 from resources.lib.helperobjects import helperobjects
-from resources.lib.vrtplayer import actions, metadatacreator, statichelper
-
-CHANNELS = dict(
-    een=dict(
-        id='O8',
-        name='Eén',
-    ),
-    canvas=dict(
-        id='1H',
-        name='Canvas',
-    ),
-    ketnet=dict(
-        id='O9',
-        name='Ketnet',
-    ),
-)
+from resources.lib.vrtplayer import CHANNELS, actions, metadatacreator, statichelper
 
 DATE_STRINGS = {
     '-2': 32330,  # 2 days ago
@@ -82,7 +67,7 @@ class TVGuide:
                         url_dict=dict(action=actions.LISTING_TVGUIDE, date=date, channel=channel),
                         is_playable=False,
                         art_dict=dict(thumb=self.__get_media(channel + '.png'), icon='DefaultAddonPVRClient.png', fanart='DefaultAddonPVRClient.png'),
-                        video_dict=dict(plot=plot),
+                        video_dict=dict(plot=plot, studio=CHANNELS[channel]['studio']),
                     ),
                 )
             self._kodi_wrapper.show_listing(channel_items, content_type='files')

--- a/resources/lib/vrtplayer/vrtapihelper.py
+++ b/resources/lib/vrtplayer/vrtapihelper.py
@@ -20,10 +20,9 @@ except ImportError:
 class VRTApiHelper:
 
     _VRT_BASE = 'https://www.vrt.be'
-    _VRTNU_API_BASE = 'https://vrtnu-api.vrt.be'
-    _VRTNU_SEARCH_URL = _VRTNU_API_BASE + '/search'
-    _VRTNU_SUGGEST_URL = _VRTNU_API_BASE + '/suggest'
-    _VRTNU_SCREENSHOT_URL = _VRTNU_API_BASE + '/screenshots'
+    _VRTNU_SEARCH_URL = 'https://vrtnu-api.vrt.be/search'
+    _VRTNU_SUGGEST_URL = 'https://vrtnu-api.vrt.be/suggest'
+    _VRTNU_SCREENSHOT_URL = 'https://vrtnu-api.vrt.be/screenshots'
 
     def __init__(self, kodi_wrapper):
         self._kodi_wrapper = kodi_wrapper

--- a/test/vrtplayertests.py
+++ b/test/vrtplayertests.py
@@ -4,9 +4,10 @@
 
 from __future__ import absolute_import, division, unicode_literals
 import mock
+import random
 import unittest
 
-from resources.lib.vrtplayer import vrtapihelper, vrtplayer
+from resources.lib.vrtplayer import CATEGORIES, vrtapihelper, vrtplayer
 
 
 class TestVRTPlayer(unittest.TestCase):
@@ -81,6 +82,25 @@ class TestVRTPlayer(unittest.TestCase):
         path = 'nieuws-en-actua'
         tvshow_items = self._api_helper.get_tvshow_items(path)
         self.assertTrue(tvshow_items)
+
+    def test_categories_scraping(self):
+        ''' Test to ensure our hardcoded categories conforms to scraped categories '''
+        # Remove thumbnails from scraped categories first
+        categories = [dict(id=c['id'], name=c['name']) for c in vrtplayer.get_categories()]
+        self.assertEqual(categories, CATEGORIES)
+
+    def test_random_tvshow_episodes(self):
+        ''' Rest episode from a random tvshow in a random category '''
+        categories = vrtplayer.get_categories()
+        self.assertTrue(categories)
+
+        category = random.choice(categories)
+        tvshow_items = self._api_helper.get_tvshow_items(category['id'])
+        self.assertTrue(tvshow_items, msg=category['id'])
+
+        tvshow = random.choice(tvshow_items)
+        episode_items, sort, ascending = self._api_helper.get_episode_items(tvshow.url_dict['video_url'])
+        self.assertTrue(episode_items, msg=tvshow.url_dict['video_url'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR includes:
- Provide better Studio names
- Fall back to hardcoded list of CATEGORIES if web-scraping fails
- A hardcoded list of channels (both tv as radio)
- Clean up of codebase to use both CHANNELS and CATEGORIES
- Generate list of live streams from CHANNELS
- Include unit test to ensure hard-coded CATEGORIES is identical to web-scraped list

We could now run our tests on an hourly basis to confirm that category-listing scraping works and our internal representation is correct and complete.

This implements https://github.com/pietje666/plugin.video.vrt.nu/issues/57#issuecomment-483650787

PS The fallback mechanism does not support thumbnails. We could do that, but I expect the thumbnails to change more often.