### PR TITLE
Improve module imports to speed up operation

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -9,7 +9,7 @@ import sys
 
 import xbmcaddon
 from resources.lib.kodiwrappers import kodiwrapper
-from resources.lib.vrtplayer import actions, streamservice, tokenresolver, tvguide, vrtapihelper, vrtplayer
+from resources.lib.vrtplayer import actions
 
 try:
     from urllib.parse import parse_qsl
@@ -23,13 +23,21 @@ _ADDON_HANDLE = int(sys.argv[1])
 def router(params_string):
     ''' This is the main router for the video plugin menu '''
     addon = xbmcaddon.Addon()
-    kodi_wrapper = kodiwrapper.KodiWrapper(_ADDON_HANDLE, _ADDON_URL, addon)
-    token_resolver = tokenresolver.TokenResolver(kodi_wrapper)
-    stream_service = streamservice.StreamService(kodi_wrapper, token_resolver)
-    api_helper = vrtapihelper.VRTApiHelper(kodi_wrapper)
-    vrt_player = vrtplayer.VRTPlayer(addon.getAddonInfo('path'), kodi_wrapper, stream_service, api_helper)
     params = dict(parse_qsl(params_string))
     action = params.get('action')
+
+    kodi_wrapper = kodiwrapper.KodiWrapper(_ADDON_HANDLE, _ADDON_URL, addon)
+
+    if action == actions.LISTING_TVGUIDE:
+        from resources.lib.vrtplayer import tvguide
+        tv_guide = tvguide.TVGuide(kodi_wrapper)
+        tv_guide.show_tvguide(params)
+        return
+
+    from resources.lib.vrtplayer import vrtapihelper, vrtplayer
+    api_helper = vrtapihelper.VRTApiHelper(kodi_wrapper)
+    vrt_player = vrtplayer.VRTPlayer(kodi_wrapper, api_helper)
+
     if action == actions.LISTING_AZ_TVSHOWS:
         vrt_player.show_tvshow_menu_items(path=None)
     elif action == actions.LISTING_CATEGORIES:
@@ -40,9 +48,6 @@ def router(params_string):
         vrt_player.show_episodes(path=params.get('video_url'))
     elif action == actions.LISTING_CATEGORY_TVSHOWS:
         vrt_player.show_tvshow_menu_items(path=params.get('video_url'))
-    elif action == actions.LISTING_TVGUIDE:
-        tv_guide = tvguide.TVGuide(addon.getAddonInfo('path'), kodi_wrapper)
-        tv_guide.show_tvguide(params)
     elif action == actions.PLAY:
         vrt_player.play(params)
     else:

--- a/resources/lib/kodiwrappers/kodiwrapper.py
+++ b/resources/lib/kodiwrappers/kodiwrapper.py
@@ -3,13 +3,8 @@
 # GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, unicode_literals
-import json
-
-import inputstreamhelper
 import xbmc
-import xbmcgui
 import xbmcplugin
-import xbmcvfs
 
 try:
     from urllib.parse import urlencode
@@ -51,6 +46,7 @@ class KodiWrapper:
         self._addon_id = addon.getAddonInfo('id')
 
     def show_listing(self, list_items, sort='unsorted', ascending=True, content_type=None, cache=True):
+        import xbmcgui
         listing = []
 
         if content_type:
@@ -99,6 +95,7 @@ class KodiWrapper:
         xbmcplugin.endOfDirectory(self._handle, ok, cacheToDisc=cache)
 
     def play(self, video):
+        import xbmcgui
         play_item = xbmcgui.ListItem(path=video.stream_url)
         if video.stream_url is not None and video.use_inputstream_adaptive:
             play_item.setProperty('inputstreamaddon', 'inputstream.adaptive')
@@ -106,6 +103,7 @@ class KodiWrapper:
             play_item.setMimeType('application/dash+xml')
             play_item.setContentLookup(False)
             if video.license_key is not None:
+                import inputstreamhelper
                 is_helper = inputstreamhelper.Helper('mpd', drm='com.widevine.alpha')
                 if is_helper.check_inputstream():
                     play_item.setProperty('inputstream.adaptive.license_type', 'com.widevine.alpha')
@@ -123,6 +121,7 @@ class KodiWrapper:
         xbmc.Player().showSubtitles(subtitles_visible)
 
     def show_ok_dialog(self, title, message):
+        import xbmcgui
         xbmcgui.Dialog().ok(self._addon.getAddonInfo('name'), title, message)
 
     def set_locale(self):
@@ -153,6 +152,7 @@ class KodiWrapper:
         self._addon.openSettings()
 
     def get_global_setting(self, setting):
+        import json
         json_result = xbmc.executeJSONRPC('{"jsonrpc": "2.0", "method": "Settings.GetSettingValue", "params": {"setting": "%s"}, "id": 1}' % setting)
         return json.loads(json_result).get('result', dict()).get('value')
 
@@ -213,15 +213,19 @@ class KodiWrapper:
         return xbmc.translatePath(path)
 
     def make_dir(self, path):
+        import xbmcvfs
         xbmcvfs.mkdir(path)
 
     def check_if_path_exists(self, path):
+        import xbmcvfs
         return xbmcvfs.exists(path)
 
     def open_path(self, path):
+        import json
         return json.loads(open(path, 'r').read())
 
     def delete_path(self, path):
+        import xbmcvfs
         return xbmcvfs.delete(path)
 
     def log_notice(self, message):

--- a/resources/lib/vrtplayer/metadatacreator.py
+++ b/resources/lib/vrtplayer/metadatacreator.py
@@ -3,10 +3,6 @@
 # GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, unicode_literals
-from datetime import datetime
-import dateutil.tz
-
-from resources.lib.vrtplayer import CHANNELS
 
 
 class MetadataCreator:
@@ -158,6 +154,10 @@ class MetadataCreator:
         self._year = value
 
     def get_video_dict(self):
+        from datetime import datetime
+        import dateutil.tz
+        from resources.lib.vrtplayer import CHANNELS
+
         epoch = datetime.fromtimestamp(0, dateutil.tz.UTC)
         video_dict = dict()
 

--- a/resources/lib/vrtplayer/tokenresolver.py
+++ b/resources/lib/vrtplayer/tokenresolver.py
@@ -3,12 +3,6 @@
 # GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, unicode_literals
-from datetime import datetime
-import dateutil.parser
-import dateutil.tz
-import json
-import requests
-
 from resources.lib.helperobjects import helperobjects
 
 
@@ -64,6 +58,8 @@ class TokenResolver:
                 yield cookie
 
     def _get_new_playertoken(self, path, token_url, headers):
+        import json
+        import requests
         playertoken = requests.post(token_url, proxies=self._proxies, headers=headers).json()
         json.dump(playertoken, open(path, 'w'))
         return playertoken.get('vrtPlayerToken')
@@ -72,6 +68,10 @@ class TokenResolver:
         cached_token = None
 
         if self._kodi_wrapper.check_if_path_exists(path):
+            from datetime import datetime
+            import dateutil.parser
+            import dateutil.tz
+            import json
             token = json.loads(open(path, 'r').read())
             now = datetime.now(dateutil.tz.tzlocal())
             exp = dateutil.parser.parse(token.get('expirationDate'))
@@ -84,6 +84,7 @@ class TokenResolver:
         return cached_token
 
     def _get_new_xvrttoken(self, path, get_roaming_token):
+        import requests
         cred = helperobjects.Credentials(self._kodi_wrapper)
         if not cred.are_filled_in():
             self._kodi_wrapper.open_settings()
@@ -113,6 +114,7 @@ class TokenResolver:
             if get_roaming_token:
                 xvrttoken = self._get_roaming_xvrttoken(xvrttoken)
             if xvrttoken is not None:
+                import json
                 token = xvrttoken.get('X-VRT-Token')
                 json.dump(xvrttoken, open(path, 'w'))
         else:
@@ -134,6 +136,7 @@ class TokenResolver:
         self._kodi_wrapper.show_ok_dialog(title, message)
 
     def _get_roaming_xvrttoken(self, xvrttoken):
+        import requests
         roaming_xvrttoken = None
         url = 'https://token.vrt.be/vrtnuinitloginEU?destination=https://www.vrt.be/vrtnu/'
         cookie_value = 'X-VRT-Token=' + xvrttoken.get('X-VRT-Token')
@@ -155,6 +158,7 @@ class TokenResolver:
         token_dictionary = None
         xvrttoken_cookie = next(TokenResolver.get_cookie_from_cookiejar('X-VRT-Token', cookie_jar))
         if xvrttoken_cookie is not None:
+            from datetime import datetime
             token_dictionary = {
                 xvrttoken_cookie.name: xvrttoken_cookie.value,
                 'expirationDate': datetime.utcfromtimestamp(xvrttoken_cookie.expires).strftime('%Y-%m-%dT%H:%M:%S.%fZ'),

--- a/resources/lib/vrtplayer/tvguide.py
+++ b/resources/lib/vrtplayer/tvguide.py
@@ -6,7 +6,6 @@ from __future__ import absolute_import, division, unicode_literals
 from datetime import datetime, timedelta
 import dateutil.parser
 import dateutil.tz
-import requests
 
 from resources.lib.helperobjects import helperobjects
 from resources.lib.vrtplayer import CHANNELS, actions, metadatacreator, statichelper
@@ -24,8 +23,7 @@ class TVGuide:
 
     VRT_TVGUIDE = 'https://www.vrt.be/bin/epg/schedule.%Y-%m-%d.json'
 
-    def __init__(self, addon_path, kodi_wrapper):
-        self._addon_path = addon_path
+    def __init__(self, kodi_wrapper):
         self._kodi_wrapper = kodi_wrapper
         self._proxies = self._kodi_wrapper.get_proxies()
         kodi_wrapper.set_locale()
@@ -84,6 +82,7 @@ class TVGuide:
             dateobj = dateutil.parser.parse(date)
             datelong = dateobj.strftime(self._kodi_wrapper.get_localized_datelong())
             api_url = dateobj.strftime(self.VRT_TVGUIDE)
+            import requests
             schedule = requests.get(api_url, proxies=self._proxies).json()
             episodes = schedule[CHANNELS[channel]['id']]
             episode_items = []

--- a/resources/lib/vrtplayer/vrtapihelper.py
+++ b/resources/lib/vrtplayer/vrtapihelper.py
@@ -3,11 +3,6 @@
 # GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, unicode_literals
-from datetime import datetime
-import dateutil.parser
-import dateutil.tz
-import requests
-
 from resources.lib.helperobjects import helperobjects
 from resources.lib.vrtplayer import actions, metadatacreator, statichelper
 
@@ -30,6 +25,7 @@ class VRTApiHelper:
         self._showpermalink = kodi_wrapper.get_setting('showpermalink') == 'true'
 
     def get_tvshow_items(self, path=None):
+        import requests
         if path:
             params = {'facets[categories]': path}
             api_url = self._VRTNU_SUGGEST_URL + '?' + urlencode(params)
@@ -77,6 +73,7 @@ class VRTApiHelper:
         return season_items, sort, ascending
 
     def get_episode_items(self, path):
+        import requests
         episode_items = []
         sort = 'episode'
         ascending = True
@@ -127,6 +124,9 @@ class VRTApiHelper:
         return episode_items, sort, ascending
 
     def _map_to_episode_items(self, episodes, titletype=None, season_key=None):
+        from datetime import datetime
+        import dateutil.parser
+        import dateutil.tz
         now = datetime.now(dateutil.tz.tzlocal())
         sort = 'episode'
         ascending = True

--- a/test/vrtplayertests.py
+++ b/test/vrtplayertests.py
@@ -24,7 +24,7 @@ class TestVRTPlayer(unittest.TestCase):
         self.assertEqual(sort, 'dateadded')
         self.assertFalse(ascending)
 
-        player = vrtplayer.VRTPlayer(None, self._kodi_wrapper, None, self._api_helper)
+        player = vrtplayer.VRTPlayer(self._kodi_wrapper, self._api_helper)
         player.show_episodes(path)
         self.assertTrue(self._kodi_wrapper.show_listing.called)
 
@@ -35,7 +35,7 @@ class TestVRTPlayer(unittest.TestCase):
         self.assertEqual(sort, 'dateadded')
         self.assertFalse(ascending)
 
-        player = vrtplayer.VRTPlayer(None, self._kodi_wrapper, None, self._api_helper)
+        player = vrtplayer.VRTPlayer(self._kodi_wrapper, self._api_helper)
         player.show_episodes(path)
         self.assertTrue(self._kodi_wrapper.show_listing.called)
 
@@ -46,7 +46,7 @@ class TestVRTPlayer(unittest.TestCase):
         self.assertEqual(sort, 'label')
         self.assertFalse(ascending)
 
-        player = vrtplayer.VRTPlayer(None, self._kodi_wrapper, None, self._api_helper)
+        player = vrtplayer.VRTPlayer(self._kodi_wrapper, self._api_helper)
         player.show_episodes(path)
         self.assertTrue(self._kodi_wrapper.show_listing.called)
 
@@ -57,7 +57,7 @@ class TestVRTPlayer(unittest.TestCase):
         self.assertEqual(sort, 'label')
         self.assertFalse(ascending)
 
-        player = vrtplayer.VRTPlayer(None, self._kodi_wrapper, None, self._api_helper)
+        player = vrtplayer.VRTPlayer(self._kodi_wrapper, self._api_helper)
         player.show_episodes(path)
         self.assertTrue(self._kodi_wrapper.show_listing.called)
 


### PR DESCRIPTION
This PR includes:
- ~Replacing **requests** module with **urllib2** (except for tokenresolver)~
- Move infrequently used libraries into local context (i.e. json, inputstream, etc...)
- Move streamservice and tokenresolver out of addon.py
- Remove unused `addon.getAddonInfo('path')` from classes

~This fixes #169 as it speeds up menus drastically on Raspberry Pi.~

Remaining problems that needs fixing before we can consider this:
- Module **urllib2** does not exist on Python 3 ! (So we need a wrapper ?)
- Playback still starts slow due to tokenresolver using **requests**.
- Breaks proxy support currently

IMO We should be fixing the root cause instead.