### PR TITLE
Enable 'reuselanguageinvoker'

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -94,5 +94,6 @@ v1.7.0 (2019-03-26)
             <screenshot>resources/media/screenshot02.jpg</screenshot>
             <screenshot>resources/media/screenshot03.jpg</screenshot>
         </assets>
+        <reuselanguageinvoker>true</reuselanguageinvoker>
     </extension>
 </addon>


### PR DESCRIPTION
This ought to speed up using the addon as it avoids loading the python
interpreter and libraries.

I don't see a noticable speed difference for v1.9.0 though.