### PR TITLE
Implement inputstream.adaptive.max_bandwidth

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -47,6 +47,10 @@ msgctxt "#30021"
 msgid "Use DRM for 720p HD-quality livestreams"
 msgstr "Use DRM for 720p HD-quality livestreams"
 
+msgctxt "#30022"
+msgid "Maximum bandwidth (bits/sec)"
+msgstr "Maximum bandwidth (bits/sec)"
+
 msgctxt "#30030"
 msgid "Advanced"
 msgstr "Advanced"

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -48,6 +48,10 @@ msgctxt "#30021"
 msgid "Use DRM for 720p HD-quality livestreams"
 msgstr "Gebruik DRM voor de livestreams in 720p HD-kwaliteit"
 
+msgctxt "#30022"
+msgid "Maximum bandwidth (bits/sec)"
+msgstr "Maximale bandbreedte (bits/sec)"
+
 msgctxt "#30030"
 msgid "Advanced"
 msgstr "Geavanceerd"

--- a/resources/lib/kodiwrappers/kodiwrapper.py
+++ b/resources/lib/kodiwrappers/kodiwrapper.py
@@ -97,6 +97,8 @@ class KodiWrapper:
     def play(self, video):
         import xbmcgui
         play_item = xbmcgui.ListItem(path=video.stream_url)
+        play_item.setProperty('inputstream.adaptive.max_bandwidth', str(self.get_max_bandwidth() * 1000))
+        play_item.setProperty('network.bandwidth', str(self.get_max_bandwidth() * 1000))
         if video.stream_url is not None and video.use_inputstream_adaptive:
             play_item.setProperty('inputstreamaddon', 'inputstream.adaptive')
             play_item.setProperty('inputstream.adaptive.manifest_type', 'mpd')
@@ -155,6 +157,17 @@ class KodiWrapper:
         import json
         json_result = xbmc.executeJSONRPC('{"jsonrpc": "2.0", "method": "Settings.GetSettingValue", "params": {"setting": "%s"}, "id": 1}' % setting)
         return json.loads(json_result).get('result', dict()).get('value')
+
+    def get_max_bandwidth(self):
+        vrtnu_max_bandwidth = int(self.get_setting('max_bandwidth'))
+        global_max_bandwidth = int(self.get_global_setting('network.bandwidth'))
+        if vrtnu_max_bandwidth != 0 and global_max_bandwidth != 0:
+            return min(vrtnu_max_bandwidth, global_max_bandwidth)
+        if vrtnu_max_bandwidth != 0:
+            return vrtnu_max_bandwidth
+        if global_max_bandwidth != 0:
+            return global_max_bandwidth
+        return 0
 
     def get_proxies(self):
         usehttpproxy = self.get_global_setting('network.usehttpproxy')

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -9,8 +9,20 @@
     </category>
     <category label="30020">
         <setting label="30021" type="bool" id="usedrm" default="false"/>
-    </category>  
+        <setting label="14041" type="number" id="max_bandwidth" help="36386">
+          <level>1</level>
+          <default>0</default>
+          <constraints>
+            <minimum label="351">0</minimum>
+            <step>512</step>
+            <maximum>102400</maximum>
+          </constraints>
+          <control type="list" format="string">
+            <formatlabel>14048</formatlabel>
+          </control>
+        </setting>
+    </category>
     <category label="30030">
         <setting label="30031" type="bool" id="showpermalink" default="false"/>
-    </category>  
+    </category>
 </settings>


### PR DESCRIPTION
Attempt to use max_bandwidth for inputstream.adaptive.

This will select the lowest value of both the global network max_bandwidth as well as our own max_bandwidth setting.

This fixes #172 