### PR TITLE
Add default values for missing settings

### DIFF
--- a/resources/lib/streamservice.py
+++ b/resources/lib/streamservice.py
@@ -207,7 +207,7 @@ class StreamService:
             # Select streaming protocol
             if not drm_stream and self._kodi.has_inputstream_adaptive():
                 protocol = 'mpeg_dash'
-            elif drm_stream and self._can_play_drm and self._kodi.get_setting('usedrm') == 'true':
+            elif drm_stream and self._can_play_drm and self._kodi.get_setting('usedrm', 'true') == 'true':
                 protocol = 'mpeg_dash'
             elif vudrm_token:
                 protocol = 'hls_aes'
@@ -307,7 +307,7 @@ class StreamService:
                 hls_variant_url = hls_base_url + match_audio.group('AUDIO_URI') + '-' + hls_variant_url.split('-')[-1]
 
         # Get subtitle url, works only for on demand streams
-        if self._kodi.get_setting('showsubtitles') == 'true' and '/live/' not in master_hls_url and hls_subtitle_id:
+        if self._kodi.get_setting('showsubtitles', 'true') == 'true' and '/live/' not in master_hls_url and hls_subtitle_id:
             subtitle_regex = re.compile(r'#EXT-X-MEDIA:TYPE=SUBTITLES[\w\-=,\.\"\/]+?GROUP-ID=\"' + hls_subtitle_id + ''
                                         r'\"[\w\-=,\.\"\/]+URI=\"(?P<SUBTITLE_URI>[\w\-=]+)\.m3u8\"')
             match_subtitle = re.search(subtitle_regex, hls_playlist)

--- a/resources/lib/tvguide.py
+++ b/resources/lib/tvguide.py
@@ -44,7 +44,7 @@ class TVGuide:
         self._kodi = _kodi
         self._proxies = _kodi.get_proxies()
         install_opener(build_opener(ProxyHandler(self._proxies)))
-        self._showfanart = _kodi.get_setting('showfanart') == 'true'
+        self._showfanart = _kodi.get_setting('showfanart', 'true') == 'true'
 
     def show_tvguide(self, params):
         ''' Offer a menu depending on the information provided '''

--- a/resources/lib/vrtplayer.py
+++ b/resources/lib/vrtplayer.py
@@ -57,7 +57,9 @@ class VRTPlayer:
             TitleItem(title=self._kodi.localize(30020),  # Recent items
                       url_dict=dict(action=actions.LISTING_RECENT),
                       is_playable=False,
-                      art_dict=dict(thumb='DefaultRecentlyAddedEpisodes.png', icon='DefaultRecentlyAddedEpisodes.png', fanart='DefaultRecentlyAddedEpisodes.png'),
+                      art_dict=dict(thumb='DefaultRecentlyAddedEpisodes.png',
+                                    icon='DefaultRecentlyAddedEpisodes.png',
+                                    fanart='DefaultRecentlyAddedEpisodes.png'),
                       video_dict=dict(plot=self._kodi.localize(30021))),
             TitleItem(title=self._kodi.localize(30022),  # Soon offline
                       url_dict=dict(action=actions.LISTING_OFFLINE),
@@ -88,7 +90,9 @@ class VRTPlayer:
             TitleItem(title=self._kodi.localize(30042),  # My recent items
                       url_dict=dict(action=actions.LISTING_RECENT, use_favorites=True),
                       is_playable=False,
-                      art_dict=dict(thumb='DefaultRecentlyAddedEpisodes.png', icon='DefaultRecentlyAddedEpisodes.png', fanart='DefaultRecentlyAddedEpisodes.png'),
+                      art_dict=dict(thumb='DefaultRecentlyAddedEpisodes.png',
+                                    icon='DefaultRecentlyAddedEpisodes.png',
+                                    fanart='DefaultRecentlyAddedEpisodes.png'),
                       video_dict=dict(plot=self._kodi.localize(30043))),
             TitleItem(title=self._kodi.localize(30044),  # My soon offline
                       url_dict=dict(action=actions.LISTING_OFFLINE, use_favorites=True),

--- a/test/xbmcaddon.py
+++ b/test/xbmcaddon.py
@@ -86,7 +86,7 @@ class Addon:
     @staticmethod
     def getSetting(key):
         ''' A working implementation for the xbmcaddon Addon class getSetting() method '''
-        return ADDON_SETTINGS.get(key)
+        return ADDON_SETTINGS.get(key, '')
 
     @staticmethod
     def setSetting(key, value):


### PR DESCRIPTION
The xbmcaddon getSetting() function returns an empty string for non-existing settings. Which makes it unclear if a setting is missing, or simply set to an empty string on purpose.
    
But for boolean values, this is not a real issue.
    
This implements providing a default in case the setting does not exist, or is empty.
    
This PR includes:
- Default values for get_settings()
- Improve kodi xbmcaddon stub
- Fix pylint issues related to long lines