### PR TITLE
Add TV-Guide information to live stream plot

### DIFF
--- a/resources/lib/vrtplayer/vrtplayer.py
+++ b/resources/lib/vrtplayer/vrtplayer.py
@@ -113,7 +113,8 @@ class VRTPlayer:
         self.show_channels(action=actions.PLAY, channels=['een', 'canvas', 'sporza', 'ketnet-jr', 'ketnet', 'stubru', 'mnm'])
 
     def show_channels(self, action=actions.PLAY, channels=None):
-        from resources.lib.vrtplayer import CHANNELS
+        from resources.lib.vrtplayer import CHANNELS, tvguide
+        _tvguide = tvguide.TVGuide(self._kodi)
 
         fanart_path = 'resource://resource.images.studios.white/%(studio)s.png'
         icon_path = 'resource://resource.images.studios.white/%(studio)s.png'
@@ -139,8 +140,7 @@ class VRTPlayer:
                 is_playable = True
                 if channel.get('name') in ['een', 'canvas', 'ketnet']:
                     fanart = self._apihelper.get_live_screenshot(channel.get('name'))
-                    plot = '%s\n%s' % (self._kodi.localize(30201),
-                                       self._kodi.localize(30102) % channel.get('label'))
+                    plot = _tvguide.live_description(channel.get('name')) or self._kodi.localize(30102) % channel.get('label')
                 else:
                     plot = self._kodi.localize(30102) % channel.get('label')
                 if channel.get('live_stream_url'):

--- a/test/tvguidetests.py
+++ b/test/tvguidetests.py
@@ -45,6 +45,14 @@ class TestTVGuide(unittest.TestCase):
         episode_items = self._tvguide.show_episodes(date, channel)
         self.assertTrue(episode_items)
 
+    def test_livetv_description(self):
+        description = self._tvguide.live_description('een')
+        print(description)
+        description = self._tvguide.live_description('canvas')
+        print(description)
+        description = self._tvguide.live_description('ketnet')
+        print(description)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This adds the previous, current and upcoming live show to the live
stream plot.

This also includes a fix where we would show today's TV-Guide, while the
EPG information goes from 6AM until 6AM. So before 6AM we would show the
previous day's EPG.