### PR TITLE
Use different string ids to not corrupt Kodi

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -15,183 +15,183 @@ msgstr ""
 "Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-msgctxt "#32000"
+msgctxt "#30000"
 msgid "Credentials"
 msgstr "Credentials"
 
-msgctxt "#32001"
+msgctxt "#30001"
 msgid "Email address"
 msgstr "Email address"
 
-msgctxt "#32002"
+msgctxt "#30002"
 msgid "Password"
 msgstr "Password"
 
-msgctxt "#32003"
+msgctxt "#30003"
 msgid "Delete cookies"
 msgstr "Delete cookies"
 
-msgctxt "#32010"
+msgctxt "#30010"
 msgid "Subtitles"
 msgstr "Subtitles"
 
-msgctxt "#32011"
+msgctxt "#30011"
 msgid "Show subtitles when available"
 msgstr "Show subtitles when available"
 
-msgctxt "#32020"
+msgctxt "#30020"
 msgid "DRM"
 msgstr "DRM"
 
-msgctxt "#32021"
+msgctxt "#30021"
 msgid "Use DRM for 720p HD-quality livestreams"
 msgstr "Use DRM for 720p HD-quality livestreams"
 
-msgctxt "#32030"
+msgctxt "#30030"
 msgid "Advanced"
 msgstr "Advanced"
 
-msgctxt "#32031"
+msgctxt "#30031"
 msgid "Show episode permalink in plot"
 msgstr "Show episode permalink in plot"
 
-msgctxt "#32051"
+msgctxt "#30051"
 msgid "Login failed!"
 msgstr "Login failed!"
 
-msgctxt "#32052"
+msgctxt "#30052"
 msgid "Invalid email adress or password. Only VRT logins are supported, no Google or Facebook logins."
 msgstr "Invalid email adress or password. Only VRT logins are supported, no Google or Facebook logins."
 
-msgctxt "#32053"
+msgctxt "#30053"
 msgid "This program cannot be played. To view this program outside of Belgium, you first have to validate a Belgian mobile phone number on the VRT NU website."
 msgstr "This program cannot be played. To view this program outside of Belgium, you first have to validate a Belgian mobile phone number on the VRT NU website."
 
-msgctxt "#32054"
+msgctxt "#30054"
 msgid "Woops something went wrong, check the log for more details"
 msgstr "Woops something went wrong, check the log for more details"
 
-msgctxt "#32055"
+msgctxt "#30055"
 msgid "Please fill in your email address to login."
 msgstr "Please fill in your email address to login."
 
-msgctxt "#32056"
+msgctxt "#30056"
 msgid "Please fill in your password to login."
 msgstr "Please fill in your password to login."
 
-msgctxt "#32061"
+msgctxt "#30061"
 msgid "Using a SOCKS proxy requires the PySocks library (script.module.pysocks) installed."
 msgstr "Using a SOCKS proxy requires the PySocks library (script.module.pysocks) installed."
 
-msgctxt "#32080"
+msgctxt "#30080"
 msgid "A-Z"
 msgstr "A-Z"
 
-msgctxt "#32081"
+msgctxt "#30081"
 msgid "Alphabetically sorted list of TV programs"
 msgstr "Alphabetically sorted list of TV programs"
 
-msgctxt "#32082"
+msgctxt "#30082"
 msgid "Categories"
 msgstr "Categories"
 
-msgctxt "#32083"
+msgctxt "#30083"
 msgid "TV programs listed by category"
 msgstr "TV programs listed by category"
 
-msgctxt "#32084"
+msgctxt "#30084"
 msgid "Channels"
 msgstr "Channels"
 
-msgctxt "#32085"
+msgctxt "#30085"
 msgid "TV programs listed by channel"
 msgstr "TV programs listed by channel"
 
-msgctxt "#32086"
+msgctxt "#30086"
 msgid "Live TV"
 msgstr "Live TV"
 
-msgctxt "#32087"
+msgctxt "#30087"
 msgid "Watch TV channels live (using Internet streaming)"
 msgstr "Watch TV channels live (using Internet streaming)"
 
-msgctxt "#32088"
+msgctxt "#30088"
 msgid "Most recent"
 msgstr "Most recent"
 
-msgctxt "#32089"
+msgctxt "#30089"
 msgid "Recently published episodes of TV programs"
 msgstr "Recently published episodes of TV programs"
 
-msgctxt "#32090"
+msgctxt "#30090"
 msgid "TV guide"
 msgstr "TV guide"
 
-msgctxt "#32091"
+msgctxt "#30091"
 msgid "Browse channel TV guides"
 msgstr "Browse channel TV guides"
 
-msgctxt "#32094"
+msgctxt "#30094"
 msgid "Season"
 msgstr "Season"
 
-msgctxt "#32095"
+msgctxt "#30095"
 msgid "Episode"
 msgstr "Episode"
 
-msgctxt "#32101"
+msgctxt "#30101"
 msgid "%s live"
 msgstr "%s live"
 
-msgctxt "#32102"
+msgctxt "#30102"
 msgid "Watch %s live TV stream (via Internet)"
 msgstr "Watch %s live TV stream (via Internet)"
 
-msgctxt "#32201"
+msgctxt "#30201"
 msgid "[B][COLOR red]Geo-blocked[/COLOR][/B]\n"
 msgstr "[B][COLOR red]Geo-blocked[/COLOR][/B]\n"
 
-msgctxt "#32202"
+msgctxt "#30202"
 msgid "[B][COLOR blue]Available until %s[/COLOR][/B]\n"
 msgstr "[B][COLOR blue]Available until %s[/COLOR][/B]\n"
 
-msgctxt "#32203"
+msgctxt "#30203"
 msgid "[B][COLOR green](%s days left)[/COLOR][/B]\n"
 msgstr "[B][COLOR green](%s days left)[/COLOR][/B]\n"
 
-msgctxt "#32204"
+msgctxt "#30204"
 msgid "[B][COLOR green](%s hours left)[/COLOR][/B]\n"
 msgstr "[B][COLOR green](%s hours left)[/COLOR][/B]\n"
 
-msgctxt "#32300"
+msgctxt "#30300"
 msgid "[B][COLOR yellow]More...[/COLOR][/B]"
 msgstr "[B][COLOR yellow]More...[/COLOR][/B]"
 
-msgctxt "#32301"
+msgctxt "#30301"
 msgid "[B]TV guide for channel %s[/B]"
 msgstr "[B]TV guide for channel %s[/B]"
 
-msgctxt "#32302"
+msgctxt "#30302"
 msgid "[B][I]Now on live TV[/I][/B]"
 msgstr "[B][I]Now on live TV[/I][/B]"
 
-msgctxt "#32330"
+msgctxt "#30330"
 msgid "2 days ago"
 msgstr "2 days ago"
 
-msgctxt "#32331"
+msgctxt "#30331"
 msgid "Yesterday"
 msgstr "Yesterday"
 
-msgctxt "#32332"
+msgctxt "#30332"
 msgid "Today"
 msgstr "Today"
 
-msgctxt "#32333"
+msgctxt "#30333"
 msgid "Tomorrow"
 msgstr "Tomorrow"
 
-msgctxt "#32334"
+msgctxt "#30334"
 msgid "In 2 days"
 msgstr "In 2 days"
 

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -16,182 +16,182 @@ msgstr ""
 "Language: nl\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-msgctxt "#32000"
+msgctxt "#30000"
 msgid "Credentials"
 msgstr "Inloggegevens"
 
-msgctxt "#32001"
+msgctxt "#30001"
 msgid "Email address"
 msgstr "E-mailadres"
 
-msgctxt "#32002"
+msgctxt "#30002"
 msgid "Password"
 msgstr "Wachtwoord"
 
-msgctxt "#32003"
+msgctxt "#30003"
 msgid "Delete cookies"
 msgstr "Verwijder cookies"
 
-msgctxt "#32010"
+msgctxt "#30010"
 msgid "Subtitles"
 msgstr "Ondertiteling"
 
-msgctxt "#32011"
+msgctxt "#30011"
 msgid "Show subtitles when available"
 msgstr "Toon ondertiteling indien beschikbaar"
 
-msgctxt "#32020"
+msgctxt "#30020"
 msgid "DRM"
 msgstr "DRM"
 
-msgctxt "#32021"
+msgctxt "#30021"
 msgid "Use DRM for 720p HD-quality livestreams"
 msgstr "Gebruik DRM voor de livestreams in 720p HD-kwaliteit"
 
-msgctxt "#32030"
+msgctxt "#30030"
 msgid "Advanced"
 msgstr "Geavanceerd"
 
-msgctxt "#32031"
+msgctxt "#30031"
 msgid "Show episode permalink in plot"
 msgstr "Toon aflevering permalink in beschrijving"
 
-msgctxt "#32051"
+msgctxt "#30051"
 msgid "Login failed!"
 msgstr "Inloggen mislukt!"
 
-msgctxt "#32052"
+msgctxt "#30052"
 msgid "Invalid email adress or password. Only VRT logins are supported, no Google or Facebook logins."
 msgstr "Ongeldig e-mailadres of wachtwoord. Alleen VRT-logins worden ondersteund, geen Google- of Facebook-logins."
 
-msgctxt "#32053"
+msgctxt "#30053"
 msgid "This program cannot be played. To view this program outside of Belgium, you first have to validate a Belgian mobile phone number on the VRT NU website."
 msgstr "Het programma kan niet afgespeeld worden. Om dit programma buiten België te bekijken moet je eerst een Belgisch gsm-nummer valideren via de VRT NU-website."
 
-msgctxt "#32054"
+msgctxt "#30054"
 msgid "Woops something went wrong, check the log for more details"
 msgstr "Oeps, er ging iets mis, check de log voor meer informatie"
 
-msgctxt "#32055"
+msgctxt "#30055"
 msgid "Please fill in your email address to login."
 msgstr "Gelieve je e-mailadres in te vullen om in te loggen."
 
-msgctxt "#32056"
+msgctxt "#30056"
 msgid "Please fill in your password to login."
 msgstr "Gelieve je wachtwoord in te vullen om in te loggen."
 
-msgctxt "#32061"
+msgctxt "#30061"
 msgid "Using a SOCKS proxy requires the PySocks library (script.module.pysocks) installed."
 msgstr "Het gebruik van SOCKS proxies vereist dat de PySocks library (script.module.pysocks) geïnstalleerd is."
 
-msgctxt "#32080"
+msgctxt "#30080"
 msgid "A-Z"
 msgstr "A-Z"
 
-msgctxt "#32081"
+msgctxt "#30081"
 msgid "Alphabetically sorted list of TV programs"
 msgstr "Alle TV-programma's in alfabetische volgorde"
 
-msgctxt "#32082"
+msgctxt "#30082"
 msgid "Categories"
 msgstr "Categorieën"
 
-msgctxt "#32083"
+msgctxt "#30083"
 msgid "TV programs listed by category"
 msgstr "Lijst van TV-programma's per categorie"
 
-msgctxt "#32084"
+msgctxt "#30084"
 msgid "Channels"
 msgstr "Kanalen"
 
-msgctxt "#32085"
+msgctxt "#30085"
 msgid "TV programs listed by channel"
 msgstr "Lijst van TV-programma's per kanaal"
 
-msgctxt "#32086"
+msgctxt "#30086"
 msgid "Live TV"
 msgstr "Live kijken"
 
-msgctxt "#32087"
+msgctxt "#30087"
 msgid "Watch TV channels live (using Internet streaming)"
 msgstr "Bekijk TV-kanalen live (via Internet)"
 
-msgctxt "#32088"
+msgctxt "#30088"
 msgid "Most recent"
 msgstr "Meest recent"
 
-msgctxt "#32089"
+msgctxt "#30089"
 msgid "Recently published episodes of TV programs"
 msgstr "Recent gepubliceerde afleveringen van TV-programma's"
 
-msgctxt "#32090"
+msgctxt "#30090"
 msgid "TV guide"
 msgstr "TV-gids"
 
-msgctxt "#32091"
+msgctxt "#30091"
 msgid "Browse channel TV guides"
 msgstr "Doorzoek de TV-gids per kanaal"
 
-msgctxt "#32094"
+msgctxt "#30094"
 msgid "Season"
 msgstr "Seizoen"
 
-msgctxt "#32095"
+msgctxt "#30095"
 msgid "Episode"
 msgstr "Aflevering"
 
-msgctxt "#32101"
+msgctxt "#30101"
 msgid "%s live"
 msgstr "%s live"
 
-msgctxt "#32102"
+msgctxt "#30102"
 msgid "Watch %s live TV stream (via Internet)"
 msgstr "Bekijk %s live tv stream (via Internet)"
 
-msgctxt "#32201"
+msgctxt "#30201"
 msgid "[B][COLOR red]Geo-blocked[/COLOR][/B]\n"
 msgstr "[B][COLOR red]Geo-geblokkeerd[/COLOR][/B]\n"
 
-msgctxt "#32202"
+msgctxt "#30202"
 msgid "[B][COLOR blue]Available until %s[/COLOR][/B]\n"
 msgstr "[B][COLOR blue]Beschikbaar tot %s[/COLOR][/B]\n"
 
-msgctxt "#32203"
+msgctxt "#30203"
 msgid "[B][COLOR green](%s days left)[/COLOR][/B]\n"
 msgstr "[B][COLOR green](nog %s dagen)[/COLOR][/B]\n"
 
-msgctxt "#32204"
+msgctxt "#30204"
 msgid "[B][COLOR green](%s hours left)[/COLOR][/B]\n"
 msgstr "[B][COLOR green](nog %s uur)[/COLOR][/B]\n"
 
-msgctxt "#32300"
+msgctxt "#30300"
 msgid "[B][COLOR yellow]More...[/COLOR][/B]"
 msgstr "[B][COLOR yellow]Meer...[/COLOR][/B]"
 
-msgctxt "#32301"
+msgctxt "#30301"
 msgid "[B]TV guide for channel %s[/B]"
 msgstr "[B]TV-gids for kanaal %s[/B]"
 
-msgctxt "#32302"
+msgctxt "#30302"
 msgid "[B][I]Now on live TV[/I][/B]"
 msgstr "[B][I]Speelt nu op TV[/I][/B]"
 
-msgctxt "#32330"
+msgctxt "#30330"
 msgid "2 days ago"
 msgstr "Eergisteren"
 
-msgctxt "#32331"
+msgctxt "#30331"
 msgid "Yesterday"
 msgstr "Gisteren"
 
-msgctxt "#32332"
+msgctxt "#30332"
 msgid "Today"
 msgstr "Vandaag"
 
-msgctxt "#32333"
+msgctxt "#30333"
 msgid "Tomorrow"
 msgstr "Morgen"
 
-msgctxt "#32334"
+msgctxt "#30334"
 msgid "In 2 days"
 msgstr "Overmorgen"

--- a/resources/lib/kodiwrappers/kodiwrapper.py
+++ b/resources/lib/kodiwrappers/kodiwrapper.py
@@ -167,7 +167,7 @@ class KodiWrapper:
         if httpproxytype != 0 and not socks_supported:
             # Only open the dialog the first time (to avoid multiple popups)
             if socks_supported is None:
-                message = self.get_localized_string(32061)
+                message = self.get_localized_string(30061)
                 self.show_ok_dialog('', message)
             return None
 

--- a/resources/lib/vrtplayer/streamservice.py
+++ b/resources/lib/vrtplayer/streamservice.py
@@ -156,7 +156,7 @@ class StreamService:
 
     def _handle_error(self, video_json):
         self._kodi_wrapper.log_error(video_json.get('message'))
-        message = self._kodi_wrapper.get_localized_string(32054)
+        message = self._kodi_wrapper.get_localized_string(30054)
         self._kodi_wrapper.show_ok_dialog('', message)
 
     @staticmethod
@@ -211,7 +211,7 @@ class StreamService:
                     # Update api_data with roaming_xvrttoken and try again
                     api_data.xvrttoken = roaming_xvrttoken
                     return self.get_stream(video, retry=True, api_data=api_data)
-                message = self._kodi_wrapper.get_localized_string(32053)
+                message = self._kodi_wrapper.get_localized_string(30053)
                 self._kodi_wrapper.show_ok_dialog('', message)
             else:
                 self._handle_error(video_json)

--- a/resources/lib/vrtplayer/tokenresolver.py
+++ b/resources/lib/vrtplayer/tokenresolver.py
@@ -139,14 +139,14 @@ class TokenResolver:
 
     def _handle_error(self, logon_json, cred):
         error_message = logon_json.get('errorDetails')
-        title = self._kodi_wrapper.get_localized_string(32051)
+        title = self._kodi_wrapper.get_localized_string(30051)
         if error_message == 'invalid loginID or password':
             cred.reset()
-            message = self._kodi_wrapper.get_localized_string(32052)
+            message = self._kodi_wrapper.get_localized_string(30052)
         elif error_message == 'loginID must be provided':
-            message = self._kodi_wrapper.get_localized_string(32055)
+            message = self._kodi_wrapper.get_localized_string(30055)
         elif error_message == 'Missing required parameter: password':
-            message = self._kodi_wrapper.get_localized_string(32056)
+            message = self._kodi_wrapper.get_localized_string(30056)
         else:
             message = error_message
         self._kodi_wrapper.show_ok_dialog(title, message)

--- a/resources/lib/vrtplayer/tvguide.py
+++ b/resources/lib/vrtplayer/tvguide.py
@@ -17,11 +17,11 @@ from resources.lib.helperobjects import helperobjects
 from resources.lib.vrtplayer import CHANNELS, actions, metadatacreator, statichelper
 
 DATE_STRINGS = {
-    '-2': 32330,  # 2 days ago
-    '-1': 32331,  # Yesterday
-    '0': 32332,  # Today
-    '1': 32333,  # Tomorrow
-    '2': 32334,  # In 2 days
+    '-2': 30330,  # 2 days ago
+    '-1': 30331,  # Yesterday
+    '0': 30332,  # Today
+    '1': 30333,  # Tomorrow
+    '2': 30334,  # In 2 days
 }
 
 
@@ -75,7 +75,7 @@ class TVGuide:
 
                 icon = icon_path % channel
                 fanart = fanart_path % channel
-                plot = self._kodi_wrapper.get_localized_string(32301) % channel.get('label') + '\n' + datelong
+                plot = self._kodi_wrapper.get_localized_string(30301) % channel.get('label') + '\n' + datelong
                 channel_items.append(
                     helperobjects.TitleItem(
                         title=channel.get('label'),
@@ -122,14 +122,14 @@ class TVGuide:
                     video_url = statichelper.add_https_method(url)
                     url_dict = dict(action=actions.PLAY, video_url=video_url)
                     if start_date < now <= end_date:  # Now playing
-                        metadata.title = '[COLOR yellow]%s[/COLOR] %s' % (label, self._kodi_wrapper.get_localized_string(32302))
+                        metadata.title = '[COLOR yellow]%s[/COLOR] %s' % (label, self._kodi_wrapper.get_localized_string(30302))
                     else:
                         metadata.title = label
                 else:
                     # FIXME: Find a better solution for non-actionable items
                     url_dict = dict(action=actions.LISTING_TVGUIDE, date=date, channel=channel)
                     if start_date < now <= end_date:  # Now playing
-                        metadata.title = '[COLOR brown]%s[/COLOR] %s' % (label, self._kodi_wrapper.get_localized_string(32302))
+                        metadata.title = '[COLOR brown]%s[/COLOR] %s' % (label, self._kodi_wrapper.get_localized_string(30302))
                     else:
                         metadata.title = '[COLOR gray]%s[/COLOR]' % label
                 episode_items.append(helperobjects.TitleItem(

--- a/resources/lib/vrtplayer/vrtapihelper.py
+++ b/resources/lib/vrtplayer/vrtapihelper.py
@@ -191,16 +191,16 @@ class VRTApiHelper:
             plot_meta = ''
             if metadata.geolocked:
                 # Show Geo-locked
-                plot_meta += self._kodi_wrapper.get_localized_string(32201)
+                plot_meta += self._kodi_wrapper.get_localized_string(30201)
             # Only display when a video disappears if it is within the next 3 months
             if metadata.offtime is not None and (metadata.offtime - now).days < 93:
                 # Show date when episode is removed
-                plot_meta += self._kodi_wrapper.get_localized_string(32202) % metadata.offtime.strftime(self._kodi_wrapper.get_localized_dateshort())
+                plot_meta += self._kodi_wrapper.get_localized_string(30202) % metadata.offtime.strftime(self._kodi_wrapper.get_localized_dateshort())
                 # Show the remaining days/hours the episode is still available
                 if (metadata.offtime - now).days > 0:
-                    plot_meta += self._kodi_wrapper.get_localized_string(32203) % (metadata.offtime - now).days
+                    plot_meta += self._kodi_wrapper.get_localized_string(30203) % (metadata.offtime - now).days
                 else:
-                    plot_meta += self._kodi_wrapper.get_localized_string(32204) % int((metadata.offtime - now).seconds / 3600)
+                    plot_meta += self._kodi_wrapper.get_localized_string(30204) % int((metadata.offtime - now).seconds / 3600)
 
             if plot_meta:
                 metadata.plot = '%s\n%s' % (plot_meta, metadata.plot)
@@ -242,7 +242,7 @@ class VRTApiHelper:
 
         for season in seasons:
             season_key = season.get('key')
-            label = '%s %s' % (self._kodi_wrapper.get_localized_string(32094), season_key)
+            label = '%s %s' % (self._kodi_wrapper.get_localized_string(30094), season_key)
             params = {'facets[seasonTitle]': season_key}
             path = api_url + '&' + urlencode(params)
             season_items.append(helperobjects.TitleItem(
@@ -316,7 +316,7 @@ class VRTApiHelper:
                 # NOTE: Sort the episodes ourselves, because Kodi does not allow to set to 'descending'
                 # sort = 'episode'
                 sort = 'label'
-                label = '%s %s: %s' % (self._kodi_wrapper.get_localized_string(32095), result.get('episodeNumber'), label)
+                label = '%s %s: %s' % (self._kodi_wrapper.get_localized_string(30095), result.get('episodeNumber'), label)
             elif options.get('showBroadcastDate') and result.get('formattedBroadcastShortDate'):
                 sort = 'dateadded'
                 label = '%s - %s' % (result.get('formattedBroadcastShortDate'), label)

--- a/resources/lib/vrtplayer/vrtplayer.py
+++ b/resources/lib/vrtplayer/vrtplayer.py
@@ -53,36 +53,36 @@ class VRTPlayer:
 
     def show_main_menu_items(self):
         main_items = [
-            helperobjects.TitleItem(title=self._kodi_wrapper.get_localized_string(32080),
+            helperobjects.TitleItem(title=self._kodi_wrapper.get_localized_string(30080),
                                     url_dict=dict(action=actions.LISTING_AZ_TVSHOWS),
                                     is_playable=False,
                                     art_dict=dict(thumb='DefaultMovieTitle.png', icon='DefaultMovieTitle.png', fanart='DefaultMovieTitle.png'),
-                                    video_dict=dict(plot=self._kodi_wrapper.get_localized_string(32081))),
-            helperobjects.TitleItem(title=self._kodi_wrapper.get_localized_string(32082),
+                                    video_dict=dict(plot=self._kodi_wrapper.get_localized_string(30081))),
+            helperobjects.TitleItem(title=self._kodi_wrapper.get_localized_string(30082),
                                     url_dict=dict(action=actions.LISTING_CATEGORIES),
                                     is_playable=False,
                                     art_dict=dict(thumb='DefaultGenre.png', icon='DefaultGenre.png', fanart='DefaultGenre.png'),
-                                    video_dict=dict(plot=self._kodi_wrapper.get_localized_string(32083))),
-            helperobjects.TitleItem(title=self._kodi_wrapper.get_localized_string(32084),
+                                    video_dict=dict(plot=self._kodi_wrapper.get_localized_string(30083))),
+            helperobjects.TitleItem(title=self._kodi_wrapper.get_localized_string(30084),
                                     url_dict=dict(action=actions.LISTING_CHANNELS),
                                     is_playable=False,
                                     art_dict=dict(thumb='DefaultTags.png', icon='DefaultTags.png', fanart='DefaultTags.png'),
-                                    video_dict=dict(plot=self._kodi_wrapper.get_localized_string(32085))),
-            helperobjects.TitleItem(title=self._kodi_wrapper.get_localized_string(32086),
+                                    video_dict=dict(plot=self._kodi_wrapper.get_localized_string(30085))),
+            helperobjects.TitleItem(title=self._kodi_wrapper.get_localized_string(30086),
                                     url_dict=dict(action=actions.LISTING_LIVE),
                                     is_playable=False,
                                     art_dict=dict(thumb='DefaultAddonPVRClient.png', icon='DefaultAddonPVRClient.png', fanart='DefaultAddonPVRClient.png'),
-                                    video_dict=dict(plot=self._kodi_wrapper.get_localized_string(32087))),
-            helperobjects.TitleItem(title=self._kodi_wrapper.get_localized_string(32088),
+                                    video_dict=dict(plot=self._kodi_wrapper.get_localized_string(30087))),
+            helperobjects.TitleItem(title=self._kodi_wrapper.get_localized_string(30088),
                                     url_dict=dict(action=actions.LISTING_RECENT, page='1'),
                                     is_playable=False,
                                     art_dict=dict(thumb='DefaultYear.png', icon='DefaultYear.png', fanart='DefaultYear.png'),
-                                    video_dict=dict(plot=self._kodi_wrapper.get_localized_string(32089))),
-            helperobjects.TitleItem(title=self._kodi_wrapper.get_localized_string(32090),
+                                    video_dict=dict(plot=self._kodi_wrapper.get_localized_string(30089))),
+            helperobjects.TitleItem(title=self._kodi_wrapper.get_localized_string(30090),
                                     url_dict=dict(action=actions.LISTING_TVGUIDE),
                                     is_playable=False,
                                     art_dict=dict(thumb='DefaultAddonTvInfo.png', icon='DefaultAddonTvInfo.png', fanart='DefaultAddonTvInfo.png'),
-                                    video_dict=dict(plot=self._kodi_wrapper.get_localized_string(32091))),
+                                    video_dict=dict(plot=self._kodi_wrapper.get_localized_string(30091))),
         ]
         self._kodi_wrapper.show_listing(main_items)
 
@@ -128,14 +128,14 @@ class VRTPlayer:
                 is_playable = False
             else:
                 url_dict = dict(action=action)
-                label = self._kodi_wrapper.get_localized_string(32101) % channel.get('label')
+                label = self._kodi_wrapper.get_localized_string(30101) % channel.get('label')
                 is_playable = True
                 if channel.get('name') in ['een', 'canvas', 'ketnet']:
                     fanart = self._api_helper.get_live_screenshot(channel.get('name'))
-                    plot = '%s\n%s' % (self._kodi_wrapper.get_localized_string(32201),
-                                       self._kodi_wrapper.get_localized_string(32102) % channel.get('label'))
+                    plot = '%s\n%s' % (self._kodi_wrapper.get_localized_string(30201),
+                                       self._kodi_wrapper.get_localized_string(30102) % channel.get('label'))
                 else:
-                    plot = self._kodi_wrapper.get_localized_string(32102) % channel.get('label')
+                    plot = self._kodi_wrapper.get_localized_string(30102) % channel.get('label')
                 if channel.get('live_stream'):
                     url_dict['video_url'] = channel.get('live_stream')
                 if channel.get('live_stream_id'):
@@ -169,7 +169,7 @@ class VRTPlayer:
         episode_items, sort, ascending = self._api_helper.get_episode_items(page=page)
 
         # Add 'More...' entry at the end
-        episode_items.append(helperobjects.TitleItem(title=self._kodi_wrapper.get_localized_string(32300),
+        episode_items.append(helperobjects.TitleItem(title=self._kodi_wrapper.get_localized_string(30300),
                                                      url_dict=dict(action=actions.LISTING_RECENT, page=page + 1),
                                                      is_playable=False,
                                                      art_dict=dict(thumb='DefaultYear.png', icon='DefaultYear.png', fanart='DefaultYear.png'),

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <settings>
-    <category label="32000">
-        <setting label="32001" type="text" id="username"/>
-        <setting label="32002" type="text" id="password" option="hidden"/>
+    <category label="30000">
+        <setting label="30001" type="text" id="username"/>
+        <setting label="30002" type="text" id="password" option="hidden"/>
     </category>
-    <category label="32010">
-        <setting label="32011" type="bool" id="showsubtitles" default="true"/>
+    <category label="30010">
+        <setting label="30011" type="bool" id="showsubtitles" default="true"/>
     </category>
-    <category label="32020">
-        <setting label="32021" type="bool" id="usedrm" default="false"/>
+    <category label="30020">
+        <setting label="30021" type="bool" id="usedrm" default="false"/>
     </category>  
-    <category label="32030">
-        <setting label="32031" type="bool" id="showpermalink" default="false"/>
+    <category label="30030">
+        <setting label="30031" type="bool" id="showpermalink" default="false"/>
     </category>  
 </settings>


### PR DESCRIPTION
Since there is something corrupting my language strings in Kodi, I started investigating and our plugin is using the wrong range for the string ids. This fixes it.

Not sure if our plugin was the cause though, time will tell.