### PR TITLE
Add "* All seasons" feature like stock Kodi

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -54,6 +54,8 @@ def router(params_string):
         vrt_player.show_livestream_items()
     elif action == actions.LISTING_EPISODES:
         vrt_player.show_episodes(path=params.get('video_url'))
+    elif action == actions.LISTING_ALL_EPISODES:
+        vrt_player.show_all_episodes(path=params.get('video_url'))
     elif action == actions.LISTING_RECENT:
         vrt_player.show_recent(page=params.get('page', 1))
     elif action == actions.LISTING_CATEGORY_TVSHOWS:

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -167,6 +167,10 @@ msgctxt "#30095"
 msgid "Episode"
 msgstr "Episode"
 
+msgctxt "#30096"
+msgid "* All seasons"
+msgstr "* All seasons"
+
 msgctxt "#30101"
 msgid "%s live"
 msgstr "%s live"

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -176,6 +176,10 @@ msgctxt "#30095"
 msgid "Episode"
 msgstr "Aflevering"
 
+msgctxt "#30096"
+msgid "* All seasons"
+msgstr "* Alle seizoenen"
+
 msgctxt "#30101"
 msgid "%s live"
 msgstr "%s live"

--- a/resources/lib/vrtplayer/actions.py
+++ b/resources/lib/vrtplayer/actions.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, division, unicode_literals
 
 
 CLEAR_COOKIES = 'clearcookies'
+LISTING_ALL_EPISODES = 'listingallepisodes'
 LISTING_AZ_TVSHOWS = 'listingaztvshows'
 LISTING_CATEGORIES = 'listingcategories'
 LISTING_CATEGORY_TVSHOWS = 'listingcategorytvshows'

--- a/resources/lib/vrtplayer/vrtplayer.py
+++ b/resources/lib/vrtplayer/vrtplayer.py
@@ -129,6 +129,10 @@ class VRTPlayer:
         episode_items, sort, ascending = self._api_helper.get_episode_items(path=path)
         self._kodi_wrapper.show_listing(episode_items, sort=sort, ascending=ascending, content_type='episodes')
 
+    def show_all_episodes(self, path):
+        episode_items, sort, ascending = self._api_helper.get_episode_items(path=path, all_seasons=True)
+        self._kodi_wrapper.show_listing(episode_items, sort=sort, ascending=ascending, content_type='episodes')
+
     def show_recent(self, page):
         try:
             page = int(page)


### PR DESCRIPTION
This implements an "* All seasons" feature like in stock Kodi.
It helps to navigate when seasons are not of interest to you.

To enable you need to set the "videolibrary.showallitems" setting
in Kodi at:

    > Settings > Media > Video > Show "All items" entry
