### PR TITLE
improve streamservice

### DIFF
--- a/resources/lib/vrtplayer/__init__.py
+++ b/resources/lib/vrtplayer/__init__.py
@@ -32,7 +32,7 @@ CHANNELS = {
         name='Eén',
         studio='Een',
         live_stream='https://www.vrt.be/vrtnu/kanalen/een/',
-        live_stream_id='vualto_een',
+        live_stream_id='vualto_een_geo',
     ),
     'canvas': dict(
         id='1H',
@@ -40,7 +40,7 @@ CHANNELS = {
         name='Canvas',
         studio='Canvas',
         live_stream='https://www.vrt.be/vrtnu/kanalen/canvas/',
-        live_stream_id='vualto_canvas',
+        live_stream_id='vualto_canvas_geo',
     ),
     'ketnet': dict(
         id='O9',
@@ -48,7 +48,7 @@ CHANNELS = {
         name='Ketnet',
         studio='Ketnet',
         live_stream='https://www.vrt.be/vrtnu/kanalen/ketnet/',
-        live_stream_id='vualto_ketnet',
+        live_stream_id='vualto_ketnet_geo',
     ),
     'ketnet-jr': dict(
         id='1H',
@@ -61,7 +61,7 @@ CHANNELS = {
         type='radio+tv',
         name='Sporza',
         studio='Sporza',
-        live_stream_id='vualto_sporza',
+        live_stream_id='vualto_sporza_geo',
     ),
     'vrtnxt': dict(
         id='',

--- a/resources/lib/vrtplayer/streamservice.py
+++ b/resources/lib/vrtplayer/streamservice.py
@@ -104,7 +104,7 @@ class StreamService:
             video_data = soup.find(lambda tag: tag.name == 'div' and tag.get('class') == ['vrtvideo']).attrs
         except Exception as e:
             # Web scraping failed, log error
-            self._kodi_wrapper.log_error('Web scraping api data failed: %s', e)
+            self._kodi_wrapper.log_error('Web scraping api data failed: %s' % e)
             return None
 
         # Web scraping failed, log error

--- a/resources/lib/vrtplayer/streamservice.py
+++ b/resources/lib/vrtplayer/streamservice.py
@@ -106,12 +106,12 @@ class StreamService:
             # Web scraping failed, log error
             self._kodi_wrapper.log_error('Web scraping api data failed: %s', e)
             return None
-        
+
         # Web scraping failed, log error
         if not video_data:
             self._kodi_wrapper.log_error('Web scraping api data failed, empty video_data')
             return None
-        
+
         # Store required html data attributes
         client = video_data.get('data-client')
         media_api_url = video_data.get('data-mediaapiurl')
@@ -127,7 +127,7 @@ class StreamService:
             publication_id += requests.utils.quote('$')
             xvrttoken = self.token_resolver.get_xvrttoken()
 
-        if client is None or meta_api_url is None or (video_id is None and publication_id is None):
+        if client is None or media_api_url is None or (video_id is None and publication_id is None):
             self._kodi_wrapper.log_error('Web scraping api data failed, required attributes missing')
             return None
 

--- a/resources/lib/vrtplayer/streamservice.py
+++ b/resources/lib/vrtplayer/streamservice.py
@@ -78,39 +78,50 @@ class StreamService:
 
         return '%s|%s|%s|' % (key_url, header, key_value)
 
-    def _get_api_data(self, video_url, video_id=None):
+    def _get_api_data(self, video):
+        '''Get and prepare api data object'''
+        video_url = video.get('video_url')
+        video_id = video.get('video_id')
+        publication_id = video.get('publication_id')
+        # Prepare api_data for on demand streams by video_id and publication_id
+        if video_id and publication_id:
+            xvrttoken = self.token_resolver.get_xvrttoken()
+            api_data = apidata.ApiData(self._CLIENT, self._VUALTO_API_URL, video_id, publication_id + requests.utils.quote('$'), xvrttoken, False)
+        # Prepare api_data for livestreams by video_id, e.g. vualto_strubru, vualto_mnm
+        elif video_id and not video_url:
+            api_data = apidata.ApiData(self._CLIENT, self._VUALTO_API_URL, video_id, '', None, True)
+        # Webscrape api_data with video_id fallback
+        elif video_url:
+            api_data = self._webscrape_api_data(video_url) or apidata.ApiData(self._CLIENT, self._VUALTO_API_URL, video_id, '', None, True)
+        return api_data
+
+    def _webscrape_api_data(self, video_url):
+        '''Scrape api data from VRT NU html page'''
+        api_data = None
         html_page = requests.get(video_url, proxies=self._proxies).text
         strainer = SoupStrainer('div', {'class': 'cq-dd-vrtvideo'})
         soup = BeautifulSoup(html_page, 'html.parser', parse_only=strainer)
         try:
             video_data = soup.find(lambda tag: tag.name == 'div' and tag.get('class') == ['vrtvideo']).attrs
+            # Store required html data attributes
+            client = video_data.get('data-client')
+            media_api_url = video_data.get('data-mediaapiurl')
+            video_id = video_data.get('data-videoid')
+            publication_id = video_data.get('data-publicationid', '')
+            # Live stream or on demand
+            if video_id is None:
+                is_live_stream = True
+                video_id = video_data.get('data-livestream')
+                xvrttoken = None
+            else:
+                is_live_stream = False
+                publication_id += requests.utils.quote('$')
+                xvrttoken = self.token_resolver.get_xvrttoken()
+            api_data = apidata.ApiData(client, media_api_url, video_id, publication_id, xvrttoken, is_live_stream)
         except Exception:
-            # Web scraping failed
-            video_data = None
-
-        # Web scraping failed, fall back to using video_id only
-        if not video_data and video_id:
-            return apidata.ApiData(self._CLIENT, self._VUALTO_API_URL, video_id, '', None, True)
-
-        # Store required data attributes
-        client = video_data.get('data-client')
-        media_api_url = video_data.get('data-mediaapiurl')
-
-        video_id = video_data.get('data-videoid')
-        # Is this a livestream instead ?
-        if video_id is None:
-            is_live_stream = True
-            xvrttoken = None
-            video_id = video_data.get('data-livestream')
-        else:
-            is_live_stream = False
-            xvrttoken = self.token_resolver.get_xvrttoken()
-
-        publication_id = video_data.get('data-publicationid', '')
-        if publication_id:
-            publication_id += requests.utils.quote('$')
-
-        return apidata.ApiData(client, media_api_url, video_id, publication_id, xvrttoken, is_live_stream)
+            # Web scraping failed, log error
+            self._kodi_wrapper.log_error('Web scraping api data failed')
+        return api_data
 
     def _get_video_json(self, api_data):
         token_url = api_data.media_api_url + '/tokens'
@@ -156,22 +167,9 @@ class StreamService:
         return stream_dict
 
     def get_stream(self, video, retry=False, api_data=None):
-        video_url = video.get('video_url')
-        video_id = video.get('video_id')
-        publication_id = video.get('publication_id')
-        # Prepare api_data for on demand streams by video_id and publication_id
-        if video_id and publication_id and not retry:
-            xvrttoken = self.token_resolver.get_xvrttoken()
-            api_data = apidata.ApiData(self._CLIENT, self._VUALTO_API_URL, video_id, publication_id + requests.utils.quote('$'), xvrttoken, False)
-        # Prepare api_data for livestreams by video_id, e.g. vualto_strubru, vualto_mnm
-        elif video_id and not video_url:
-            api_data = apidata.ApiData(self._CLIENT, self._VUALTO_API_URL, video_id, '', None, True)
-        # Support .mpd streams directly (only works on Kodi 18+ with inputstream.adaptive)
-        elif video_url.endswith('.mpd'):
-            return streamurls.StreamURLS(video_url, use_inputstream_adaptive=True)
-        # Webscrape api_data from html video_url
-        else:
-            api_data = api_data or self._get_api_data(video_url, video_id)
+        '''Main streamservice function'''
+        if not api_data:
+            api_data = self._get_api_data(video)
 
         vudrm_token = None
         video_json = self._get_video_json(api_data)

--- a/resources/lib/vrtplayer/vrtplayer.py
+++ b/resources/lib/vrtplayer/vrtplayer.py
@@ -88,7 +88,7 @@ class VRTPlayer:
 
     def show_livestream_items(self):
         livestream_items = []
-        for channel in ['een', 'canvas', 'ketnet', 'stubru', 'mnm']:
+        for channel in ['een', 'canvas', 'ketnet', 'sporza', 'stubru', 'mnm']:
             if channel in ['een', 'canvas', 'ketnet']:
                 thumbnail = self.__get_media(channel + '.png')
                 fanart = self._api_helper.get_live_screenshot(channel)


### PR DESCRIPTION
`vualto_een`, `vualto_canvas`, `vualto_ketnet` and `vualto_sporza` are deprecated video_id's since VRT geoblocks live streams. This was the main cause the previous commit was failing on hls streams.

Other changes:
- removed direct mpeg_dash option, for two reasons:
    - every VRT stream is available through vualto video aggregator api
    - in the past direct stream urls changed several times a year at unpredictable times
- separated web scraping function, so it's easier and more failsafe to fix
- added an error message to Kodi log when web scraping fails
- centralized `api_data` manipulations in `_get_api_data` function