### PR TITLE
Re-add option to disable favorites

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -39,25 +39,22 @@ def router(params_string):
         _tvguide = tvguide.TVGuide(_kodi)
         _tvguide.show_tvguide(params)
         return
+
+    from resources.lib.vrtplayer import favorites
+    _favorites = favorites.Favorites(_kodi)
     if action == actions.FOLLOW:
-        from resources.lib.vrtplayer import favorites
-        _favorites = favorites.Favorites(_kodi)
         _favorites.follow(program=params.get('program'), path=params.get('path'))
         return
     if action == actions.UNFOLLOW:
-        from resources.lib.vrtplayer import favorites
-        _favorites = favorites.Favorites(_kodi)
         _favorites.unfollow(program=params.get('program'), path=params.get('path'))
         return
     if action == actions.REFRESH_FAVORITES:
-        from resources.lib.vrtplayer import favorites
-        _favorites = favorites.Favorites(_kodi)
         _favorites.update_favorites()
         return
 
     from resources.lib.vrtplayer import vrtapihelper, vrtplayer
-    _apihelper = vrtapihelper.VRTApiHelper(_kodi)
-    _vrtplayer = vrtplayer.VRTPlayer(_kodi, _apihelper)
+    _apihelper = vrtapihelper.VRTApiHelper(_kodi, _favorites)
+    _vrtplayer = vrtplayer.VRTPlayer(_kodi, _favorites, _apihelper)
 
     if action == actions.PLAY:
         _vrtplayer.play(params)

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -15,178 +15,91 @@ msgstr ""
 "Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-msgctxt "#30000"
-msgid "Interface"
-msgstr ""
-
-msgctxt "#30001"
-msgid "Enable My programs"
-msgstr ""
-
-msgctxt "#30002"
-msgid "Show episode permalink in plot"
-msgstr ""
-
-msgctxt "#30003"
-msgid "Enable menu caching"
-msgstr ""
-
+### MAIN MENU
 msgctxt "#30010"
-msgid "Credentials"
-msgstr ""
-
-msgctxt "#30011"
-msgid "Email address"
-msgstr ""
-
-msgctxt "#30012"
-msgid "Password"
-msgstr ""
-
-msgctxt "#30020"
-msgid "Video"
-msgstr ""
-
-msgctxt "#30021"
-msgid "Subtitles"
-msgstr ""
-
-msgctxt "#30022"
-msgid "Show subtitles when available"
-msgstr ""
-
-msgctxt "#30023"
-msgid "Streaming"
-msgstr ""
-
-msgctxt "#30024"
-msgid "Use DRM for 720p HD-quality livestreams"
-msgstr ""
-
-msgctxt "#30025"
-msgid "Maximum bandwidth (kbps)"
-msgstr ""
-
-msgctxt "#30040"
-msgid "Debug"
-msgstr ""
-
-msgctxt "#30041"
-msgid "InputStream Adaptive settings..."
-msgstr ""
-
-msgctxt "#30042"
-msgid "Install Widevine (for DRM content)"
-msgstr ""
-
-msgctxt "#30047"
-msgid "Refresh favorites"
-msgstr ""
-
-msgctxt "#30048"
-msgid "Clear VRT cookies"
-msgstr ""
-
-msgctxt "#30049"
-msgid "Log level"
-msgstr ""
-
-msgctxt "#30051"
-msgid "Login failed!"
-msgstr ""
-
-msgctxt "#30052"
-msgid "Invalid email adress or password. Only VRT logins are supported, no Google or Facebook logins."
-msgstr ""
-
-msgctxt "#30053"
-msgid "This program cannot be played. To view this program outside of Belgium, you first have to validate a Belgian mobile phone number on the VRT NU website."
-msgstr ""
-
-msgctxt "#30054"
-msgid "Whoops something went wrong, check the kodi log for more details."
-msgstr ""
-
-msgctxt "#30055"
-msgid "Please fill in your email address to login."
-msgstr ""
-
-msgctxt "#30056"
-msgid "Please fill in your password to login."
-msgstr ""
-
-msgctxt "#30057"
-msgid "Please increase the maximum bandwidth. Maximum bandwidth is set to %s kbps, but this stream needs a minimum of %s kbps."
-msgstr ""
-
-msgctxt "#30061"
-msgid "Using a SOCKS proxy requires the PySocks library (script.module.pysocks) installed."
-msgstr ""
-
-msgctxt "#30078"
 msgid "My programs"
 msgstr ""
 
-msgctxt "#30079"
+msgctxt "#30011"
 msgid "Browse only the programs you follow"
 msgstr ""
 
-msgctxt "#30080"
+msgctxt "#30012"
 msgid "A-Z"
 msgstr ""
 
-msgctxt "#30081"
+msgctxt "#30013"
 msgid "Alphabetically sorted list of TV programs"
 msgstr ""
 
-msgctxt "#30082"
+msgctxt "#30014"
 msgid "Categories"
 msgstr ""
 
-msgctxt "#30083"
+msgctxt "#30015"
 msgid "TV programs listed by category"
 msgstr ""
 
-msgctxt "#30084"
+msgctxt "#30016"
 msgid "Channels"
 msgstr ""
 
-msgctxt "#30085"
+msgctxt "#30017"
 msgid "TV programs listed by channel"
 msgstr ""
 
-msgctxt "#30086"
+msgctxt "#30018"
 msgid "Live TV"
 msgstr ""
 
-msgctxt "#30087"
+msgctxt "#30019"
 msgid "Watch TV channels live (using Internet streaming)"
 msgstr ""
 
-msgctxt "#30088"
+msgctxt "#30020"
 msgid "Most recent"
 msgstr ""
 
-msgctxt "#30089"
+msgctxt "#30021"
 msgid "Recently published episodes of TV programs"
 msgstr ""
 
-msgctxt "#30090"
+msgctxt "#30022"
 msgid "TV guide"
 msgstr ""
 
-msgctxt "#30091"
+msgctxt "#30023"
 msgid "Browse channel TV guides"
 msgstr ""
 
-msgctxt "#30092"
+msgctxt "#30024"
 msgid "Search VRT NU"
 msgstr ""
 
-msgctxt "#30093"
+msgctxt "#30025"
 msgid "Search the complete VRT NU library"
 msgstr ""
 
+
+### FAVORITES
+msgctxt "#30040"
+msgid "My A-Z"
+msgstr ""
+
+msgctxt "#30041"
+msgid "Alphabetically sorted list of My TV programs"
+msgstr ""
+
+msgctxt "#30042"
+msgid "My recent items"
+msgstr ""
+
+msgctxt "#30043"
+msgid "Recently published episodes of My TV programs"
+msgstr ""
+
+
+### APPLICATION
 msgctxt "#30094"
 msgid "Season"
 msgstr ""
@@ -283,18 +196,146 @@ msgctxt "#30416"
 msgid "We could not find any programs that were followed.\n\nEither right-click on a program or an episode to follow a program, or follow a program on the VRT NU website."
 msgstr ""
 
-msgctxt "#30420"
-msgid "My A-Z"
+
+### SETTINGS
+msgctxt "#30800"
+msgid "Interface"
 msgstr ""
 
-msgctxt "#30421"
-msgid "Alphabetically sorted list of My TV programs"
+msgctxt "#30801"
+msgid "Enable My programs"
 msgstr ""
 
-msgctxt "#30422"
-msgid "My recent items"
+msgctxt "#30802"
+msgid "When enabled, the user can follow their favourite programs and list these separately. In this case the VRT NU addon will download and update a list of your followed programs on the VRT NU website."
 msgstr ""
 
-msgctxt "#30423"
-msgid "Recently published episodes of My TV programs"
+msgctxt "#30803"
+msgid "Show episode permalink in plot"
+msgstr ""
+
+msgctxt "#30804"
+msgid "When enabled, the video description will include a permanent link that points to this episode. This is useful for quickly opening an episode or movie on a mobile device."
+msgstr ""
+
+msgctxt "#30805"
+msgid "Enable menu caching"
+msgstr ""
+
+msgctxt "#30806"
+msgid "When enabled, menus are being cached so they work more quickly. Only in very specific use-cases this is problematic as new episodes may not appear when they are expected."
+msgstr ""
+
+msgctxt "#30820"
+msgid "Credentials"
+msgstr ""
+
+msgctxt "#30821"
+msgid "Email address"
+msgstr ""
+
+msgctxt "#30822"
+msgid "Provide your VRT NU email address. In case this is a Google or Facebook account, please ensure that this login is enabled for normal username/password authentication. See the wiki for more information."
+msgstr ""
+
+msgctxt "#30823"
+msgid "Password"
+msgstr ""
+
+msgctxt "#30824"
+msgid "Provide your VRT NU account password."
+msgstr ""
+
+msgctxt "#30840"
+msgid "Video"
+msgstr ""
+
+msgctxt "#30841"
+msgid "Subtitles"
+msgstr ""
+
+msgctxt "#30843"
+msgid "Show subtitles when available"
+msgstr ""
+
+msgctxt "#30844"
+msgid "This enables subtitles by default for all content that includes substitles."
+msgstr ""
+
+msgctxt "#30845"
+msgid "Streaming"
+msgstr ""
+
+msgctxt "#30847"
+msgid "Use DRM for 720p HD-quality live streams"
+msgstr ""
+
+msgctxt "#30848"
+msgid "Most live streams are available in 720p HD-quality, but may require DRM to be enabled."
+msgstr ""
+
+msgctxt "#30849"
+msgid "Maximum bandwidth (kbps)"
+msgstr ""
+
+msgctxt "#30850"
+msgid "In case you have limited bandwidth available, you may want to specify a maximum bandwidth so that a lower bitrate stream can be selected for playback."
+msgstr ""
+
+msgctxt "#30860"
+msgid "Debug"
+msgstr ""
+
+msgctxt "#30861"
+msgid "InputStream Adaptive settings..."
+msgstr ""
+
+msgctxt "#30863"
+msgid "Install Widevine (for DRM content)"
+msgstr ""
+
+msgctxt "#30865"
+msgid "Refresh favorites"
+msgstr ""
+
+msgctxt "#30867"
+msgid "Clear VRT cookies"
+msgstr ""
+
+msgctxt "#30869"
+msgid "Log level"
+msgstr ""
+
+
+### MESSAGES
+msgctxt "#30951"
+msgid "Login failed!"
+msgstr ""
+
+msgctxt "#30952"
+msgid "Invalid email adress or password. Only VRT logins are supported, no Google or Facebook logins."
+msgstr ""
+
+msgctxt "#30953"
+msgid "This program cannot be played. To view this program outside of Belgium, you first have to validate a Belgian mobile phone number on the VRT NU website."
+msgstr ""
+
+msgctxt "#30954"
+msgid "Whoops something went wrong, check the kodi log for more details."
+msgstr ""
+
+msgctxt "#30955"
+msgid "Please fill in your email address to login."
+msgstr ""
+
+msgctxt "#30956"
+msgid "Please fill in your password to login."
+msgstr ""
+
+msgctxt "#30957"
+msgid "Please increase the maximum bandwidth. Maximum bandwidth is set to %s kbps, but this stream needs a minimum of %s kbps."
+msgstr ""
+
+msgctxt "#30961"
+msgid "Using a SOCKS proxy requires the PySocks library (script.module.pysocks) installed."
 msgstr ""

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -16,186 +16,91 @@ msgstr ""
 "Language: nl\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-msgctxt "#30000"
-msgid "Interface"
-msgstr "Interface"
-
-msgctxt "#30001"
-msgid "Enable My programs"
-msgstr "Toon Mijn TV programma's"
-
-msgctxt "#30002"
-msgid "Show episode permalink in plot"
-msgstr "Toon aflevering permalink in beschrijving"
-
-msgctxt "#30003"
-msgid "Enable menu caching"
-msgstr "Gebruik menu caching"
-
+### MAIN MENU
 msgctxt "#30010"
-msgid "Credentials"
-msgstr "Inloggegevens"
-
-msgctxt "#30011"
-msgid "Email address"
-msgstr "E-mailadres"
-
-msgctxt "#30012"
-msgid "Password"
-msgstr "Wachtwoord"
-
-msgctxt "#30020"
-msgid "Video"
-msgstr "Video"
-
-msgctxt "#30021"
-msgid "Subtitles"
-msgstr "Ondertiteling"
-
-msgctxt "#30022"
-msgid "Show subtitles when available"
-msgstr "Toon ondertiteling indien beschikbaar"
-
-msgctxt "#30023"
-msgid "Streaming"
-msgstr "Streaming"
-
-msgctxt "#30024"
-msgid "Use DRM for 720p HD-quality livestreams"
-msgstr "Gebruik DRM voor de livestreams in 720p HD-kwaliteit"
-
-msgctxt "#30025"
-msgid "Maximum bandwidth (kbps)"
-msgstr "Maximale bandbreedte (kbps)"
-
-msgctxt "#30030"
-msgid "VRT Radio"
-msgstr "VRT Radio"
-
-msgctxt "#30031"
-msgid "Use VRT Radio addon (plugin.audio.vrt.radio)"
-msgstr "Gebruik VRT Radio addon (plugin.audio.vrt.radio)"
-
-msgctxt "#30040"
-msgid "Debug"
-msgstr "Debug"
-
-msgctxt "#30041"
-msgid "InputStream Adaptive settings..."
-msgstr "InputStream Adaptive instellingen..."
-
-msgctxt "#30042"
-msgid "Install Widevine (for DRM content)"
-msgstr "Installeer Widevine (voor DRM content)"
-
-msgctxt "#30047"
-msgid "Refresh favorites"
-msgstr "Ververs gevolgde programma's"
-
-msgctxt "#30048"
-msgid "Clear VRT cookies"
-msgstr "Verwijder VRT cookies"
-
-msgctxt "#30049"
-msgid "Log level"
-msgstr "Log level"
-
-msgctxt "#30051"
-msgid "Login failed!"
-msgstr "Inloggen mislukt!"
-
-msgctxt "#30052"
-msgid "Invalid email adress or password. Only VRT logins are supported, no Google or Facebook logins."
-msgstr "Ongeldig e-mailadres of wachtwoord. Alleen VRT-logins worden ondersteund, geen Google- of Facebook-logins."
-
-msgctxt "#30053"
-msgid "This program cannot be played. To view this program outside of Belgium, you first have to validate a Belgian mobile phone number on the VRT NU website."
-msgstr "Het programma kan niet afgespeeld worden. Om dit programma buiten België te bekijken moet je eerst een Belgisch gsm-nummer valideren via de VRT NU-website."
-
-msgctxt "#30054"
-msgid "Whoops something went wrong, check the kodi log for more details."
-msgstr "Oeps, er ging iets mis, check de kodi log voor meer informatie."
-
-msgctxt "#30055"
-msgid "Please fill in your email address to login."
-msgstr "Gelieve je e-mailadres in te vullen om in te loggen."
-
-msgctxt "#30056"
-msgid "Please fill in your password to login."
-msgstr "Gelieve je wachtwoord in te vullen om in te loggen."
-
-msgctxt "#30057"
-msgid "Please increase the maximum bandwidth. Maximum bandwidth is set to %s kbps, but this stream needs a minimum of %s kbps."
-msgstr "Verhoog de maximale bandbreedte alstublieft. De maximale bandbreedte is ingesteld op %s kbps, maar deze stream heeft minimum %s kbps nodig."
-
-msgctxt "#30061"
-msgid "Using a SOCKS proxy requires the PySocks library (script.module.pysocks) installed."
-msgstr "Het gebruik van SOCKS proxies vereist dat de PySocks library (script.module.pysocks) geïnstalleerd is."
-
-msgctxt "#30078"
 msgid "My programs"
 msgstr "Mijn TV programma's"
 
-msgctxt "#30079"
+msgctxt "#30011"
 msgid "Browse only the programs you follow"
 msgstr "Bekijk enkel de programma's die je volgt"
 
-msgctxt "#30080"
+msgctxt "#30012"
 msgid "A-Z"
 msgstr "A-Z"
 
-msgctxt "#30081"
+msgctxt "#30013"
 msgid "Alphabetically sorted list of TV programs"
 msgstr "Alle TV-programma's in alfabetische volgorde"
 
-msgctxt "#30082"
+msgctxt "#30014"
 msgid "Categories"
 msgstr "Categorieën"
 
-msgctxt "#30083"
+msgctxt "#30015"
 msgid "TV programs listed by category"
 msgstr "Lijst van TV-programma's per categorie"
 
-msgctxt "#30084"
+msgctxt "#30016"
 msgid "Channels"
 msgstr "Kanalen"
 
-msgctxt "#30085"
+msgctxt "#30017"
 msgid "TV programs listed by channel"
 msgstr "Lijst van TV-programma's per kanaal"
 
-msgctxt "#30086"
+msgctxt "#30018"
 msgid "Live TV"
 msgstr "Live kijken"
 
-msgctxt "#30087"
+msgctxt "#30019"
 msgid "Watch TV channels live (using Internet streaming)"
 msgstr "Bekijk TV-kanalen live (via Internet)"
 
-msgctxt "#30088"
+msgctxt "#30020"
 msgid "Most recent"
 msgstr "Meest recent"
 
-msgctxt "#30089"
+msgctxt "#30021"
 msgid "Recently published episodes of TV programs"
 msgstr "Recent gepubliceerde afleveringen van TV-programma's"
 
-msgctxt "#30090"
+msgctxt "#30022"
 msgid "TV guide"
 msgstr "TV-gids"
 
-msgctxt "#30091"
+msgctxt "#30023"
 msgid "Browse channel TV guides"
 msgstr "Doorzoek de TV-gids per kanaal"
 
-msgctxt "#30092"
+msgctxt "#30024"
 msgid "Doorzoek VRT NU"
 msgstr "Doorzoek VRT NU"
 
-msgctxt "#30093"
+msgctxt "#30025"
 msgid "Search the complete VRT NU library"
 msgstr "Doorzoek de hele VRT NU bibliotheek"
 
+
+### FAVORITES
+msgctxt "#30040"
+msgid "My A-Z"
+msgstr "Mijn TV programma's"
+
+msgctxt "#30041"
+msgid "Alphabetically sorted list of My TV programs"
+msgstr "Alle TV-programma's die je volgt in alfabetische volgorde"
+
+msgctxt "#30042"
+msgid "My recent items"
+msgstr "Mijn recente afleveringen"
+
+msgctxt "#30043"
+msgid "Recently published episodes of My TV programs"
+msgstr "Recent gepubliceerde afleveringen van TV-programma's die je volgt"
+
+
+### APPLICATION
 msgctxt "#30094"
 msgid "Season"
 msgstr "Seizoen"
@@ -292,18 +197,120 @@ msgctxt "#30416"
 msgid "We could not find any programs that were followed.\n\nEither right-click on a program or an episode to follow a program, or follow a program on the VRT NU website."
 msgstr "We konden geen programma's vonden die je volgt.\n\nJe kan een programma volgen door rechts te klikken op een programma of aflevering, of om ze op de VRT NU website to volgen."
 
-msgctxt "#30420"
-msgid "My A-Z"
-msgstr "Mijn TV programma's"
+msgctxt "#30800"
+msgid "Interface"
+msgstr "Interface"
 
-msgctxt "#30421"
-msgid "Alphabetically sorted list of My TV programs"
-msgstr "Alle TV-programma's die je volgt in alfabetische volgorde"
+msgctxt "#30801"
+msgid "Enable My programs"
+msgstr "Toon Mijn TV programma's"
 
-msgctxt "#30422"
-msgid "My recent items"
-msgstr "Mijn recente afleveringen"
+msgctxt "#30802"
+msgid "Indien actief kan de gebruiker zijn favoriete programma's volgen en apart aanroepen. Dit zorgt er wel voor dat de VRT NU addon een lijst van favoriete programma's download en aanpast op de VRT NU website."
+msgstr ""
 
-msgctxt "#30423"
-msgid "Recently published episodes of My TV programs"
-msgstr "Recent gepubliceerde afleveringen van TV-programma's die je volgt"
+msgctxt "#30803"
+msgid "Show episode permalink in plot"
+msgstr "Toon aflevering permalink in beschrijving"
+
+msgctxt "#30804"
+msgid "Indien actief zal de beschrijving van iedere video een permanent link bevatten die je rechtstreeks naar de VRT NU website brengt. Dit is handig om snel een aflevering of film to openen op een mobiel toestel."
+msgstr ""
+
+msgctxt "#30805"
+msgid "Enable menu caching"
+msgstr "Gebruik menu caching"
+
+msgctxt "#30820"
+msgid "Credentials"
+msgstr "Inloggegevens"
+
+msgctxt "#30821"
+msgid "Email address"
+msgstr "E-mailadres"
+
+msgctxt "#30823"
+msgid "Password"
+msgstr "Wachtwoord"
+
+msgctxt "#30840"
+msgid "Video"
+msgstr "Video"
+
+msgctxt "#30841"
+msgid "Subtitles"
+msgstr "Ondertiteling"
+
+msgctxt "#30843"
+msgid "Show subtitles when available"
+msgstr "Toon ondertiteling indien beschikbaar"
+
+msgctxt "#30845"
+msgid "Streaming"
+msgstr "Streaming"
+
+msgctxt "#30847"
+msgid "Use DRM for 720p HD-quality livestreams"
+msgstr "Gebruik DRM voor de livestreams in 720p HD-kwaliteit"
+
+msgctxt "#30849"
+msgid "Maximum bandwidth (kbps)"
+msgstr "Maximale bandbreedte (kbps)"
+
+msgctxt "#30060"
+msgid "Debug"
+msgstr "Debug"
+
+msgctxt "#30061"
+msgid "InputStream Adaptive settings..."
+msgstr "InputStream Adaptive instellingen..."
+
+msgctxt "#30063"
+msgid "Install Widevine (for DRM content)"
+msgstr "Installeer Widevine (voor DRM content)"
+
+msgctxt "#30065"
+msgid "Refresh favorites"
+msgstr "Ververs gevolgde programma's"
+
+msgctxt "#30067"
+msgid "Clear VRT cookies"
+msgstr "Verwijder VRT cookies"
+
+msgctxt "#30069"
+msgid "Log level"
+msgstr "Log level"
+
+
+### MESSAGES
+msgctxt "#30951"
+msgid "Login failed!"
+msgstr "Inloggen mislukt!"
+
+msgctxt "#30952"
+msgid "Invalid email adress or password. Only VRT logins are supported, no Google or Facebook logins."
+msgstr "Ongeldig e-mailadres of wachtwoord. Alleen VRT-logins worden ondersteund, geen Google- of Facebook-logins."
+
+msgctxt "#30953"
+msgid "This program cannot be played. To view this program outside of Belgium, you first have to validate a Belgian mobile phone number on the VRT NU website."
+msgstr "Het programma kan niet afgespeeld worden. Om dit programma buiten België te bekijken moet je eerst een Belgisch gsm-nummer valideren via de VRT NU-website."
+
+msgctxt "#30954"
+msgid "Whoops something went wrong, check the kodi log for more details."
+msgstr "Oeps, er ging iets mis, check de kodi log voor meer informatie."
+
+msgctxt "#30955"
+msgid "Please fill in your email address to login."
+msgstr "Gelieve je e-mailadres in te vullen om in te loggen."
+
+msgctxt "#30956"
+msgid "Please fill in your password to login."
+msgstr "Gelieve je wachtwoord in te vullen om in te loggen."
+
+msgctxt "#30957"
+msgid "Please increase the maximum bandwidth. Maximum bandwidth is set to %s kbps, but this stream needs a minimum of %s kbps."
+msgstr "Verhoog de maximale bandbreedte alstublieft. De maximale bandbreedte is ingesteld op %s kbps, maar deze stream heeft minimum %s kbps nodig."
+
+msgctxt "#30961"
+msgid "Using a SOCKS proxy requires the PySocks library (script.module.pysocks) installed."
+msgstr "Het gebruik van SOCKS proxies vereist dat de PySocks library (script.module.pysocks) geïnstalleerd is."

--- a/resources/lib/helperobjects/helperobjects.py
+++ b/resources/lib/helperobjects/helperobjects.py
@@ -24,7 +24,7 @@ class Credentials:
         self._password = _kodi.get_setting('password')
 
     def are_filled_in(self):
-        return not (self._username is None or self._password is None or self._username == '' or self._password == '')
+        return bool(self._username and self._password)
 
     def reload(self):
         self._username = self._kodi.get_setting('username')

--- a/resources/lib/kodiwrappers/kodiwrapper.py
+++ b/resources/lib/kodiwrappers/kodiwrapper.py
@@ -218,7 +218,7 @@ class KodiWrapper:
             locale.setlocale(locale.LC_ALL, locale_lang)
             return True
         except Exception as e:
-            self.log_notice(e, 'Verbose')
+            self.log_notice(e, 'Debug')
             return False
 
     def localize(self, string_id):
@@ -278,7 +278,7 @@ class KodiWrapper:
         if httpproxytype != 0 and not socks_supported:
             # Only open the dialog the first time (to avoid multiple popups)
             if socks_supported is None:
-                self.show_ok_dialog('', self.localize(30061))
+                self.show_ok_dialog('', self.localize(30961))  # Requires PySocks
             return None
 
         proxy_types = ['http', 'socks4', 'socks4a', 'socks5', 'socks5h']
@@ -308,6 +308,9 @@ class KodiWrapper:
     # Note: InputStream Adaptive is not pre-installed on Windows and in some cases users can uninstall it
     def has_inputstream_adaptive_installed(self):
         return xbmc.getCondVisibility('System.HasAddon("{0}")'.format('inputstream.adaptive')) == 1
+
+    def has_credentials(self):
+        return bool(self.get_setting('username') and self.get_setting('password'))
 
     def can_play_drm(self):
         kodi_version = int(xbmc.getInfoLabel('System.BuildVersion').split('.')[0])

--- a/resources/lib/vrtplayer/favorites.py
+++ b/resources/lib/vrtplayer/favorites.py
@@ -22,8 +22,12 @@ class Favorites:
         self._proxies = _kodi.get_proxies()
         install_opener(build_opener(ProxyHandler(self._proxies)))
         self._cache_file = _kodi.get_userdata_path() + 'favorites.json'
-        self._favorites = {}
-        self.get_favorites()
+        self._favorites = None
+        if _kodi.get_setting('usefavorites') == 'true' and _kodi.has_credentials():
+            self.get_favorites()
+
+    def is_activated(self):
+        return self._favorites is not None
 
     def get_favorites(self):
         if self._kodi.check_if_path_exists(self._cache_file):

--- a/resources/lib/vrtplayer/streamservice.py
+++ b/resources/lib/vrtplayer/streamservice.py
@@ -159,7 +159,7 @@ class StreamService:
 
     def _handle_error(self, video_json):
         self._kodi.log_error(video_json.get('message'))
-        message = self._kodi.localize(30054)
+        message = self._kodi.localize(30954)  # Whoops something went wrong
         self._kodi.show_ok_dialog('', message)
 
     @staticmethod
@@ -216,7 +216,7 @@ class StreamService:
                     # Update api_data with roaming_xvrttoken and try again
                     api_data.xvrttoken = roaming_xvrttoken
                     return self.get_stream(video, retry=True, api_data=api_data)
-                message = self._kodi.localize(30053)
+                message = self._kodi.localize(30953)  # Cannot be played
                 self._kodi.show_ok_dialog('', message)
             else:
                 self._handle_error(video_json)
@@ -287,7 +287,7 @@ class StreamService:
                 break
 
         if not hls_variant_url:
-            message = self._kodi.localize(30057) % (str(max_bandwidth), stream_bandwidth)
+            message = self._kodi.localize(30957) % (str(max_bandwidth), stream_bandwidth)
             self._kodi.show_ok_dialog('', message)
             self._kodi.open_settings()
 

--- a/resources/lib/vrtplayer/tokenresolver.py
+++ b/resources/lib/vrtplayer/tokenresolver.py
@@ -192,14 +192,14 @@ class TokenResolver:
 
     def _handle_error(self, logon_json, cred):
         error_message = logon_json.get('errorDetails')
-        title = self._kodi.localize(30051)
+        title = self._kodi.localize(30951)  # Login failed!
         if error_message == 'invalid loginID or password':
             cred.reset()
-            message = self._kodi.localize(30052)
+            message = self._kodi.localize(30952)  # Invalid login!
         elif error_message == 'loginID must be provided':
-            message = self._kodi.localize(30055)
+            message = self._kodi.localize(30955)  # Please fill in username
         elif error_message == 'Missing required parameter: password':
-            message = self._kodi.localize(30056)
+            message = self._kodi.localize(30956)  # Please fill in password
         else:
             message = error_message
         self._kodi.show_ok_dialog(title, message)

--- a/resources/lib/vrtplayer/vrtapihelper.py
+++ b/resources/lib/vrtplayer/vrtapihelper.py
@@ -4,7 +4,7 @@
 
 from __future__ import absolute_import, division, unicode_literals
 from resources.lib.helperobjects.helperobjects import TitleItem
-from resources.lib.vrtplayer import actions, favorites, metadatacreator, statichelper
+from resources.lib.vrtplayer import actions, metadatacreator, statichelper
 
 try:
     from urllib.parse import urlencode, unquote
@@ -21,15 +21,12 @@ class VRTApiHelper:
     _VRTNU_SUGGEST_URL = 'https://vrtnu-api.vrt.be/suggest'
     _VRTNU_SCREENSHOT_URL = 'https://vrtnu-api.vrt.be/screenshots'
 
-    def __init__(self, _kodi):
+    def __init__(self, _kodi, _favorites):
         self._kodi = _kodi
         self._proxies = _kodi.get_proxies()
         install_opener(build_opener(ProxyHandler(self._proxies)))
         self._showpermalink = _kodi.get_setting('showpermalink') == 'true'
-        if _kodi.get_setting('usefavorites') == 'true':
-            self._favorites = favorites.Favorites(self._kodi)
-        else:
-            self._favorites = None
+        self._favorites = _favorites
 
     def get_tvshow_items(self, category=None, channel=None, filtered=False):
         import json
@@ -68,7 +65,7 @@ class VRTApiHelper:
             label = tvshow.get('title', '???')
             thumbnail = statichelper.add_https_method(tvshow.get('thumbnail', 'DefaultAddonVideo.png'))
             program_path = statichelper.unique_path(tvshow.get('targetUrl'))
-            if self._favorites:
+            if self._favorites.is_activated():
                 if self._favorites.is_favorite(program_path):
                     params = dict(action='unfollow', program=tvshow.get('title'), path=program_path)
                     context_menu = [(self._kodi.localize(30412), 'RunPlugin(plugin://plugin.video.vrt.nu?%s)' % urlencode(params))]
@@ -253,7 +250,7 @@ class VRTApiHelper:
                 metadata.plot = '%s\n\n[COLOR yellow]%s[/COLOR]' % (metadata.plot, metadata.permalink)
 
             program_path = statichelper.unique_path(episode.get('programUrl'))
-            if self._favorites:
+            if self._favorites.is_activated():
                 if self._favorites.is_favorite(program_path):
                     params = dict(action='unfollow', program=episode.get('program'), path=program_path)
                     context_menu = [(self._kodi.localize(30412), 'RunPlugin(plugin://plugin.video.vrt.nu?%s)' % urlencode(params))]

--- a/resources/lib/vrtplayer/vrtplayer.py
+++ b/resources/lib/vrtplayer/vrtplayer.py
@@ -14,76 +14,77 @@ except ImportError:
 
 class VRTPlayer:
 
-    def __init__(self, _kodi, _apihelper):
+    def __init__(self, _kodi, _favorites, _apihelper):
         self._kodi = _kodi
         self._proxies = _kodi.get_proxies()
         install_opener(build_opener(ProxyHandler(self._proxies)))
+        self._favorites = _favorites
         self._apihelper = _apihelper
 
     def show_main_menu_items(self):
         main_items = []
 
-        # Only add 'My programs' when this is enabled in config
-        if self._kodi.get_setting('usefavorites') == 'true':
+        # Only add 'My programs' when it has been activated
+        if self._favorites.is_activated():
             main_items.append(TitleItem(
-                title=self._kodi.localize(30078),
+                title=self._kodi.localize(30010),
                 url_dict=dict(action=actions.LISTING_FAVORITES),
                 is_playable=False,
                 art_dict=dict(thumb='icons/settings/profiles.png', icon='icons/settings/profiles.png', fanart='icons/settings/profiles.png'),
-                video_dict=dict(plot=self._kodi.localize(30079))
+                video_dict=dict(plot=self._kodi.localize(30011))
             ))
 
         main_items.extend([
-            TitleItem(title=self._kodi.localize(30080),
+            TitleItem(title=self._kodi.localize(30012),
                       url_dict=dict(action=actions.LISTING_AZ_TVSHOWS),
                       is_playable=False,
                       art_dict=dict(thumb='DefaultMovieTitle.png', icon='DefaultMovieTitle.png', fanart='DefaultMovieTitle.png'),
-                      video_dict=dict(plot=self._kodi.localize(30081))),
-            TitleItem(title=self._kodi.localize(30082),
+                      video_dict=dict(plot=self._kodi.localize(30013))),
+            TitleItem(title=self._kodi.localize(30014),
                       url_dict=dict(action=actions.LISTING_CATEGORIES),
                       is_playable=False,
                       art_dict=dict(thumb='DefaultGenre.png', icon='DefaultGenre.png', fanart='DefaultGenre.png'),
-                      video_dict=dict(plot=self._kodi.localize(30083))),
-            TitleItem(title=self._kodi.localize(30084),
+                      video_dict=dict(plot=self._kodi.localize(30015))),
+            TitleItem(title=self._kodi.localize(30016),
                       url_dict=dict(action=actions.LISTING_CHANNELS),
                       is_playable=False,
                       art_dict=dict(thumb='DefaultTags.png', icon='DefaultTags.png', fanart='DefaultTags.png'),
-                      video_dict=dict(plot=self._kodi.localize(30085))),
-            TitleItem(title=self._kodi.localize(30086),
+                      video_dict=dict(plot=self._kodi.localize(30017))),
+            TitleItem(title=self._kodi.localize(30018),
                       url_dict=dict(action=actions.LISTING_LIVE),
                       is_playable=False,
                       art_dict=dict(thumb='DefaultAddonPVRClient.png', icon='DefaultAddonPVRClient.png', fanart='DefaultAddonPVRClient.png'),
-                      video_dict=dict(plot=self._kodi.localize(30087))),
-            TitleItem(title=self._kodi.localize(30088),
+                      video_dict=dict(plot=self._kodi.localize(30019))),
+            TitleItem(title=self._kodi.localize(30020),
                       url_dict=dict(action=actions.LISTING_RECENT, page='1'),
                       is_playable=False,
                       art_dict=dict(thumb='DefaultYear.png', icon='DefaultYear.png', fanart='DefaultYear.png'),
-                      video_dict=dict(plot=self._kodi.localize(30089))),
-            TitleItem(title=self._kodi.localize(30090),
+                      video_dict=dict(plot=self._kodi.localize(30021))),
+            TitleItem(title=self._kodi.localize(30022),
                       url_dict=dict(action=actions.LISTING_TVGUIDE),
                       is_playable=False,
                       art_dict=dict(thumb='DefaultAddonTvInfo.png', icon='DefaultAddonTvInfo.png', fanart='DefaultAddonTvInfo.png'),
-                      video_dict=dict(plot=self._kodi.localize(30091))),
-            TitleItem(title=self._kodi.localize(30092),
+                      video_dict=dict(plot=self._kodi.localize(30023))),
+            TitleItem(title=self._kodi.localize(30024),
                       url_dict=dict(action=actions.SEARCH),
                       is_playable=False,
                       art_dict=dict(thumb='DefaultAddonsSearch.png', icon='DefaultAddonsSearch.png', fanart='DefaultAddonsSearch.png'),
-                      video_dict=dict(plot=self._kodi.localize(30093))),
+                      video_dict=dict(plot=self._kodi.localize(30025))),
         ])
         self._kodi.show_listing(main_items)
 
     def show_favorites_menu_items(self):
         favorites_items = [
-            TitleItem(title=self._kodi.localize(30420),
+            TitleItem(title=self._kodi.localize(30040),
                       url_dict=dict(action=actions.LISTING_AZ_TVSHOWS, filtered=True),
                       is_playable=False,
                       art_dict=dict(thumb='DefaultMovieTitle.png', icon='DefaultMovieTitle.png', fanart='DefaultMovieTitle.png'),
-                      video_dict=dict(plot=self._kodi.localize(30421))),
-            TitleItem(title=self._kodi.localize(30422),
+                      video_dict=dict(plot=self._kodi.localize(30041))),
+            TitleItem(title=self._kodi.localize(30042),
                       url_dict=dict(action=actions.LISTING_RECENT, page='1', filtered=True),
                       is_playable=False,
                       art_dict=dict(thumb='DefaultYear.png', icon='DefaultYear.png', fanart='DefaultYear.png'),
-                      video_dict=dict(plot=self._kodi.localize(30423))),
+                      video_dict=dict(plot=self._kodi.localize(30043))),
         ]
         self._kodi.show_listing(favorites_items)
 

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -1,26 +1,26 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <settings>
-    <category label="30000"> <!-- Interface -->
-        <setting label="30001" type="bool" id="usefavorites" default="true" visible="false"/>
-        <setting label="30002" type="bool" id="usemenucaching" default="true"/>
-        <setting label="30003" type="bool" id="showpermalink" default="false"/>
+    <category label="30800"> <!-- Interface -->
+        <setting label="30801" help="30802" type="bool" id="usefavorites" default="true"/>
+        <setting label="30803" help="30804" type="bool" id="usemenucaching" default="true"/>
+        <setting label="30805" help="30806" type="bool" id="showpermalink" default="false"/>
     </category>
-    <category label="30010"> <!-- Credentials -->
-        <setting label="30011" type="text" id="username"/>
-        <setting label="30012" type="text" id="password" option="hidden"/>
+    <category label="30820"> <!-- Credentials -->
+        <setting label="30821" help="30822" type="text" id="username"/>
+        <setting label="30823" help="30824" type="text" id="password" option="hidden"/>
     </category>
-    <category label="30020"> <!-- Video -->
-        <setting label="30021" type="lsep"/>
-        <setting label="30022" type="bool" id="showsubtitles" default="true"/>
-        <setting label="30023" type="lsep"/> <!-- InputStream Adaptive -->
-        <setting label="30024" type="bool" id="usedrm" default="false"/>
-        <setting label="30025" type="select" id="max_bandwidth" default="0" values="0|256|512|1024|1536|2048|2560|3072|4096|6144|8192|10240|15360|20480|25600|30720"/>
+    <category label="30840"> <!-- Video -->
+        <setting label="30841" type="lsep"/>
+        <setting label="30843" help="30844" type="bool" id="showsubtitles" default="true"/>
+        <setting label="30845" type="lsep"/> <!-- InputStream Adaptive -->
+        <setting label="30847" help="30848" type="bool" id="usedrm" default="false"/>
+        <setting label="30849" help="30850" type="select" id="max_bandwidth" default="0" values="0|256|512|1024|1536|2048|2560|3072|4096|6144|8192|10240|15360|20480|25600|30720"/>
     </category>
-    <category label="30040"> <!-- Troubleshooting -->
-        <setting label="30041" type="action" id="adaptive_settings" option="close" action="Addon.OpenSettings(inputstream.adaptive)" enable="System.HasAddon(inputstream.adaptive)"/>
-        <!-- setting label="30042" type="action" id="widevine_install" option="close" action="RunPlugin(plugin://plugin.video.vrt.nu?action=installwidevine)" enable="System.HasAddon(script.module.inputstreamhelper)"/ -->
-        <setting label="30047" type="action" id="refresh_favorites" action="RunPlugin(plugin://plugin.video.vrt.nu/?action=refreshfavorites)"/>
-        <setting label="30048" type="action" id="clear_tokens" action="RunPlugin(plugin://plugin.video.vrt.nu/?action=clearcookies)"/>
-        <setting label="30049" type="select" id="max_log_level" values="Quiet|Info|Verbose|Debug" default="Info"/>
+    <category label="30860"> <!-- Troubleshooting -->
+        <setting label="30861" help="30862" type="action" id="adaptive_settings" option="close" action="Addon.OpenSettings(inputstream.adaptive)" enable="System.HasAddon(inputstream.adaptive)"/>
+        <!-- setting label="30863" help="30864" type="action" id="widevine_install" option="close" action="RunPlugin(plugin://plugin.video.vrt.nu?action=installwidevine)" enable="System.HasAddon(script.module.inputstreamhelper)"/ -->
+        <setting label="30865" help="30866" type="action" id="refresh_favorites" action="RunPlugin(plugin://plugin.video.vrt.nu/?action=refreshfavorites)"/>
+        <setting label="30867" help="30868" type="action" id="clear_tokens" action="RunPlugin(plugin://plugin.video.vrt.nu/?action=clearcookies)"/>
+        <setting label="30869" help="30870" type="select" id="max_log_level" values="Quiet|Info|Verbose|Debug" default="Info"/>
     </category>
 </settings>

--- a/service.py
+++ b/service.py
@@ -24,6 +24,8 @@ class VrtMonitor(xbmc.Monitor):
         addon = xbmcaddon.Addon(id='plugin.video.vrt.nu')
         _kodi = kodiwrapper.KodiWrapper(None, None, addon)
         _kodi.log_notice('VRT NU Addon: settings changed')
+        _kodi.container_refresh()
+
         _tokenresolver = tokenresolver.TokenResolver(_kodi)
         _tokenresolver.reset_cookies()
 

--- a/test/searchtests.py
+++ b/test/searchtests.py
@@ -7,7 +7,7 @@ import mock
 import os
 import unittest
 
-from resources.lib.vrtplayer import vrtapihelper
+from resources.lib.vrtplayer import favorites, vrtapihelper
 from test import get_setting, log_notice, open_file, stat_file
 
 
@@ -24,7 +24,8 @@ class TestSearch(unittest.TestCase):
     _kodiwrapper.make_dir.return_value = None
     _kodiwrapper.open_file = mock.MagicMock(side_effect=open_file)
     _kodiwrapper.stat_file = mock.MagicMock(side_effect=stat_file)
-    _apihelper = vrtapihelper.VRTApiHelper(_kodiwrapper)
+    _favorites = favorites.Favorites(_kodiwrapper)
+    _apihelper = vrtapihelper.VRTApiHelper(_kodiwrapper, _favorites)
 
     def test_search_journaal(self):
         ''' Test for journaal '''

--- a/test/streamservicetests.py
+++ b/test/streamservicetests.py
@@ -11,7 +11,7 @@ import mock
 import unittest
 from urllib2 import HTTPError
 
-from resources.lib.vrtplayer import CHANNELS, streamservice, tokenresolver, vrtapihelper
+from resources.lib.vrtplayer import CHANNELS, streamservice, tokenresolver
 from test import SETTINGS, get_setting, get_localized_string, log_notice
 
 SETTINGS['use_drm'] = 'false'
@@ -31,7 +31,6 @@ class StreamServiceTests(unittest.TestCase):
     _kodiwrapper.get_userdata_path.return_value = './userdata/'
     _kodiwrapper.log_notice = mock.MagicMock(side_effect=log_notice)
     _kodiwrapper.make_dir.return_value = None
-    _apihelper = vrtapihelper.VRTApiHelper(_kodiwrapper)
     _tokenresolver = tokenresolver.TokenResolver(_kodiwrapper)
     _streamservice = streamservice.StreamService(_kodiwrapper, _tokenresolver)
 


### PR DESCRIPTION
This PR includes:
- Re-added the settings option to enable/disable favorites
- Only enable My programs when settings enable it and credentials are detected
- Reorganize unit tests (move from vrtplayer to apihelper)

This is done over concerns from https://github.com/pietje666/plugin.video.vrt.nu/pull/213#issuecomment-492657267

Additionally, I think we need to add help to individual settings to give a little bit more insight into how settings affect the VRT NU addon. This also gives more maturity to our addon settings pages...