### PR TITLE
Fix Live TV EPG after midnight

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -129,7 +129,7 @@ msgid "{label} live"
 msgstr ""
 
 msgctxt "#30102"
-msgid "Watch {label} live TV stream (via Internet)"
+msgid "Watch {label} live via Internet"
 msgstr ""
 
 msgctxt "#30201"

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -130,8 +130,8 @@ msgid "{label} live"
 msgstr "{label} live"
 
 msgctxt "#30102"
-msgid "Watch {label} live TV stream (via Internet)"
-msgstr "Bekijk {label} live tv stream (via Internet)"
+msgid "Watch {label} live via Internet"
+msgstr "Bekijk {label} live via Internet"
 
 msgctxt "#30201"
 msgid "[B][COLOR red]Geo-blocked[/COLOR][/B]\n"

--- a/resources/lib/vrtplayer/tvguide.py
+++ b/resources/lib/vrtplayer/tvguide.py
@@ -57,13 +57,13 @@ class TVGuide:
             self._kodi.show_listing(episode_items, content='episodes', cache=False)
 
     def show_date_menu(self):
-        now = datetime.now(dateutil.tz.tzlocal())
+        epg = datetime.now(dateutil.tz.tzlocal())
         # Daily EPG information shows information from 6AM until 6AM
-        if now.hour < 6:
-            now += timedelta(days=-1)
+        if epg.hour < 6:
+            epg += timedelta(days=-1)
         date_items = []
         for i in range(7, -31, -1):
-            day = now + timedelta(days=i)
+            day = epg + timedelta(days=i)
             title = self._kodi.localize_datelong(day)
 
             # Highlight today with context of 2 days
@@ -179,10 +179,11 @@ class TVGuide:
 
     def live_description(self, channel):
         now = datetime.now(dateutil.tz.tzlocal())
+        epg = now
         # Daily EPG information shows information from 6AM until 6AM
-        if now.hour < 6:
-            now += timedelta(days=-1)
-        api_url = now.strftime(self.VRT_TVGUIDE)
+        if epg.hour < 6:
+            epg += timedelta(days=-1)
+        api_url = epg.strftime(self.VRT_TVGUIDE)
         self._kodi.log_notice('URL get: ' + api_url, 'Verbose')
         schedule = json.loads(urlopen(api_url).read())
         name = channel

--- a/test/apihelpertests.py
+++ b/test/apihelpertests.py
@@ -28,7 +28,7 @@ class ApiHelperTests(unittest.TestCase):
 
     def test_get_api_data_single_season(self):
         title_items, sort, ascending, content = self._apihelper.get_episode_items(path='/vrtnu/a-z/het-journaal.relevant/')
-        self.assertTrue(123 < len(title_items) < 130, 'We got %s items instead.' % len(title_items))
+        self.assertTrue(122 < len(title_items) < 130, 'We got %s items instead.' % len(title_items))
         self.assertEqual(sort, 'dateadded')
         self.assertFalse(ascending)
         self.assertEqual(content, 'episodes')


### PR DESCRIPTION
Because we did not make a distinction between the actual time and the
EPG data we needed to fetch, the EPG information would be off.