### PR TITLE
Fallback for live streams when web scraping fails

### DIFF
--- a/resources/lib/vrtplayer/__init__.py
+++ b/resources/lib/vrtplayer/__init__.py
@@ -32,7 +32,7 @@ CHANNELS = {
         name='Eén',
         studio='Een',
         live_stream='https://www.vrt.be/vrtnu/kanalen/een/',
-
+        live_stream_id='vualto_een',
     ),
     'canvas': dict(
         id='1H',
@@ -40,6 +40,7 @@ CHANNELS = {
         name='Canvas',
         studio='Canvas',
         live_stream='https://www.vrt.be/vrtnu/kanalen/canvas/',
+        live_stream_id='vualto_canvas',
     ),
     'ketnet': dict(
         id='O9',
@@ -47,6 +48,7 @@ CHANNELS = {
         name='Ketnet',
         studio='Ketnet',
         live_stream='https://www.vrt.be/vrtnu/kanalen/ketnet/',
+        live_stream_id='vualto_ketnet',
     ),
     'ketnet-jr': dict(
         id='1H',
@@ -59,6 +61,7 @@ CHANNELS = {
         type='radio+tv',
         name='Sporza',
         studio='Sporza',
+        live_stream_id='vualto_sporza',
     ),
     'vrtnxt': dict(
         id='',
@@ -90,7 +93,7 @@ CHANNELS = {
         name='Studio Brussel',
         studio='Studio Brussel',
         # live_stream='https://stubru.be/live',
-        live_stream='https://live-radio-cf-vrt.akamaized.net/groupb/live/0f394a26-c87d-475e-8590-e9c6e79b28d9/live.isml/.mpd',
+        live_stream_id='vualto_stubru',
     ),
     'mnm': dict(
         id='55',
@@ -98,12 +101,14 @@ CHANNELS = {
         name='MNM',
         studio='MNM',
         # live_stream='https://mnm.be/kijk/live',
-        live_stream='https://live-radio-cf-vrt.akamaized.net/groupa/live/bac277a1-306d-44a0-8e2e-e5b9c07fa270/live.isml/.mpd',
+        live_stream_id='vualto_mnm',
     ),
     'vrtnws': dict(
         id='13',
         type='radio+tv',
         name='VRT NWS',
         studio='VRT NWS',
+        live_stream_id='vualto_nieuws',
+        # live_stream_id='vualto_journaal',
     ),
 }

--- a/resources/lib/vrtplayer/vrtplayer.py
+++ b/resources/lib/vrtplayer/vrtplayer.py
@@ -97,9 +97,16 @@ class VRTPlayer:
                 thumbnail = 'DefaultAddonMusic.png'
                 fanart = 'DefaultAddonPVRClient.png'
                 plot = self._kodi_wrapper.get_localized_string(32102) % CHANNELS[channel].get('name')
+
+            url_dict = dict(action=actions.PLAY)
+            if CHANNELS[channel].get('live_stream'):
+                url_dict['video_url'] = CHANNELS[channel].get('live_stream')
+            if CHANNELS[channel].get('live_stream_id'):
+                url_dict['video_id'] = CHANNELS[channel].get('live_stream_id')
+
             livestream_items.append(helperobjects.TitleItem(
                 title=self._kodi_wrapper.get_localized_string(32101) % CHANNELS[channel].get('name'),
-                url_dict=dict(action=actions.PLAY, video_url=CHANNELS[channel].get('live_stream')),
+                url_dict=url_dict,
                 is_playable=True,
                 art_dict=dict(thumb=thumbnail, icon='DefaultAddonPVRClient.png', fanart=fanart),
                 video_dict=dict(


### PR DESCRIPTION
This implements vualto live stream support (by video_id) for streams
that do not rely on web scraping, but also implements a fallback
mechanism in case web scraping fails.

This is the last piece to get rid of any reliance on web scraping.
Users everywhere rejoice !

This fixes #57 