### PR TITLE
Add "My programs" menu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ unit:
 	PYTHONPATH=$(pwd) python test/apihelpertests.py
 	PYTHONPATH=$(pwd) python test/tvguidetests.py
 	PYTHONPATH=$(pwd) python test/searchtests.py
+	PYTHONPATH=$(pwd) python test/favoritestests.py
 	@echo -e "$(white)=$(blue) Unit tests finished successfully.$(reset)"
 
 zip: test

--- a/addon.py
+++ b/addon.py
@@ -39,6 +39,21 @@ def router(params_string):
         _tvguide = tvguide.TVGuide(_kodiwrapper)
         _tvguide.show_tvguide(params)
         return
+    if action == actions.FOLLOW:
+        from resources.lib.vrtplayer import favorites
+        _favorites = favorites.Favorites(_kodiwrapper)
+        _favorites.follow(program=params.get('program'), path=params.get('path'))
+        return
+    if action == actions.UNFOLLOW:
+        from resources.lib.vrtplayer import favorites
+        _favorites = favorites.Favorites(_kodiwrapper)
+        _favorites.unfollow(program=params.get('program'), path=params.get('path'))
+        return
+    if action == actions.REFRESH_FAVORITES:
+        from resources.lib.vrtplayer import favorites
+        _favorites = favorites.Favorites(_kodiwrapper)
+        _favorites.update_favorites()
+        return
 
     from resources.lib.vrtplayer import vrtapihelper, vrtplayer
     _apihelper = vrtapihelper.VRTApiHelper(_kodiwrapper)
@@ -47,13 +62,15 @@ def router(params_string):
     if action == actions.PLAY:
         _vrtplayer.play(params)
     elif action == actions.LISTING_AZ_TVSHOWS:
-        _vrtplayer.show_tvshow_menu_items()
+        _vrtplayer.show_tvshow_menu_items(filtered=params.get('filtered'))
     elif action == actions.LISTING_CATEGORIES:
         _vrtplayer.show_category_menu_items()
     elif action == actions.LISTING_CATEGORY_TVSHOWS:
         _vrtplayer.show_tvshow_menu_items(category=params.get('category'))
     elif action == actions.LISTING_CHANNELS:
         _vrtplayer.show_channels_menu_items(channel=params.get('channel'))
+    elif action == actions.LISTING_FAVORITES:
+        _vrtplayer.show_favorites_menu_items()
     elif action == actions.LISTING_LIVE:
         _vrtplayer.show_livestream_items()
     elif action == actions.LISTING_EPISODES:
@@ -61,7 +78,7 @@ def router(params_string):
     elif action == actions.LISTING_ALL_EPISODES:
         _vrtplayer.show_all_episodes(path=params.get('video_url'))
     elif action == actions.LISTING_RECENT:
-        _vrtplayer.show_recent(page=params.get('page', 1))
+        _vrtplayer.show_recent(page=params.get('page', 1), filtered=params.get('filtered'))
     elif action == actions.SEARCH:
         _vrtplayer.search(search_string=params.get('query'), page=params.get('page', 1))
     else:

--- a/addon.xml
+++ b/addon.xml
@@ -15,6 +15,7 @@
         <provides>video</provides>
     </extension>
     <extension point="xbmc.service" library="service.py"/>
+
     <extension point="xbmc.addon.metadata">
         <summary lang="en_GB">Watch videos from VRT NU</summary>
         <description lang="en_GB">

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -20,10 +20,14 @@ msgid "Interface"
 msgstr ""
 
 msgctxt "#30001"
-msgid "Show episode permalink in plot"
+msgid "Enable My programs"
 msgstr ""
 
 msgctxt "#30002"
+msgid "Show episode permalink in plot"
+msgstr ""
+
+msgctxt "#30003"
 msgid "Enable menu caching"
 msgstr ""
 
@@ -75,6 +79,10 @@ msgctxt "#30042"
 msgid "Install Widevine (for DRM content)"
 msgstr ""
 
+msgctxt "#30047"
+msgid "Refresh favorites"
+msgstr ""
+
 msgctxt "#30048"
 msgid "Clear VRT cookies"
 msgstr ""
@@ -113,6 +121,14 @@ msgstr ""
 
 msgctxt "#30061"
 msgid "Using a SOCKS proxy requires the PySocks library (script.module.pysocks) installed."
+msgstr ""
+
+msgctxt "#30078"
+msgid "My programs"
+msgstr ""
+
+msgctxt "#30079"
+msgid "Browse only the programs you follow"
 msgstr ""
 
 msgctxt "#30080"
@@ -251,3 +267,34 @@ msgctxt "#30334"
 msgid "In 2 days"
 msgstr ""
 
+msgctxt "#30411"
+msgid "Follow"
+msgstr ""
+
+msgctxt "#30412"
+msgid "Unfollow"
+msgstr ""
+
+msgctxt "#30415"
+msgid "No followed programs found"
+msgstr ""
+
+msgctxt "#30416"
+msgid "We could not find any programs that were followed.\n\nEither right-click on a program or an episode to follow a program, or follow a program on the VRT NU website."
+msgstr ""
+
+msgctxt "#30420"
+msgid "My A-Z"
+msgstr ""
+
+msgctxt "#30421"
+msgid "Alphabetically sorted list of My TV programs"
+msgstr ""
+
+msgctxt "#30422"
+msgid "My recent items"
+msgstr ""
+
+msgctxt "#30423"
+msgid "Recently published episodes of My TV programs"
+msgstr ""

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -21,10 +21,14 @@ msgid "Interface"
 msgstr "Interface"
 
 msgctxt "#30001"
+msgid "Enable My programs"
+msgstr "Toon Mijn TV programma's"
+
+msgctxt "#30002"
 msgid "Show episode permalink in plot"
 msgstr "Toon aflevering permalink in beschrijving"
 
-msgctxt "#30002"
+msgctxt "#30003"
 msgid "Enable menu caching"
 msgstr "Gebruik menu caching"
 
@@ -84,6 +88,10 @@ msgctxt "#30042"
 msgid "Install Widevine (for DRM content)"
 msgstr "Installeer Widevine (voor DRM content)"
 
+msgctxt "#30047"
+msgid "Refresh favorites"
+msgstr "Ververs gevolgde programma's"
+
 msgctxt "#30048"
 msgid "Clear VRT cookies"
 msgstr "Verwijder VRT cookies"
@@ -123,6 +131,14 @@ msgstr "Verhoog de maximale bandbreedte alstublieft. De maximale bandbreedte is 
 msgctxt "#30061"
 msgid "Using a SOCKS proxy requires the PySocks library (script.module.pysocks) installed."
 msgstr "Het gebruik van SOCKS proxies vereist dat de PySocks library (script.module.pysocks) geïnstalleerd is."
+
+msgctxt "#30078"
+msgid "My programs"
+msgstr "Mijn TV programma's"
+
+msgctxt "#30079"
+msgid "Browse only the programs you follow"
+msgstr "Bekijk enkel de programma's die je volgt"
 
 msgctxt "#30080"
 msgid "A-Z"
@@ -259,3 +275,35 @@ msgstr "Morgen"
 msgctxt "#30334"
 msgid "In 2 days"
 msgstr "Overmorgen"
+
+msgctxt "#30411"
+msgid "Follow"
+msgstr "Volg"
+
+msgctxt "#30412"
+msgid "Unfollow"
+msgstr "Vergeet"
+
+msgctxt "#30415"
+msgid "No followed programs found"
+msgstr "Geen programma's worden gevolgd"
+
+msgctxt "#30416"
+msgid "We could not find any programs that were followed.\n\nEither right-click on a program or an episode to follow a program, or follow a program on the VRT NU website."
+msgstr "We konden geen programma's vonden die je volgt.\n\nJe kan een programma volgen door rechts te klikken op een programma of aflevering, of om ze op de VRT NU website to volgen."
+
+msgctxt "#30420"
+msgid "My A-Z"
+msgstr "Mijn TV programma's"
+
+msgctxt "#30421"
+msgid "Alphabetically sorted list of My TV programs"
+msgstr "Alle TV-programma's die je volgt in alfabetische volgorde"
+
+msgctxt "#30422"
+msgid "My recent items"
+msgstr "Mijn recente afleveringen"
+
+msgctxt "#30423"
+msgid "Recently published episodes of My TV programs"
+msgstr "Recent gepubliceerde afleveringen van TV-programma's die je volgt"

--- a/resources/lib/helperobjects/helperobjects.py
+++ b/resources/lib/helperobjects/helperobjects.py
@@ -7,12 +7,13 @@ from __future__ import absolute_import, division, unicode_literals
 
 class TitleItem:
 
-    def __init__(self, title, url_dict, is_playable, art_dict=None, video_dict=None):
+    def __init__(self, title, url_dict, is_playable, art_dict=None, video_dict=None, context_menu=None):
         self.title = title
         self.url_dict = url_dict
         self.is_playable = is_playable
         self.art_dict = art_dict
         self.video_dict = video_dict
+        self.context_menu = context_menu
 
 
 class Credentials:

--- a/resources/lib/kodiwrappers/kodiwrapper.py
+++ b/resources/lib/kodiwrappers/kodiwrapper.py
@@ -155,6 +155,9 @@ class KodiWrapper:
             if title_item.video_dict:
                 list_item.setInfo(type='video', infoLabels=title_item.video_dict)
 
+            if title_item.context_menu:
+                list_item.addContextMenuItems(title_item.context_menu)
+
             listing.append((url, list_item, not title_item.is_playable))
 
         ok = xbmcplugin.addDirectoryItems(self._handle, listing, len(listing))
@@ -199,7 +202,13 @@ class KodiWrapper:
 
     def show_ok_dialog(self, title, message):
         import xbmcgui
-        xbmcgui.Dialog().ok(self._addon.getAddonInfo('name'), title, message)
+        if not title:
+            title = self._addon.getAddonInfo('name')
+        xbmcgui.Dialog().ok(title, message)
+
+    def show_notification(self, message, time=4000):
+        import xbmcgui
+        xbmcgui.Dialog().notification(self._addon.getAddonInfo('name'), message, xbmcgui.NOTIFICATION_INFO, time)
 
     def set_locale(self):
         import locale
@@ -334,9 +343,16 @@ class KodiWrapper:
         yield f
         f.close()
 
+    def stat_file(self, path):
+        import xbmcvfs
+        return xbmcvfs.Stat(path)
+
     def delete_file(self, path):
         import xbmcvfs
         return xbmcvfs.delete(path)
+
+    def container_refresh(self):
+        xbmc.executebuiltin('Container.Refresh')
 
     def log_access(self, url, query_string, log_level='Verbose'):
         ''' Log addon access '''

--- a/resources/lib/vrtplayer/actions.py
+++ b/resources/lib/vrtplayer/actions.py
@@ -5,14 +5,18 @@
 from __future__ import absolute_import, division, unicode_literals
 
 CLEAR_COOKIES = 'clearcookies'
+FOLLOW = 'follow'
 LISTING_ALL_EPISODES = 'listingallepisodes'
 LISTING_AZ_TVSHOWS = 'listingaztvshows'
 LISTING_CATEGORIES = 'listingcategories'
 LISTING_CATEGORY_TVSHOWS = 'listingcategorytvshows'
 LISTING_CHANNELS = 'listingchannels'
 LISTING_EPISODES = 'listingepisodes'
+LISTING_FAVORITES = 'favorites'
 LISTING_LIVE = 'listinglive'
 LISTING_RECENT = 'listingrecent'
 LISTING_TVGUIDE = 'listingtvguide'
 PLAY = 'play'
+REFRESH_FAVORITES = 'refreshfavorites'
 SEARCH = 'search'
+UNFOLLOW = 'unfollow'

--- a/resources/lib/vrtplayer/favorites.py
+++ b/resources/lib/vrtplayer/favorites.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+
+# GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, unicode_literals
+import json
+import time
+
+from resources.lib.vrtplayer import tokenresolver
+
+try:
+    from urllib.request import build_opener, install_opener, ProxyHandler, Request, urlopen
+except ImportError:
+    from urllib2 import build_opener, install_opener, ProxyHandler, Request, urlopen
+
+
+class Favorites:
+
+    def __init__(self, _kodiwrapper):
+        self._kodiwrapper = _kodiwrapper
+        self._tokenresolver = tokenresolver.TokenResolver(_kodiwrapper)
+        self._proxies = _kodiwrapper.get_proxies()
+        install_opener(build_opener(ProxyHandler(self._proxies)))
+        self._cache_file = _kodiwrapper.get_userdata_path() + 'favorites.json'
+        self._favorites = {}
+        self.get_favorites()
+
+    def get_favorites(self):
+        if self._kodiwrapper.check_if_path_exists(self._cache_file):
+            if self._kodiwrapper.stat_file(self._cache_file).st_mtime() > time.mktime(time.localtime()) - (2 * 60):
+                self._kodiwrapper.log_notice('CACHE: %s vs %s' % (self._kodiwrapper.stat_file(self._cache_file).st_mtime(), time.mktime(time.localtime()) - (5 * 60)), 'Debug')
+                with self._kodiwrapper.open_file(self._cache_file) as f:
+                    self._favorites = json.loads(f.read())
+                return
+        self.update_favorites()
+
+    def update_favorites(self):
+        xvrttoken = self._tokenresolver.get_fav_xvrttoken()
+        headers = {
+            'authorization': 'Bearer ' + xvrttoken,
+            'content-type': 'application/json',
+            # 'Cookie': 'X-VRT-Token=' + xvrttoken,
+            'Referer': 'https://www.vrt.be/vrtnu',
+        }
+        req = Request('https://video-user-data.vrt.be/favorites', headers=headers)
+        self._favorites = json.loads(urlopen(req).read())
+        self.write_favorites()
+
+    def set_favorite(self, program, path, value=True):
+        if value is not self.is_favorite(path):
+            xvrttoken = self._tokenresolver.get_fav_xvrttoken()
+            headers = {
+                'authorization': 'Bearer ' + xvrttoken,
+                'content-type': 'application/json',
+                # 'Cookie': 'X-VRT-Token=' + xvrttoken,
+                'Referer': 'https://www.vrt.be/vrtnu',
+            }
+            payload = dict(isFavorite=value, programUrl=path, title=program)
+            self._kodiwrapper.log_notice('URL post: https://video-user-data.vrt.be/favorites/%s' % self.uuid(path), 'Verbose')
+            req = Request('https://video-user-data.vrt.be/favorites/%s' % self.uuid(path), data=json.dumps(payload), headers=headers)
+            # TODO: Test that we get a HTTP 200, otherwise log and fail graceful
+            result = urlopen(req)
+            if result.getcode() != 200:
+                self._kodiwrapper.log_error("Failed to follow program '%s' at VRT NU" % path)
+            # NOTE: Updates to favorites take a longer time to take effect, so we keep our own cache and use it
+            self._favorites[self.uuid(path)] = dict(value=payload)
+            self.write_favorites()
+
+    def write_favorites(self):
+        with self._kodiwrapper.open_file(self._cache_file, 'w') as f:
+            f.write(json.dumps(self._favorites))
+
+    def is_favorite(self, path):
+        value = False
+        favorite = self._favorites.get(self.uuid(path))
+        if favorite:
+            value = favorite.get('value', dict(isFavorite=False)).get('isFavorite', False)
+        return value
+
+    def follow(self, program, path):
+        self._kodiwrapper.show_notification('Follow ' + program)
+        self.set_favorite(program, path, True)
+        self._kodiwrapper.container_refresh()
+
+    def unfollow(self, program, path):
+        self._kodiwrapper.show_notification('Unfollow ' + program)
+        self.set_favorite(program, path, False)
+        self._kodiwrapper.container_refresh()
+
+    def uuid(self, path):
+        return path.replace('/', '').replace('-', '')
+
+    def name(self, path):
+        return path.replace('.relevant/', '/').split('/')[-2]
+
+    def names(self):
+        return [self.name(p.get('value').get('programUrl')) for p in self._favorites.values() if p.get('value').get('isFavorite')]
+
+    def titles(self):
+        return [p.get('value').get('title') for p in self._favorites.values() if p.get('value').get('isFavorite')]

--- a/resources/lib/vrtplayer/statichelper.py
+++ b/resources/lib/vrtplayer/statichelper.py
@@ -30,6 +30,12 @@ def convert_html_to_kodilabel(text):
     return unescape(text).strip()
 
 
+def unique_path(path):
+    if path.startswith('//www.vrt.be/vrtnu'):
+        return path.replace('//www.vrt.be/vrtnu/', '/vrtnu/').replace('.relevant/', '/')
+    return path
+
+
 def shorten_link(url):
     if url is None:
         return None

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <settings>
     <category label="30000"> <!-- Interface -->
-        <setting label="30001" type="bool" id="showpermalink" default="false"/>
+        <setting label="30001" type="bool" id="usefavorites" default="true" visible="false"/>
         <setting label="30002" type="bool" id="usemenucaching" default="true"/>
+        <setting label="30003" type="bool" id="showpermalink" default="false"/>
     </category>
     <category label="30010"> <!-- Credentials -->
         <setting label="30011" type="text" id="username"/>
@@ -18,6 +19,7 @@
     <category label="30040"> <!-- Troubleshooting -->
         <setting label="30041" type="action" id="adaptive_settings" option="close" action="Addon.OpenSettings(inputstream.adaptive)" enable="System.HasAddon(inputstream.adaptive)"/>
         <!-- setting label="30042" type="action" id="widevine_install" option="close" action="RunPlugin(plugin://plugin.video.vrt.nu?action=installwidevine)" enable="System.HasAddon(script.module.inputstreamhelper)"/ -->
+        <setting label="30047" type="action" id="refresh_favorites" action="RunPlugin(plugin://plugin.video.vrt.nu/?action=refreshfavorites)"/>
         <setting label="30048" type="action" id="clear_tokens" action="RunPlugin(plugin://plugin.video.vrt.nu/?action=clearcookies)"/>
         <setting label="30049" type="select" id="max_log_level" values="Quiet|Info|Verbose|Debug" default="Info"/>
     </category>

--- a/test/favoritestests.py
+++ b/test/favoritestests.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+
+# GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+import mock
+import os
+import unittest
+
+from resources.lib.vrtplayer import favorites
+from test import SETTINGS, get_setting, log_notice, open_file, stat_file
+
+SETTINGS['usefavorites'] = 'true'
+
+
+class TestFavorites(unittest.TestCase):
+
+    _kodiwrapper = mock.MagicMock()
+    _kodiwrapper.check_if_path_exists = mock.MagicMock(side_effect=os.path.exists)
+    _kodiwrapper.get_proxies = mock.MagicMock(return_value=dict())
+    _kodiwrapper.get_setting = mock.MagicMock(side_effect=get_setting)
+    _kodiwrapper.get_userdata_path.return_value = './userdata/'
+    _kodiwrapper.log_notice = mock.MagicMock(side_effect=log_notice)
+    _kodiwrapper.make_dir.return_value = None
+    _kodiwrapper.open_file = mock.MagicMock(side_effect=open_file)
+    _kodiwrapper.stat_file = mock.MagicMock(side_effect=stat_file)
+    _favorites = favorites.Favorites(_kodiwrapper)
+
+    def test_follow_unfollow(self):
+        program = 'Winteruur'
+        program_path = '/vrtnu/a-z/winteruur/'
+        self._favorites.follow(program, program_path)
+        self.assertTrue(self._favorites.is_favorite(program_path))
+
+        self._favorites.unfollow(program, program_path)
+        self.assertFalse(self._favorites.is_favorite(program_path))
+
+        self._favorites.follow(program, program_path)
+        self.assertTrue(self._favorites.is_favorite(program_path))
+
+    def test_names(self):
+        names = self._favorites.names()
+        self.assertTrue(names)
+        print(names)
+
+    def test_titles(self):
+        titles = self._favorites.titles()
+        self.assertTrue(titles)
+        print(sorted(titles))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR adds a way of tracking the programs you follow.
- Add a context menu to programs or episodes with either "Follow" or "Unfollow"
- Download and cache favorites from VRT NU
- Add an A-Z listing of followed programs
- Add a Recent listing of followed programs
- Add invisible setting 'usefavorites' to disable "My programs" (for unit tests)
- Disable brand filter in "My programs" recent listing (should be configurable really)

This fixes #181 