### PR TITLE
Add setting to disabe menu caching

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -16,48 +16,52 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgctxt "#30000"
-msgid "Credentials"
-msgstr "Credentials"
-
-msgctxt "#30001"
-msgid "Email address"
-msgstr "Email address"
-
-msgctxt "#30002"
-msgid "Password"
-msgstr "Password"
-
-msgctxt "#30010"
-msgid "Video"
-msgstr "Video"
-
-msgctxt "#30011"
-msgid "Subtitles"
-msgstr "Subtitles"
-
-msgctxt "#30012"
-msgid "Show subtitles when available"
-msgstr "Show subtitles when available"
-
-msgctxt "#30013"
-msgid "Streaming"
-msgstr "Streaming"
-
-msgctxt "#30014"
-msgid "Use DRM for 720p HD-quality livestreams"
-msgstr "Use DRM for 720p HD-quality livestreams"
-
-msgctxt "#30015"
-msgid "Maximum bandwidth (kbps)"
-msgstr "Maximum bandwidth (kbps)"
-
-msgctxt "#30020"
 msgid "Interface"
 msgstr "Interface"
 
-msgctxt "#30021"
+msgctxt "#30001"
 msgid "Show episode permalink in plot"
 msgstr "Show episode permalink in plot"
+
+msgctxt "#30002"
+msgid "Enable menu caching"
+msgstr "Enable menu caching"
+
+msgctxt "#30010"
+msgid "Credentials"
+msgstr "Credentials"
+
+msgctxt "#30011"
+msgid "Email address"
+msgstr "Email address"
+
+msgctxt "#30012"
+msgid "Password"
+msgstr "Password"
+
+msgctxt "#30020"
+msgid "Video"
+msgstr "Video"
+
+msgctxt "#30021"
+msgid "Subtitles"
+msgstr "Subtitles"
+
+msgctxt "#30022"
+msgid "Show subtitles when available"
+msgstr "Show subtitles when available"
+
+msgctxt "#30023"
+msgid "Streaming"
+msgstr "Streaming"
+
+msgctxt "#30024"
+msgid "Use DRM for 720p HD-quality livestreams"
+msgstr "Use DRM for 720p HD-quality livestreams"
+
+msgctxt "#30025"
+msgid "Maximum bandwidth (kbps)"
+msgstr "Maximum bandwidth (kbps)"
 
 msgctxt "#30040"
 msgid "Debug"

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -17,48 +17,52 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgctxt "#30000"
-msgid "Credentials"
-msgstr "Inloggegevens"
-
-msgctxt "#30001"
-msgid "Email address"
-msgstr "E-mailadres"
-
-msgctxt "#30002"
-msgid "Password"
-msgstr "Wachtwoord"
-
-msgctxt "#30010"
-msgid "Video"
-msgstr "Video"
-
-msgctxt "#30011"
-msgid "Subtitles"
-msgstr "Ondertiteling"
-
-msgctxt "#30012"
-msgid "Show subtitles when available"
-msgstr "Toon ondertiteling indien beschikbaar"
-
-msgctxt "#30013"
-msgid "Streaming"
-msgstr "Streaming"
-
-msgctxt "#30014"
-msgid "Use DRM for 720p HD-quality livestreams"
-msgstr "Gebruik DRM voor de livestreams in 720p HD-kwaliteit"
-
-msgctxt "#30015"
-msgid "Maximum bandwidth (kbps)"
-msgstr "Maximale bandbreedte (kbps)"
-
-msgctxt "#30020"
 msgid "Interface"
 msgstr "Interface"
 
-msgctxt "#30021"
+msgctxt "#30001"
 msgid "Show episode permalink in plot"
 msgstr "Toon aflevering permalink in beschrijving"
+
+msgctxt "#30002"
+msgid "Enable menu caching"
+msgstr "Gebruik menu caching"
+
+msgctxt "#30010"
+msgid "Credentials"
+msgstr "Inloggegevens"
+
+msgctxt "#30011"
+msgid "Email address"
+msgstr "E-mailadres"
+
+msgctxt "#30012"
+msgid "Password"
+msgstr "Wachtwoord"
+
+msgctxt "#30020"
+msgid "Video"
+msgstr "Video"
+
+msgctxt "#30021"
+msgid "Subtitles"
+msgstr "Ondertiteling"
+
+msgctxt "#30022"
+msgid "Show subtitles when available"
+msgstr "Toon ondertiteling indien beschikbaar"
+
+msgctxt "#30023"
+msgid "Streaming"
+msgstr "Streaming"
+
+msgctxt "#30024"
+msgid "Use DRM for 720p HD-quality livestreams"
+msgstr "Gebruik DRM voor de livestreams in 720p HD-kwaliteit"
+
+msgctxt "#30025"
+msgid "Maximum bandwidth (kbps)"
+msgstr "Maximale bandbreedte (kbps)"
 
 msgctxt "#30030"
 msgid "VRT Radio"

--- a/resources/lib/kodiwrappers/kodiwrapper.py
+++ b/resources/lib/kodiwrappers/kodiwrapper.py
@@ -52,10 +52,14 @@ class KodiWrapper:
         self._addon = addon
         self._addon_id = addon.getAddonInfo('id')
         self._max_log_level = log_levels.get(self.get_setting('max_log_level'), 3)
+        self._usemenucaching = self.get_setting('usemenucaching')
 
-    def show_listing(self, list_items, sort='unsorted', ascending=True, content_type=None, cache=True):
+    def show_listing(self, list_items, sort='unsorted', ascending=True, content_type=None, cache=None):
         import xbmcgui
         listing = []
+
+        if cache is None:
+            cache = self._usemenucaching
 
         if content_type:
             xbmcplugin.setContent(self._handle, content=content_type)

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -1,18 +1,19 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <settings>
-    <category label="30000"> <!-- Credentials -->
-        <setting label="30001" type="text" id="username"/>
-        <setting label="30002" type="text" id="password" option="hidden"/>
+    <category label="30000"> <!-- Interface -->
+        <setting label="30001" type="bool" id="showpermalink" default="false"/>
+        <setting label="30002" type="bool" id="usemenucaching" default="true"/>
     </category>
-    <category label="30010"> <!-- Video -->
-        <setting label="30011" type="lsep"/>
-        <setting label="30012" type="bool" id="showsubtitles" default="true"/>
-        <setting label="30013" type="lsep"/> <!-- InputStream Adaptive -->
-        <setting label="30014" type="bool" id="usedrm" default="false"/>
-        <setting label="30015" type="select" id="max_bandwidth" default="0" values="0|256|512|1024|1536|2048|2560|3072|4096|6144|8192|10240|15360|20480|25600|30720"/>
+    <category label="30010"> <!-- Credentials -->
+        <setting label="30011" type="text" id="username"/>
+        <setting label="30012" type="text" id="password" option="hidden"/>
     </category>
-    <category label="30020"> <!-- Interface -->
-        <setting label="30021" type="bool" id="showpermalink" default="false"/>
+    <category label="30020"> <!-- Video -->
+        <setting label="30021" type="lsep"/>
+        <setting label="30022" type="bool" id="showsubtitles" default="true"/>
+        <setting label="30023" type="lsep"/> <!-- InputStream Adaptive -->
+        <setting label="30024" type="bool" id="usedrm" default="false"/>
+        <setting label="30025" type="select" id="max_bandwidth" default="0" values="0|256|512|1024|1536|2048|2560|3072|4096|6144|8192|10240|15360|20480|25600|30720"/>
     </category>
     <category label="30040"> <!-- Troubleshooting -->
         <setting label="30041" type="action" id="adaptive_settings" option="close" action="Addon.OpenSettings(inputstream.adaptive)" enable="System.HasAddon(inputstream.adaptive)"/>


### PR DESCRIPTION
In some use-cases (e.g. when using favourites often) menu caching causes
new episodes to not appear when expected. In this case users can disable
this with an expected performance hit when navigating the menus.

This fixes #210 

This PR also changes the order of the Settings tabs to fix a long-standing issue related to the cursor being stuck in the email-field.