### PR TITLE
Fix translation strings

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -469,7 +469,7 @@ msgid "Install Widevine using 'InputStream Helper' add-on"
 msgstr ""
 
 msgctxt "#30972"
-msgid "Installing Widevine libraries using the 'InputStream Helper' add-on is done at your own risk and the VRT NU add-on is not responsible for any results. Nor is it guaranteed that Widevine will be installed correctly."
+msgid "Installing Widevine libraries using the 'InputStream Helper' add-on is done at your own risk and the VRT NU add-on is not responsible for any results. Nor is it guaranteed that Widevine will be (re)installed correctly."
 msgstr ""
 
 msgctxt "#30973"

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -300,8 +300,8 @@ msgid "Streaming"
 msgstr "Streaming"
 
 msgctxt "#30847"
-msgid "Use DRM for 720p HD-quality livestreams"
-msgstr "Gebruik DRM voor de livestreams in 720p HD-kwaliteit"
+msgid "Use DRM for 720p HD-quality live streams"
+msgstr "Gebruik DRM voor de live streams in 720p HD-kwaliteit"
 
 msgctxt "#30849"
 msgid "Maximum bandwidth (kbps)"
@@ -312,7 +312,7 @@ msgid "Channels"
 msgstr "Kanalen"
 
 msgctxt "#30861"
-msgid "Select channels for 'Most recent' and 'Soon offline' listings"
+msgid "Select channels to use for 'Most recent' and 'Soon offline' listings"
 msgstr "Selecteer kanalen voor de 'Meest recent' en 'Binnenkort offline' lijsten"
 
 msgctxt "#30863"


### PR DESCRIPTION
A few strings were not correct between en_gb and nl_nl, which caused the
translation not to work.