### PR TITLE
Add 720p support without DRM

### DIFF
--- a/resources/lib/vrtplayer/streamservice.py
+++ b/resources/lib/vrtplayer/streamservice.py
@@ -265,8 +265,8 @@ class StreamService:
         hls_audio_id = None
         hls_subtitle_id = None
         hls_base_url = master_hls_url.split('.m3u8')[0]
-        self._kodi_wrapper.log_notice('URL get: ' + master_hls_url, 'Verbose')
-        hls_playlist = urlopen(master_hls_url).read()
+        self._kodi_wrapper.log_notice('URL get: ' + master_hls_url + '?hd', 'Verbose')
+        hls_playlist = urlopen(master_hls_url + '?hd').read()
         max_bandwidth = self._kodi_wrapper.get_max_bandwidth()
         stream_bandwidth = None
 


### PR DESCRIPTION
I discovered that as soon as a query-string is added to a (live) stream_url, a 720p stream is part of the M3U8 file. This could be any string.

So this opens up the possibility to have 720p without the need for DRM.