### PR TITLE
Fix recalculation when using today, tomorrow, yesterday

### DIFF
--- a/resources/lib/vrtplayer/tvguide.py
+++ b/resources/lib/vrtplayer/tvguide.py
@@ -240,9 +240,15 @@ class TVGuide:
 
     def parse(self, date, now):
         if date == 'today':
+            if now.hour < 6:
+                return now + timedelta(days=-1)
             return now
         if date == 'yesterday':
+            if now.hour < 6:
+                return now + timedelta(days=-2)
             return now + timedelta(days=-1)
         if date == 'tomorrow':
+            if now.hour < 6:
+                return now
             return now + timedelta(days=1)
         return dateutil.parser.parse(date)


### PR DESCRIPTION
This fixes an issues where today, tomorrow and yesterday would not bring you to the advertised date between 12AM and 6AM.