### PR TITLE
Add timing to 'No transmission'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ unit:
 	PYTHONPATH=$(CURDIR) python test/favoritestests.py
 	@echo -e "$(white)=$(blue) Unit tests finished successfully.$(reset)"
 
-zip: test
+zip: test clean
 	@echo -e "$(white)=$(blue) Building new package$(reset)"
 	@rm -f ../$(zip_name)
 	cd ..; zip -r $(zip_name) $(include_paths) -x $(exclude_files)
@@ -53,3 +53,4 @@ zip: test
 
 clean:
 	find . -name '*.pyc' -delete
+	find . -name '__pycache__' -delete

--- a/resources/lib/vrtplayer/tvguide.py
+++ b/resources/lib/vrtplayer/tvguide.py
@@ -235,7 +235,8 @@ class TVGuide:
                     break
                 break
         if not description:
-            description = '[COLOR yellow][B]%s[/B]\n» %s[/COLOR]' % (self._kodi.localize(30421), self._kodi.localize(30423))
+            # Add a final 'No transmission' program
+            description = '[COLOR yellow][B]%s[/B] %s - 06:00\n» %s[/COLOR]' % (self._kodi.localize(30421), episode.get('end'), self._kodi.localize(30423))
         return description
 
     def parse(self, date, now):


### PR DESCRIPTION
Since we know there is no transmission if we can't find a match or a next program when we reach the end. We do know when the previous program ended, and we know the next broadcasting day starts at 06:00. So let's add this for completeness.

The vrtnu website is doing the same thing.