### PR TITLE
Make code more readable

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -26,38 +26,38 @@ def router(params_string):
     params = dict(parse_qsl(params_string))
     action = params.get('action')
 
-    _kodiwrapper = kodiwrapper.KodiWrapper(_ADDON_HANDLE, _ADDON_URL, addon)
-    _kodiwrapper.log_access(_ADDON_URL, params_string)
+    _kodi = kodiwrapper.KodiWrapper(_ADDON_HANDLE, _ADDON_URL, addon)
+    _kodi.log_access(_ADDON_URL, params_string)
 
     if action == actions.CLEAR_COOKIES:
         from resources.lib.vrtplayer import tokenresolver
-        _tokenresolver = tokenresolver.TokenResolver(_kodiwrapper)
+        _tokenresolver = tokenresolver.TokenResolver(_kodi)
         _tokenresolver.reset_cookies()
         return
     if action == actions.LISTING_TVGUIDE:
         from resources.lib.vrtplayer import tvguide
-        _tvguide = tvguide.TVGuide(_kodiwrapper)
+        _tvguide = tvguide.TVGuide(_kodi)
         _tvguide.show_tvguide(params)
         return
     if action == actions.FOLLOW:
         from resources.lib.vrtplayer import favorites
-        _favorites = favorites.Favorites(_kodiwrapper)
+        _favorites = favorites.Favorites(_kodi)
         _favorites.follow(program=params.get('program'), path=params.get('path'))
         return
     if action == actions.UNFOLLOW:
         from resources.lib.vrtplayer import favorites
-        _favorites = favorites.Favorites(_kodiwrapper)
+        _favorites = favorites.Favorites(_kodi)
         _favorites.unfollow(program=params.get('program'), path=params.get('path'))
         return
     if action == actions.REFRESH_FAVORITES:
         from resources.lib.vrtplayer import favorites
-        _favorites = favorites.Favorites(_kodiwrapper)
+        _favorites = favorites.Favorites(_kodi)
         _favorites.update_favorites()
         return
 
     from resources.lib.vrtplayer import vrtapihelper, vrtplayer
-    _apihelper = vrtapihelper.VRTApiHelper(_kodiwrapper)
-    _vrtplayer = vrtplayer.VRTPlayer(_kodiwrapper, _apihelper)
+    _apihelper = vrtapihelper.VRTApiHelper(_kodi)
+    _vrtplayer = vrtplayer.VRTPlayer(_kodi, _apihelper)
 
     if action == actions.PLAY:
         _vrtplayer.play(params)

--- a/resources/lib/helperobjects/helperobjects.py
+++ b/resources/lib/helperobjects/helperobjects.py
@@ -18,21 +18,21 @@ class TitleItem:
 
 class Credentials:
 
-    def __init__(self, _kodiwrapper):
-        self._kodiwrapper = _kodiwrapper
-        self._username = _kodiwrapper.get_setting('username')
-        self._password = _kodiwrapper.get_setting('password')
+    def __init__(self, _kodi):
+        self._kodi = _kodi
+        self._username = _kodi.get_setting('username')
+        self._password = _kodi.get_setting('password')
 
     def are_filled_in(self):
         return not (self._username is None or self._password is None or self._username == '' or self._password == '')
 
     def reload(self):
-        self._username = self._kodiwrapper.get_setting('username')
-        self._password = self._kodiwrapper.get_setting('password')
+        self._username = self._kodi.get_setting('username')
+        self._password = self._kodi.get_setting('password')
 
     def reset(self):
-        self._username = self._kodiwrapper.set_setting('username', None)
-        self._password = self._kodiwrapper.set_setting('password', None)
+        self._username = self._kodi.set_setting('username', None)
+        self._password = self._kodi.set_setting('password', None)
 
     @property
     def username(self):

--- a/resources/lib/kodiwrappers/kodiwrapper.py
+++ b/resources/lib/kodiwrappers/kodiwrapper.py
@@ -194,7 +194,7 @@ class KodiWrapper:
 
     def get_search_string(self):
         search_string = None
-        keyboard = xbmc.Keyboard('', self.get_localized_string(30097))
+        keyboard = xbmc.Keyboard('', self.localize(30097))
         keyboard.doModal()
         if keyboard.isConfirmed():
             search_string = keyboard.getText()
@@ -221,14 +221,8 @@ class KodiWrapper:
             self.log_notice(e, 'Verbose')
             return False
 
-    def get_localized_string(self, string_id):
+    def localize(self, string_id):
         return self._addon.getLocalizedString(string_id)
-
-    def get_localized_dateshort(self):
-        return xbmc.getRegion('dateshort')
-
-    def get_localized_datelong(self):
-        return xbmc.getRegion('datelong')
 
     def localize_date(self, date, strftime):
         if not self._system_locale_works:
@@ -243,10 +237,10 @@ class KodiWrapper:
         return date.strftime(strftime)
 
     def localize_dateshort(self, date):
-        return self.localize_date(date, self.get_localized_dateshort())
+        return self.localize_date(date, xbmc.getRegion('dateshort'))
 
     def localize_datelong(self, date):
-        return self.localize_date(date, self.get_localized_datelong())
+        return self.localize_date(date, xbmc.getRegion('datelong'))
 
     def get_setting(self, setting_id):
         return self._addon.getSetting(setting_id)
@@ -284,7 +278,7 @@ class KodiWrapper:
         if httpproxytype != 0 and not socks_supported:
             # Only open the dialog the first time (to avoid multiple popups)
             if socks_supported is None:
-                self.show_ok_dialog('', self.get_localized_string(30061))
+                self.show_ok_dialog('', self.localize(30061))
             return None
 
         proxy_types = ['http', 'socks4', 'socks4a', 'socks5', 'socks5h']

--- a/resources/lib/vrtplayer/favorites.py
+++ b/resources/lib/vrtplayer/favorites.py
@@ -16,20 +16,20 @@ except ImportError:
 
 class Favorites:
 
-    def __init__(self, _kodiwrapper):
-        self._kodiwrapper = _kodiwrapper
-        self._tokenresolver = tokenresolver.TokenResolver(_kodiwrapper)
-        self._proxies = _kodiwrapper.get_proxies()
+    def __init__(self, _kodi):
+        self._kodi = _kodi
+        self._tokenresolver = tokenresolver.TokenResolver(_kodi)
+        self._proxies = _kodi.get_proxies()
         install_opener(build_opener(ProxyHandler(self._proxies)))
-        self._cache_file = _kodiwrapper.get_userdata_path() + 'favorites.json'
+        self._cache_file = _kodi.get_userdata_path() + 'favorites.json'
         self._favorites = {}
         self.get_favorites()
 
     def get_favorites(self):
-        if self._kodiwrapper.check_if_path_exists(self._cache_file):
-            if self._kodiwrapper.stat_file(self._cache_file).st_mtime() > time.mktime(time.localtime()) - (2 * 60):
-                self._kodiwrapper.log_notice('CACHE: %s vs %s' % (self._kodiwrapper.stat_file(self._cache_file).st_mtime(), time.mktime(time.localtime()) - (5 * 60)), 'Debug')
-                with self._kodiwrapper.open_file(self._cache_file) as f:
+        if self._kodi.check_if_path_exists(self._cache_file):
+            if self._kodi.stat_file(self._cache_file).st_mtime() > time.mktime(time.localtime()) - (2 * 60):
+                self._kodi.log_notice('CACHE: %s vs %s' % (self._kodi.stat_file(self._cache_file).st_mtime(), time.mktime(time.localtime()) - (5 * 60)), 'Debug')
+                with self._kodi.open_file(self._cache_file) as f:
                     self._favorites = json.loads(f.read())
                 return
         self.update_favorites()
@@ -56,18 +56,18 @@ class Favorites:
                 'Referer': 'https://www.vrt.be/vrtnu',
             }
             payload = dict(isFavorite=value, programUrl=path, title=program)
-            self._kodiwrapper.log_notice('URL post: https://video-user-data.vrt.be/favorites/%s' % self.uuid(path), 'Verbose')
+            self._kodi.log_notice('URL post: https://video-user-data.vrt.be/favorites/%s' % self.uuid(path), 'Verbose')
             req = Request('https://video-user-data.vrt.be/favorites/%s' % self.uuid(path), data=json.dumps(payload), headers=headers)
             # TODO: Test that we get a HTTP 200, otherwise log and fail graceful
             result = urlopen(req)
             if result.getcode() != 200:
-                self._kodiwrapper.log_error("Failed to follow program '%s' at VRT NU" % path)
+                self._kodi.log_error("Failed to follow program '%s' at VRT NU" % path)
             # NOTE: Updates to favorites take a longer time to take effect, so we keep our own cache and use it
             self._favorites[self.uuid(path)] = dict(value=payload)
             self.write_favorites()
 
     def write_favorites(self):
-        with self._kodiwrapper.open_file(self._cache_file, 'w') as f:
+        with self._kodi.open_file(self._cache_file, 'w') as f:
             f.write(json.dumps(self._favorites))
 
     def is_favorite(self, path):
@@ -78,14 +78,14 @@ class Favorites:
         return value
 
     def follow(self, program, path):
-        self._kodiwrapper.show_notification('Follow ' + program)
+        self._kodi.show_notification('Follow ' + program)
         self.set_favorite(program, path, True)
-        self._kodiwrapper.container_refresh()
+        self._kodi.container_refresh()
 
     def unfollow(self, program, path):
-        self._kodiwrapper.show_notification('Unfollow ' + program)
+        self._kodi.show_notification('Unfollow ' + program)
         self.set_favorite(program, path, False)
-        self._kodiwrapper.container_refresh()
+        self._kodi.container_refresh()
 
     def uuid(self, path):
         return path.replace('/', '').replace('-', '')

--- a/resources/lib/vrtplayer/vrtapihelper.py
+++ b/resources/lib/vrtplayer/vrtapihelper.py
@@ -21,13 +21,13 @@ class VRTApiHelper:
     _VRTNU_SUGGEST_URL = 'https://vrtnu-api.vrt.be/suggest'
     _VRTNU_SCREENSHOT_URL = 'https://vrtnu-api.vrt.be/screenshots'
 
-    def __init__(self, _kodiwrapper):
-        self._kodiwrapper = _kodiwrapper
-        self._proxies = _kodiwrapper.get_proxies()
+    def __init__(self, _kodi):
+        self._kodi = _kodi
+        self._proxies = _kodi.get_proxies()
         install_opener(build_opener(ProxyHandler(self._proxies)))
-        self._showpermalink = _kodiwrapper.get_setting('showpermalink') == 'true'
-        if _kodiwrapper.get_setting('usefavorites') == 'true':
-            self._favorites = favorites.Favorites(self._kodiwrapper)
+        self._showpermalink = _kodi.get_setting('showpermalink') == 'true'
+        if _kodi.get_setting('usefavorites') == 'true':
+            self._favorites = favorites.Favorites(self._kodi)
         else:
             self._favorites = None
 
@@ -46,7 +46,7 @@ class VRTApiHelper:
             params['facets[transcodingStatus]'] = 'AVAILABLE'
 
         api_url = self._VRTNU_SUGGEST_URL + '?' + urlencode(params)
-        self._kodiwrapper.log_notice('URL get: ' + unquote(api_url), 'Verbose')
+        self._kodi.log_notice('URL get: ' + unquote(api_url), 'Verbose')
         api_json = json.loads(urlopen(api_url).read())
         return self._map_to_tvshow_items(api_json, filtered=filtered)
 
@@ -71,10 +71,10 @@ class VRTApiHelper:
             if self._favorites:
                 if self._favorites.is_favorite(program_path):
                     params = dict(action='unfollow', program=tvshow.get('title'), path=program_path)
-                    context_menu = [(self._kodiwrapper.get_localized_string(30412), 'RunPlugin(plugin://plugin.video.vrt.nu?%s)' % urlencode(params))]
+                    context_menu = [(self._kodi.localize(30412), 'RunPlugin(plugin://plugin.video.vrt.nu?%s)' % urlencode(params))]
                 else:
                     params = dict(action='follow', program=tvshow.get('title'), path=program_path)
-                    context_menu = [(self._kodiwrapper.get_localized_string(30411), 'RunPlugin(plugin://plugin.video.vrt.nu?%s)' % urlencode(params))]
+                    context_menu = [(self._kodi.localize(30411), 'RunPlugin(plugin://plugin.video.vrt.nu?%s)' % urlencode(params))]
             else:
                 context_menu = []
             # Cut vrtbase url off since it will be added again when searching for episodes
@@ -128,7 +128,7 @@ class VRTApiHelper:
                 params['facets[programBrands]'] = '[een,canvas,sporza,vrtnws,vrtnxt,radio1,radio2,klara,stubru,mnm]'
 
             api_url = self._VRTNU_SEARCH_URL + '?' + urlencode(params)
-            self._kodiwrapper.log_notice('URL get: ' + unquote(api_url), 'Verbose')
+            self._kodi.log_notice('URL get: ' + unquote(api_url), 'Verbose')
             api_json = json.loads(urlopen(api_url).read())
             episode_items, sort, ascending, content = self._map_to_episode_items(api_json.get('results', []), titletype='recent', filtered=filtered)
 
@@ -142,7 +142,7 @@ class VRTApiHelper:
                 api_url = self._VRTNU_SEARCH_URL + '?' + urlencode(params)
             else:
                 api_url = path
-            self._kodiwrapper.log_notice('URL get: ' + unquote(api_url), 'Verbose')
+            self._kodi.log_notice('URL get: ' + unquote(api_url), 'Verbose')
             api_json = json.loads(urlopen(api_url).read())
 
             episodes = api_json.get('results', [{}])
@@ -235,16 +235,16 @@ class VRTApiHelper:
             plot_meta = ''
             if metadata.geolocked:
                 # Show Geo-locked
-                plot_meta += self._kodiwrapper.get_localized_string(30201)
+                plot_meta += self._kodi.localize(30201)
             # Only display when a video disappears if it is within the next 3 months
             if metadata.offtime is not None and (metadata.offtime - now).days < 93:
                 # Show date when episode is removed
-                plot_meta += self._kodiwrapper.get_localized_string(30202) % self._kodiwrapper.localize_dateshort(metadata.offtime)
+                plot_meta += self._kodi.localize(30202) % self._kodi.localize_dateshort(metadata.offtime)
                 # Show the remaining days/hours the episode is still available
                 if (metadata.offtime - now).days > 0:
-                    plot_meta += self._kodiwrapper.get_localized_string(30203) % (metadata.offtime - now).days
+                    plot_meta += self._kodi.localize(30203) % (metadata.offtime - now).days
                 else:
-                    plot_meta += self._kodiwrapper.get_localized_string(30204) % int((metadata.offtime - now).seconds / 3600)
+                    plot_meta += self._kodi.localize(30204) % int((metadata.offtime - now).seconds / 3600)
 
             if plot_meta:
                 metadata.plot = '%s\n%s' % (plot_meta, metadata.plot)
@@ -256,10 +256,10 @@ class VRTApiHelper:
             if self._favorites:
                 if self._favorites.is_favorite(program_path):
                     params = dict(action='unfollow', program=episode.get('program'), path=program_path)
-                    context_menu = [(self._kodiwrapper.get_localized_string(30412), 'RunPlugin(plugin://plugin.video.vrt.nu?%s)' % urlencode(params))]
+                    context_menu = [(self._kodi.localize(30412), 'RunPlugin(plugin://plugin.video.vrt.nu?%s)' % urlencode(params))]
                 else:
                     params = dict(action='follow', program=episode.get('program'), path=program_path)
-                    context_menu = [(self._kodiwrapper.get_localized_string(30411), 'RunPlugin(plugin://plugin.video.vrt.nu?%s)' % urlencode(params))]
+                    context_menu = [(self._kodi.localize(30411), 'RunPlugin(plugin://plugin.video.vrt.nu?%s)' % urlencode(params))]
             else:
                 context_menu = []
 
@@ -302,7 +302,7 @@ class VRTApiHelper:
         plot_meta = ''
         if metadata.geolocked:
             # Show Geo-locked
-            plot_meta += self._kodiwrapper.get_localized_string(30201) + '\n'
+            plot_meta += self._kodi.localize(30201) + '\n'
         metadata.plot = '%s[B]%s[/B]\n%s' % (plot_meta, episode.get('program'), metadata.plot)
 
         # Reverse sort seasons if program_type is 'reeksaflopend' or 'daily'
@@ -310,9 +310,9 @@ class VRTApiHelper:
             ascending = False
 
         # Add an "* All seasons" list item
-        if self._kodiwrapper.get_global_setting('videolibrary.showallitems') is True:
+        if self._kodi.get_global_setting('videolibrary.showallitems') is True:
             season_items.append(TitleItem(
-                title=self._kodiwrapper.get_localized_string(30096),
+                title=self._kodi.localize(30096),
                 url_dict=dict(action=actions.LISTING_ALL_EPISODES, video_url=api_url),
                 is_playable=False,
                 art_dict=dict(thumb=fanart, icon='DefaultSets.png', fanart=fanart),
@@ -331,7 +331,7 @@ class VRTApiHelper:
                 episode = episodes[0]
             fanart = statichelper.add_https_method(episode.get('programImageUrl', 'DefaultSets.png'))
             thumbnail = statichelper.add_https_method(episode.get('videoThumbnailUrl', fanart))
-            label = '%s %s' % (self._kodiwrapper.get_localized_string(30094), season_key)
+            label = '%s %s' % (self._kodi.localize(30094), season_key)
             params = {'facets[seasonTitle]': season_key}
             path = api_url + '&' + urlencode(params)
             season_items.append(TitleItem(
@@ -354,7 +354,7 @@ class VRTApiHelper:
             'highlight': 'true',
         }
         api_url = 'https://search.vrt.be/search?' + urlencode(params)
-        self._kodiwrapper.log_notice('URL get: ' + unquote(api_url), 'Verbose')
+        self._kodi.log_notice('URL get: ' + unquote(api_url), 'Verbose')
         api_json = json.loads(urlopen(api_url).read())
 
         episodes = api_json.get('results', [{}])
@@ -370,7 +370,7 @@ class VRTApiHelper:
         crc = self.__get_crc32(url)
         ext = url.split('.')[-1]
         path = 'special://thumbnails/%s/%s.%s' % (crc[0], crc, ext)
-        self._kodiwrapper.delete_file(path)
+        self._kodi.delete_file(path)
 
     @staticmethod
     def __get_crc32(string):
@@ -423,7 +423,7 @@ class VRTApiHelper:
                 # NOTE: Sort the episodes ourselves, because Kodi does not allow to set to 'descending'
                 # sort = 'episode'
                 sort = 'label'
-                label = '%s %s: %s' % (self._kodiwrapper.get_localized_string(30095), result.get('episodeNumber'), label)
+                label = '%s %s: %s' % (self._kodi.localize(30095), result.get('episodeNumber'), label)
             elif options.get('showBroadcastDate') and result.get('formattedBroadcastShortDate'):
                 sort = 'dateadded'
                 label = '%s - %s' % (result.get('formattedBroadcastShortDate'), label)

--- a/resources/lib/vrtplayer/vrtplayer.py
+++ b/resources/lib/vrtplayer/vrtplayer.py
@@ -14,9 +14,9 @@ except ImportError:
 
 class VRTPlayer:
 
-    def __init__(self, _kodiwrapper, _apihelper):
-        self._kodiwrapper = _kodiwrapper
-        self._proxies = _kodiwrapper.get_proxies()
+    def __init__(self, _kodi, _apihelper):
+        self._kodi = _kodi
+        self._proxies = _kodi.get_proxies()
         install_opener(build_opener(ProxyHandler(self._proxies)))
         self._apihelper = _apihelper
 
@@ -24,86 +24,86 @@ class VRTPlayer:
         main_items = []
 
         # Only add 'My programs' when this is enabled in config
-        if self._kodiwrapper.get_setting('usefavorites') == 'true':
+        if self._kodi.get_setting('usefavorites') == 'true':
             main_items.append(TitleItem(
-                title=self._kodiwrapper.get_localized_string(30078),
+                title=self._kodi.localize(30078),
                 url_dict=dict(action=actions.LISTING_FAVORITES),
                 is_playable=False,
                 art_dict=dict(thumb='icons/settings/profiles.png', icon='icons/settings/profiles.png', fanart='icons/settings/profiles.png'),
-                video_dict=dict(plot=self._kodiwrapper.get_localized_string(30079))
+                video_dict=dict(plot=self._kodi.localize(30079))
             ))
 
         main_items.extend([
-            TitleItem(title=self._kodiwrapper.get_localized_string(30080),
+            TitleItem(title=self._kodi.localize(30080),
                       url_dict=dict(action=actions.LISTING_AZ_TVSHOWS),
                       is_playable=False,
                       art_dict=dict(thumb='DefaultMovieTitle.png', icon='DefaultMovieTitle.png', fanart='DefaultMovieTitle.png'),
-                      video_dict=dict(plot=self._kodiwrapper.get_localized_string(30081))),
-            TitleItem(title=self._kodiwrapper.get_localized_string(30082),
+                      video_dict=dict(plot=self._kodi.localize(30081))),
+            TitleItem(title=self._kodi.localize(30082),
                       url_dict=dict(action=actions.LISTING_CATEGORIES),
                       is_playable=False,
                       art_dict=dict(thumb='DefaultGenre.png', icon='DefaultGenre.png', fanart='DefaultGenre.png'),
-                      video_dict=dict(plot=self._kodiwrapper.get_localized_string(30083))),
-            TitleItem(title=self._kodiwrapper.get_localized_string(30084),
+                      video_dict=dict(plot=self._kodi.localize(30083))),
+            TitleItem(title=self._kodi.localize(30084),
                       url_dict=dict(action=actions.LISTING_CHANNELS),
                       is_playable=False,
                       art_dict=dict(thumb='DefaultTags.png', icon='DefaultTags.png', fanart='DefaultTags.png'),
-                      video_dict=dict(plot=self._kodiwrapper.get_localized_string(30085))),
-            TitleItem(title=self._kodiwrapper.get_localized_string(30086),
+                      video_dict=dict(plot=self._kodi.localize(30085))),
+            TitleItem(title=self._kodi.localize(30086),
                       url_dict=dict(action=actions.LISTING_LIVE),
                       is_playable=False,
                       art_dict=dict(thumb='DefaultAddonPVRClient.png', icon='DefaultAddonPVRClient.png', fanart='DefaultAddonPVRClient.png'),
-                      video_dict=dict(plot=self._kodiwrapper.get_localized_string(30087))),
-            TitleItem(title=self._kodiwrapper.get_localized_string(30088),
+                      video_dict=dict(plot=self._kodi.localize(30087))),
+            TitleItem(title=self._kodi.localize(30088),
                       url_dict=dict(action=actions.LISTING_RECENT, page='1'),
                       is_playable=False,
                       art_dict=dict(thumb='DefaultYear.png', icon='DefaultYear.png', fanart='DefaultYear.png'),
-                      video_dict=dict(plot=self._kodiwrapper.get_localized_string(30089))),
-            TitleItem(title=self._kodiwrapper.get_localized_string(30090),
+                      video_dict=dict(plot=self._kodi.localize(30089))),
+            TitleItem(title=self._kodi.localize(30090),
                       url_dict=dict(action=actions.LISTING_TVGUIDE),
                       is_playable=False,
                       art_dict=dict(thumb='DefaultAddonTvInfo.png', icon='DefaultAddonTvInfo.png', fanart='DefaultAddonTvInfo.png'),
-                      video_dict=dict(plot=self._kodiwrapper.get_localized_string(30091))),
-            TitleItem(title=self._kodiwrapper.get_localized_string(30092),
+                      video_dict=dict(plot=self._kodi.localize(30091))),
+            TitleItem(title=self._kodi.localize(30092),
                       url_dict=dict(action=actions.SEARCH),
                       is_playable=False,
                       art_dict=dict(thumb='DefaultAddonsSearch.png', icon='DefaultAddonsSearch.png', fanart='DefaultAddonsSearch.png'),
-                      video_dict=dict(plot=self._kodiwrapper.get_localized_string(30093))),
+                      video_dict=dict(plot=self._kodi.localize(30093))),
         ])
-        self._kodiwrapper.show_listing(main_items)
+        self._kodi.show_listing(main_items)
 
     def show_favorites_menu_items(self):
         favorites_items = [
-            TitleItem(title=self._kodiwrapper.get_localized_string(30420),
+            TitleItem(title=self._kodi.localize(30420),
                       url_dict=dict(action=actions.LISTING_AZ_TVSHOWS, filtered=True),
                       is_playable=False,
                       art_dict=dict(thumb='DefaultMovieTitle.png', icon='DefaultMovieTitle.png', fanart='DefaultMovieTitle.png'),
-                      video_dict=dict(plot=self._kodiwrapper.get_localized_string(30421))),
-            TitleItem(title=self._kodiwrapper.get_localized_string(30422),
+                      video_dict=dict(plot=self._kodi.localize(30421))),
+            TitleItem(title=self._kodi.localize(30422),
                       url_dict=dict(action=actions.LISTING_RECENT, page='1', filtered=True),
                       is_playable=False,
                       art_dict=dict(thumb='DefaultYear.png', icon='DefaultYear.png', fanart='DefaultYear.png'),
-                      video_dict=dict(plot=self._kodiwrapper.get_localized_string(30423))),
+                      video_dict=dict(plot=self._kodi.localize(30423))),
         ]
-        self._kodiwrapper.show_listing(favorites_items)
+        self._kodi.show_listing(favorites_items)
 
         # Show dialog when no favorites were found
         from resources.lib.vrtplayer import favorites
-        if not favorites.Favorites(self._kodiwrapper).names():
-            self._kodiwrapper.show_ok_dialog(self._kodiwrapper.get_localized_string(30415), self._kodiwrapper.get_localized_string(30416))
+        if not favorites.Favorites(self._kodi).names():
+            self._kodi.show_ok_dialog(self._kodi.localize(30415), self._kodi.localize(30416))
 
     def show_tvshow_menu_items(self, category=None, filtered=False):
         tvshow_items = self._apihelper.get_tvshow_items(category=category, filtered=filtered)
-        self._kodiwrapper.show_listing(tvshow_items, sort='label', content='tvshows')
+        self._kodi.show_listing(tvshow_items, sort='label', content='tvshows')
 
     def show_category_menu_items(self):
         category_items = self.__get_category_menu_items()
-        self._kodiwrapper.show_listing(category_items, sort='label', content='files')
+        self._kodi.show_listing(category_items, sort='label', content='files')
 
     def show_channels_menu_items(self, channel=None):
         if channel:
             tvshow_items = self._apihelper.get_tvshow_items(channel=channel)
-            self._kodiwrapper.show_listing(tvshow_items, sort='label', content='tvshows')
+            self._kodi.show_listing(tvshow_items, sort='label', content='tvshows')
         else:
             from resources.lib.vrtplayer import CHANNELS
             self.show_channels(action=actions.LISTING_CHANNELS, channels=[c.get('name') for c in CHANNELS])
@@ -134,14 +134,14 @@ class VRTPlayer:
                 is_playable = False
             else:
                 url_dict = dict(action=action)
-                label = self._kodiwrapper.get_localized_string(30101) % channel.get('label')
+                label = self._kodi.localize(30101) % channel.get('label')
                 is_playable = True
                 if channel.get('name') in ['een', 'canvas', 'ketnet']:
                     fanart = self._apihelper.get_live_screenshot(channel.get('name'))
-                    plot = '%s\n%s' % (self._kodiwrapper.get_localized_string(30201),
-                                       self._kodiwrapper.get_localized_string(30102) % channel.get('label'))
+                    plot = '%s\n%s' % (self._kodi.localize(30201),
+                                       self._kodi.localize(30102) % channel.get('label'))
                 else:
-                    plot = self._kodiwrapper.get_localized_string(30102) % channel.get('label')
+                    plot = self._kodi.localize(30102) % channel.get('label')
                 if channel.get('live_stream_url'):
                     url_dict['video_url'] = channel.get('live_stream_url')
                 elif channel.get('live_stream'):
@@ -162,15 +162,15 @@ class VRTPlayer:
                 ),
             ))
 
-        self._kodiwrapper.show_listing(channel_items, cache=False)
+        self._kodi.show_listing(channel_items, cache=False)
 
     def show_episodes(self, path):
         episode_items, sort, ascending, content = self._apihelper.get_episode_items(path=path)
-        self._kodiwrapper.show_listing(episode_items, sort=sort, ascending=ascending, content=content)
+        self._kodi.show_listing(episode_items, sort=sort, ascending=ascending, content=content)
 
     def show_all_episodes(self, path):
         episode_items, sort, ascending, content = self._apihelper.get_episode_items(path=path, all_seasons=True)
-        self._kodiwrapper.show_listing(episode_items, sort=sort, ascending=ascending, content=content)
+        self._kodi.show_listing(episode_items, sort=sort, ascending=ascending, content=content)
 
     def show_recent(self, page, filtered=False):
         try:
@@ -183,22 +183,22 @@ class VRTPlayer:
         # Add 'More...' entry at the end
         if len(episode_items) == 50:
             episode_items.append(TitleItem(
-                title=self._kodiwrapper.get_localized_string(30300),
+                title=self._kodi.localize(30300),
                 url_dict=dict(action=actions.LISTING_RECENT, page=page + 1, filtered=filtered),
                 is_playable=False,
                 art_dict=dict(thumb='DefaultYear.png', icon='DefaultYear.png', fanart='DefaultYear.png'),
                 video_dict=dict(),
             ))
 
-        self._kodiwrapper.show_listing(episode_items, sort=sort, ascending=ascending, content=content, cache=False)
+        self._kodi.show_listing(episode_items, sort=sort, ascending=ascending, content=content, cache=False)
 
     def play(self, params):
         from resources.lib.vrtplayer import streamservice, tokenresolver
-        _tokenresolver = tokenresolver.TokenResolver(self._kodiwrapper)
-        _streamservice = streamservice.StreamService(self._kodiwrapper, _tokenresolver)
+        _tokenresolver = tokenresolver.TokenResolver(self._kodi)
+        _streamservice = streamservice.StreamService(self._kodi, _tokenresolver)
         stream = _streamservice.get_stream(params)
         if stream is not None:
-            self._kodiwrapper.play(stream)
+            self._kodi.play(stream)
 
     def search(self, search_string=None, page=1):
         try:
@@ -207,26 +207,27 @@ class VRTPlayer:
             page = 1
 
         if search_string is None:
-            search_string = self._kodiwrapper.get_search_string()
+            search_string = self._kodi.get_search_string()
 
         if not search_string:
             return
 
         search_items, sort, ascending, content = self._apihelper.search(search_string, page=page)
         if not search_items:
-            self._kodiwrapper.show_ok_dialog(self._kodiwrapper.get_localized_string(30098), self._kodiwrapper.get_localized_string(30099) % search_string)
+            self._kodi.show_ok_dialog(self._kodi.localize(30098), self._kodi.localize(30099) % search_string)
+            return
 
         # Add 'More...' entry at the end
         if len(search_items) == 50:
             search_items.append(TitleItem(
-                title=self._kodiwrapper.get_localized_string(30300),
+                title=self._kodi.localize(30300),
                 url_dict=dict(action=actions.SEARCH, query=search_string, page=page + 1),
                 is_playable=False,
                 art_dict=dict(thumb='DefaultAddonSearch.png', icon='DefaultAddonSearch.png', fanart='DefaultAddonSearch.png'),
                 video_dict=dict(),
             ))
 
-        self._kodiwrapper.show_listing(search_items, sort=sort, ascending=ascending, content=content, cache=False)
+        self._kodi.show_listing(search_items, sort=sort, ascending=ascending, content=content, cache=False)
 
     def __get_category_menu_items(self):
         try:
@@ -253,7 +254,7 @@ class VRTPlayer:
 
     def get_categories(self, proxies=None):
         from bs4 import BeautifulSoup, SoupStrainer
-        self._kodiwrapper.log_notice('URL get: https://www.vrt.be/vrtnu/categorieen/', 'Verbose')
+        self._kodi.log_notice('URL get: https://www.vrt.be/vrtnu/categorieen/', 'Verbose')
         response = urlopen('https://www.vrt.be/vrtnu/categorieen/')
         tiles = SoupStrainer('nui-list--content')
         soup = BeautifulSoup(response.read(), 'html.parser', parse_only=tiles)

--- a/service.py
+++ b/service.py
@@ -22,9 +22,9 @@ class VrtMonitor(xbmc.Monitor):
     def onSettingsChanged(self):
         ''' Handler for changes to settings '''
         addon = xbmcaddon.Addon(id='plugin.video.vrt.nu')
-        _kodiwrapper = kodiwrapper.KodiWrapper(None, None, addon)
-        _kodiwrapper.log_notice('VRT NU Addon: settings changed')
-        _tokenresolver = tokenresolver.TokenResolver(_kodiwrapper)
+        _kodi = kodiwrapper.KodiWrapper(None, None, addon)
+        _kodi.log_notice('VRT NU Addon: settings changed')
+        _tokenresolver = tokenresolver.TokenResolver(_kodi)
         _tokenresolver.reset_cookies()
 
 


### PR DESCRIPTION
We have overly long constructions like:

    self._kodiwrapper.get_localized_string()

and this would now become:

    self._kodi.localize()