### PR TITLE
Add docstrings to remaining modules

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -15,19 +15,6 @@
     </extension>
     <extension point="xbmc.service" library="service.py"/>
 
-    <extension point="kodi.context.item">
-        <menu id="kodi.core.main">
-            <item library="resources/menus/follow.py">
-                <label>30411</label>
-                <visible>IsEqual(ListItem.Property(Favorite),False)</visible>
-            </item>
-            <item library="resources/menus/unfollow.py">
-                <label>30412</label>
-                <visible>IsEqual(ListItem.Property(Favorite),True)</visible>
-            </item>
-        </menu>
-    </extension>
-
     <extension point="xbmc.addon.metadata">
         <summary lang="en_GB">Watch videos from VRT NU</summary>
         <description lang="en_GB">

--- a/pylintrc
+++ b/pylintrc
@@ -6,7 +6,6 @@ disable=
     import-error,
     invalid-name,
     line-too-long,
-    missing-docstring, # Temporarily disabled until we fixed it
     no-init,
     no-self-use,
     old-style-class,

--- a/resources/lib/helperobjects.py
+++ b/resources/lib/helperobjects.py
@@ -8,8 +8,10 @@ from __future__ import absolute_import, division, unicode_literals
 
 
 class ApiData:
+    ''' This helper object holds all media information '''
 
     def __init__(self, client, media_api_url, video_id, publication_id, is_live_stream):
+        ''' The constructor for the ApiData class '''
         self.client = client
         self.media_api_url = media_api_url
         self.video_id = video_id
@@ -18,27 +20,34 @@ class ApiData:
 
 
 class Credentials:
+    ''' This helper object holds all credential information '''
 
     def __init__(self, _kodi):
+        ''' The constructor for the Credentials class '''
         self._kodi = _kodi
         self.username = _kodi.get_setting('username')
         self.password = _kodi.get_setting('password')
 
     def are_filled_in(self):
+        ''' Whether the credentials have been filled in and are stored in the settings '''
         return bool(self.username and self.password)
 
     def reload(self):
+        ''' Reload the credentials from the settings '''
         self.username = self._kodi.get_setting('username')
         self.password = self._kodi.get_setting('password')
 
     def reset(self):
+        ''' Reset the credentials in the settings '''
         self.username = self._kodi.set_setting('username', None)
         self.password = self._kodi.set_setting('password', None)
 
 
 class StreamURLS:
+    ''' This helper object holds all information to be used when playing streams '''
 
     def __init__(self, stream_url, subtitle_url=None, license_key=None, use_inputstream_adaptive=False):
+        ''' The constructor for the StreamURLS class '''
         self.stream_url = stream_url
         self.subtitle_url = subtitle_url
         self.license_key = license_key
@@ -47,8 +56,10 @@ class StreamURLS:
 
 
 class TitleItem:
+    ''' This helper object holds all information to be used with Kodi xbmc's ListItem object '''
 
     def __init__(self, title, url_dict, is_playable, art_dict=None, video_dict=None, context_menu=None):
+        ''' The constructor for the TitleItem class '''
         self.title = title
         self.url_dict = url_dict
         self.is_playable = is_playable

--- a/resources/lib/vrtplayer.py
+++ b/resources/lib/vrtplayer.py
@@ -202,6 +202,7 @@ class VRTPlayer:
         self._kodi.show_listing(search_items, sort=sort, ascending=ascending, content=content, cache=False)
 
     def play_latest_episode(self, params):
+        ''' A hidden feature in the VRT NU add-on to play the latest episode of a program '''
         video = self._apihelper.get_latest_episode(params.get('tvshow'))
         if not video:
             self._kodi.log_error('Play latest episode failed, params %s' % params)

--- a/test/apihelpertests.py
+++ b/test/apihelpertests.py
@@ -2,6 +2,8 @@
 
 # GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+# pylint: disable=missing-docstring
+
 from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 

--- a/test/favoritestests.py
+++ b/test/favoritestests.py
@@ -2,6 +2,8 @@
 
 # GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+# pylint: disable=missing-docstring
+
 from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 

--- a/test/routertests.py
+++ b/test/routertests.py
@@ -2,6 +2,8 @@
 
 # GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+# pylint: disable=missing-docstring
+
 from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 

--- a/test/searchtests.py
+++ b/test/searchtests.py
@@ -2,6 +2,8 @@
 
 # GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+# pylint: disable=missing-docstring
+
 from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 

--- a/test/streamservicetests.py
+++ b/test/streamservicetests.py
@@ -3,6 +3,7 @@
 # GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 # pylint: disable=unused-variable
+# pylint: disable=missing-docstring
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 from datetime import datetime, timedelta

--- a/test/tvguidetests.py
+++ b/test/tvguidetests.py
@@ -2,6 +2,8 @@
 
 # GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+# pylint: disable=missing-docstring
+
 from __future__ import absolute_import, division, print_function, unicode_literals
 from datetime import datetime, timedelta
 import random

--- a/test/vrtplayertests.py
+++ b/test/vrtplayertests.py
@@ -3,6 +3,7 @@
 # GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 # pylint: disable=unused-variable
+# pylint: disable=missing-docstring
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 import random

--- a/test/xbmc.py
+++ b/test/xbmc.py
@@ -2,6 +2,8 @@
 
 # GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+''' This file implements the Kodi xbmc module, either using stubs or alternative functionality '''
+
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import sys
@@ -33,37 +35,47 @@ except Exception as e:
     GLOBAL_SETTINGS = {}
 
 
-class Keyboard():
+class Keyboard:
+    ''' A stub implementation of the xbmc Keyboard class '''
+
     def __init__(self, line='', heading=''):
-        pass
+        ''' A stub constructor for the xbmc Keyboard class '''
 
     def doModal(self, autoclose=0):
-        pass
+        ''' A stub implementation for the xbmc Keyboard class doModal() method '''
 
     def isConfirmed(self):
+        ''' A stub implementation for the xbmc Keyboard class isConfirmed() method '''
         return True
 
     def getText(self):
+        ''' A stub implementation for the xbmc Keyboard class getText() method '''
         return 'unittest'
 
 
 class Monitor:
+    ''' A stub implementation of the xbmc Monitor class '''
+
     def abortRequested(self):
+        ''' A stub implementation for the xbmc Keyboard class abortRequested() method '''
         return
 
     def waitForAbort(self):
+        ''' A stub implementation for the xbmc Keyboard class waitForAbort() method '''
         return
 
 
 class Player:
-    pass
+    ''' A stub implementation of the xbmc Player class '''
 
 
 def executebuiltin(s):
+    ''' A stub implementation of the xbmc executebuiltin() function '''
     return
 
 
 def executeJSONRPC(jsonrpccommand):
+    ''' A reimplementation of the xbmc executeJSONRPC() function '''
     command = json.loads(jsonrpccommand)
     if command.get('method') == 'Settings.GetSettingValue':
         key = command.get('params').get('setting')
@@ -72,14 +84,17 @@ def executeJSONRPC(jsonrpccommand):
 
 
 def getCondVisibility(s):
+    ''' A reimplementation of the xbmc getCondVisibility() function '''
     return 1
 
 
 def getInfoLabel(key):
+    ''' A reimplementation of the xbmc getInfoLabel() function '''
     return INFO_LABELS.get(key)
 
 
 def getLocalizedString(msgctxt):
+    ''' A reimplementation of the xbmc getLocalizedString() function '''
     for entry in PO:
         if entry.msgctxt == '#%s' % msgctxt:
             return entry.msgstr or entry.msgid
@@ -87,20 +102,25 @@ def getLocalizedString(msgctxt):
 
 
 def getRegion(key):
+    ''' A reimplementation of the xbmc getRegion() function '''
     return REGIONS.get(key)
 
 
 def setContent(self, content):
+    ''' A stub implementation of the xbmc setContent() function '''
     return
 
 
 def sleep(seconds):
+    ''' A reimplementation of the xbmc sleep() function '''
     time.sleep(seconds)
 
 
 def translatePath(path):
+    ''' A stub implementation of the xbmc translatePath() function '''
     return path
 
 
 def log(msg, level):
+    ''' A reimplementation of the xbmc log() function '''
     print('%s: %s' % (level, msg))

--- a/test/xbmcaddon.py
+++ b/test/xbmcaddon.py
@@ -2,6 +2,8 @@
 
 # GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+''' This file implements the Kodi xbmcaddon module, either using stubs or alternative functionality '''
+
 from __future__ import absolute_import, division, print_function, unicode_literals
 import sys
 import json
@@ -26,7 +28,8 @@ except Exception as e:
     print("Error using 'test/userdata/credentials.json': %s" % e, file=sys.stderr)
 
 
-def read_addon_xml(path):
+def __read_addon_xml(path):
+    ''' Parse the addon.xml and return an info dictionary '''
     info = dict(
         path='./',  # '/storage/.kodi/addons/plugin.video.vrt.nu',
         profile='./test/userdata/',  # 'special://profile/addon_data/plugin.video.vrt.nu/',
@@ -57,20 +60,24 @@ def read_addon_xml(path):
     return info
 
 
-ADDON_INFO = read_addon_xml('addon.xml')
+ADDON_INFO = __read_addon_xml('addon.xml')
 
 
 class Addon:
+    ''' A reimplementation of the xbmcaddon Addon class '''
+
     @staticmethod
     def __init__():
-        pass
+        ''' A stub constructor for the xbmcaddon Addon class '''
 
     @staticmethod
     def getAddonInfo(key):
+        ''' A working implementation for the xbmcaddon Addon class getAddonInfo() method '''
         return ADDON_INFO.get(key)
 
     @staticmethod
     def getLocalizedString(msgctxt):
+        ''' A working implementation for the xbmcaddon Addon class getLocalizedString() method '''
         for entry in PO:
             if entry.msgctxt == '#%s' % msgctxt:
                 return entry.msgstr or entry.msgid
@@ -78,8 +85,9 @@ class Addon:
 
     @staticmethod
     def getSetting(key):
+        ''' A working implementation for the xbmcaddon Addon class getSetting() method '''
         return ADDON_SETTINGS.get(key)
 
     @staticmethod
     def setSetting(key, value):
-        pass
+        ''' A stub implementation for the xbmcaddon Addon class setSetting() method '''

--- a/test/xbmcgui.py
+++ b/test/xbmcgui.py
@@ -2,43 +2,60 @@
 
 # GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+''' This file implements the Kodi xbmcgui module, either using stubs or alternative functionality '''
+
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 
 class Dialog:
+    ''' A reimplementation of the xbmcgui Dialog class '''
+
     def notification(self, heading='', message='', icon='', time=''):
+        ''' A working implementation for the xbmcgui Dialog class notification() method '''
         print('GUI NOTIFICATION: [%s] %s' % (heading, message))
 
     def ok(self, heading='', line1=''):
+        ''' A stub implementation for the xbmcgui Dialog class ok() method '''
         return
 
     def yesno(self, heading='', line1=''):
+        ''' A stub implementation for the xbmcgui Dialog class yesno() method '''
         return True
 
 
 class ListItem:
+    ''' A reimplementation of the xbmcgui ListItem class '''
+
     def __init__(self, label='', label2='', iconImage='', thumbnailImage='', path='', offScreen=False):
+        ''' A stub constructor for the xbmcgui ListItem class '''
         self.label = label
         self.label2 = label2
         self.path = path
 
     def addContextMenuItems(self, items, replaceItems=False):
+        ''' A stub implementation for the xbmcgui ListItem class addContextMenuItems() method '''
         return
 
     def setArt(self, key):
+        ''' A stub implementation for the xbmcgui ListItem class setArt() method '''
         return
 
     def setContentLookup(self, enable):
+        ''' A stub implementation for the xbmcgui ListItem class setContentLookup() method '''
         return
 
     def setInfo(self, type, infoLabels):  # pylint: disable=redefined-builtin
+        ''' A stub implementation for the xbmcgui ListItem class setInfo() method '''
         return
 
     def setMimeType(self, mimetype):
+        ''' A stub implementation for the xbmcgui ListItem class setMimeType() method '''
         return
 
     def setProperty(self, key, value):
+        ''' A stub implementation for the xbmcgui ListItem class setProperty() method '''
         return
 
     def setSubtitles(self, subtitleFiles):
+        ''' A stub implementation for the xbmcgui ListItem class setSubtitles() method '''
         return

--- a/test/xbmcplugin.py
+++ b/test/xbmcplugin.py
@@ -2,6 +2,8 @@
 
 # GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+''' This file implements the Kodi xbmcplugin module, either using stubs or alternative functionality '''
+
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 SORT_METHOD_NONE = 0
@@ -33,18 +35,22 @@ SORT_METHOD_DATE_TAKEN = 44
 
 
 def addDirectoryItems(handle, listing, length):
+    ''' A reimplementation of the xbmcplugin addDirectoryItems() function '''
     for item in listing:
         print('* {label} -> {path}'.format(label=item[1].label, path=item[0]))
     return True
 
 
 def addSortMethod(handle, sortMethod):
+    ''' A stub implementation of the xbmcplugin addSortMethod() function '''
     return
 
 
 def endOfDirectory(handle, succeeded=True, updateListing=True, cacheToDisc=True):
+    ''' A stub implementation of the xbmcplugin endOfDirectory() function '''
     return
 
 
 def setContent(self, content):
+    ''' A stub implementation of the xbmcplugin setContent() function '''
     return

--- a/test/xbmcvfs.py
+++ b/test/xbmcvfs.py
@@ -2,26 +2,36 @@
 
 # GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+''' This file implements the Kodi xbmcvfs module, either using stubs or alternative functionality '''
+
 from __future__ import absolute_import, division, print_function, unicode_literals
 import os
 
 
 def File(path, flags='r'):
+    ''' A reimplementation of the xbmcvfs File() function '''
     return open(path, flags)
 
 
 def Stat(path):
+    ''' A reimplementation of the xbmcvfs Stat() function '''
+
     class stat:
+        ''' A reimplementation of the xbmcvfs stat class '''
         def __init__(self, path):
+            ''' The constructor xbmcvfs stat class '''
             self._stat = os.stat(path)
 
         def st_mtime(self):
+            ''' The xbmcvfs stat class st_mtime method '''
             return self._stat.st_mtime
 
     return stat(path)
 
 
 def delete(path):
+    ''' A reimplementation of the xbmcvfs delete() function '''
+
     try:
         os.remove(path)
     except OSError:
@@ -29,10 +39,12 @@ def delete(path):
 
 
 def exists(path):
+    ''' A reimplementation of the xbmcvfs exists() function '''
     return os.path.exists(path)
 
 
 def listdir(path):
+    ''' A reimplementation of the xbmcvfs listdir() function '''
     files = []
     dirs = []
     for f in os.listdir(path):
@@ -44,8 +56,10 @@ def listdir(path):
 
 
 def mkdir(path):
+    ''' A reimplementation of the xbmcvfs mkdir() function '''
     return os.mkdir(path)
 
 
 def mkdirs(path):
+    ''' A reimplementation of the xbmcvfs mkdirs() function '''
     return os.makedirs(path)


### PR DESCRIPTION
This PR includes:
- Adding docstrings to all remaining modules, except unit tests
- Remove unwanted context snipper from addon.xml (testing leftover)
- Re-add pylint missing-docstring test

The helper-objects may need a more sensible docstring.
Other docstrings probably could use some more context information as well.