### PR TITLE
always use programUrl (instead of programName)

### DIFF
--- a/resources/lib/favorites.py
+++ b/resources/lib/favorites.py
@@ -6,6 +6,7 @@
 ''' Implementation of Favorites class '''
 
 from __future__ import absolute_import, division, unicode_literals
+from resources.lib import statichelper
 
 try:  # Python 3
     from urllib.request import build_opener, install_opener, ProxyHandler, Request, urlopen
@@ -54,12 +55,12 @@ class Favorites:
                     self._kodi.update_cache('favorites.json', api_json)
         self._favorites = api_json
 
-    def set_favorite(self, program, path, value=True):
+    def set_favorite(self, title, program, value=True):
         ''' Set a program as favorite, and update local copy '''
         import json
 
         self.get_favorites(ttl=60 * 60)
-        if value is self.is_favorite(path):
+        if value is self.is_favorite(program):
             # Already followed/unfollowed, nothing to do
             return True
 
@@ -74,62 +75,54 @@ class Favorites:
             'content-type': 'application/json',
             'Referer': 'https://www.vrt.be/vrtnu',
         }
-        payload = dict(isFavorite=value, programUrl=path, title=program)
+        payload = dict(isFavorite=value, programUrl=statichelper.program_to_url(program, 'short'), title=title)
         data = json.dumps(payload).encode('utf-8')
-        self._kodi.log_notice('URL post: https://video-user-data.vrt.be/favorites/%s' % self.uuid(path), 'Verbose')
-        req = Request('https://video-user-data.vrt.be/favorites/%s' % self.uuid(path), data=data, headers=headers)
+        self._kodi.log_notice('URL post: https://video-user-data.vrt.be/favorites/%s' % self.uuid(program), 'Verbose')
+        req = Request('https://video-user-data.vrt.be/favorites/%s' % self.uuid(program), data=data, headers=headers)
         result = urlopen(req)
         if result.getcode() != 200:
-            self._kodi.show_notification(message="Failed to (un)follow program '%s' at VRT NU" % path)
-            self._kodi.log_error("Failed to (un)follow program '%s' at VRT NU" % path)
+            self._kodi.show_notification(message="Failed to (un)follow program '%s' at VRT NU" % program)
+            self._kodi.log_error("Failed to (un)follow program '%s' at VRT NU" % program)
             return False
         # NOTE: Updates to favorites take a longer time to take effect, so we keep our own cache and use it
-        self._favorites[self.uuid(path)] = dict(value=payload)
+        self._favorites[self.uuid(program)] = dict(value=payload)
         self._kodi.update_cache('favorites.json', self._favorites)
         self.invalidate_caches()
         return True
 
-    def is_favorite(self, path):
+    def is_favorite(self, program):
         ''' Is a program a favorite ? '''
         value = False
-        favorite = self._favorites.get(self.uuid(path))
+        favorite = self._favorites.get(self.uuid(program))
         if favorite is not None:
             value = favorite.get('value', dict(isFavorite=False)).get('isFavorite', False)
         return value
 
-    def follow(self, program, path):
+    def follow(self, title, program):
         ''' Follow your favorite program '''
-        ok = self.set_favorite(program, path, True)
+        ok = self.set_favorite(title, program, True)
         if ok:
-            self._kodi.show_notification(message='Follow ' + program)
+            self._kodi.show_notification(message='Follow ' + title)
             self._kodi.container_refresh()
 
-    def unfollow(self, program, path):
+    def unfollow(self, title, program):
         ''' Unfollow your favorite program '''
-        ok = self.set_favorite(program, path, False)
+        ok = self.set_favorite(title, program, False)
         if ok:
-            self._kodi.show_notification(message='Unfollow ' + program)
+            self._kodi.show_notification(message='Unfollow ' + title)
             self._kodi.container_refresh()
 
-    def uuid(self, path):
-        ''' Return a favorite uuid, used for lookups in favorites dict '''
-        return path.replace('/', '').replace('-', '')
-
-    def name(self, path):
-        ''' Return the favorite name '''
-        try:
-            return path.replace('.relevant/', '/').split('/')[-2]
-        except IndexError:
-            # FIXME: Investigate when this fails !
-            return path
-
-    def names(self):
-        ''' Return all favorite names '''
-        return [self.name(p.get('value').get('programUrl')) for p in self._favorites.values() if p.get('value').get('isFavorite')]
+    def uuid(self, program):
+        ''' Convert a program url component (e.g. de-campus-cup) to a favorite uuid (e.g. vrtnuazdecampuscup), used for lookups in favorites dict '''
+        return 'vrtnuaz' + program.replace('-', '')
 
     def titles(self):
         ''' Return all favorite titles '''
         return [p.get('value').get('title') for p in self._favorites.values() if p.get('value').get('isFavorite')]
+
+    def programs(self):
+        ''' Return all favorite programs '''
+        return [statichelper.url_to_program(p.get('value').get('programUrl')) for p in self._favorites.values() if p.get('value').get('isFavorite')]
 
     def invalidate_caches(self):
         ''' Invalidate caches that rely on favorites '''

--- a/resources/lib/router.py
+++ b/resources/lib/router.py
@@ -49,10 +49,10 @@ def router(argv):
 
     # Actions requiring _favorites as well
     if action == actions.FOLLOW:
-        _favorites.follow(program=params.get('program'), path=params.get('path'))
+        _favorites.follow(title=params.get('title'), program=params.get('program'))
         return
     if action == actions.UNFOLLOW:
-        _favorites.unfollow(program=params.get('program'), path=params.get('path'))
+        _favorites.unfollow(title=params.get('title'), program=params.get('program'))
         return
     if action == actions.REFRESH_FAVORITES:
         _favorites.get_favorites(ttl=0)
@@ -109,11 +109,11 @@ def router(argv):
         return
     if action == actions.LISTING_EPISODES:
         _favorites.get_favorites(ttl=60 * 60)
-        _vrtplayer.show_episodes(path=params.get('video_url'))
+        _vrtplayer.show_episodes(program=params.get('program'), season=params.get('season'))
         return
     if action == actions.LISTING_ALL_EPISODES:
         _favorites.get_favorites(ttl=60 * 60)
-        _vrtplayer.show_all_episodes(path=params.get('video_url'))
+        _vrtplayer.show_all_episodes(program=params.get('program'))
         return
     if action == actions.SEARCH:
         _favorites.get_favorites(ttl=60 * 60)

--- a/resources/lib/statichelper.py
+++ b/resources/lib/statichelper.py
@@ -34,11 +34,36 @@ def convert_html_to_kodilabel(text):
     return unescape(text).strip()
 
 
-def unique_path(path):
-    ''' Create a unique path to be used in VRT favorites '''
-    if path.startswith('//www.vrt.be/vrtnu'):
-        return path.replace('//www.vrt.be/vrtnu/', '/vrtnu/').replace('.relevant/', '/')
-    return path
+def program_to_url(program, url_type):
+    ''' Convert a program url component (e.g. de-campus-cup) to a short programUrl (e.g. /vrtnu/a-z/de-campus-cup/)
+        or to a long programUrl (e.g. //www.vrt.be/vrtnu/a-z/de-campus-cup/)
+    '''
+    url = None
+    if program:
+        # short programUrl
+        if url_type == 'short':
+            url = '/vrtnu/a-z/' + program + '/'
+        # long programUrl
+        elif url_type == 'long':
+            url = '//www.vrt.be/vrtnu/a-z/' + program + '/'
+    return url
+
+
+def url_to_program(url):
+    ''' Convert a targetUrl (e.g. //www.vrt.be/vrtnu/a-z/de-campus-cup.relevant/), a short programUrl (e.g. /vrtnu/a-z/de-campus-cup/)
+        or a long programUrl (e.g. //www.vrt.be/vrtnu/a-z/de-campus-cup/) to a program url component (e.g. de-campus-cup)
+    '''
+    program = None
+    # targetUrl
+    if url.startswith('//www.vrt.be/vrtnu/a-z/') and url.endswith('.relevant/'):
+        program = url.replace('//www.vrt.be/vrtnu/a-z/', '').replace('.relevant/', '')
+    # short programUrl
+    elif url.startswith('/vrtnu/a-z/'):
+        program = url.replace('/vrtnu/a-z/', '').rstrip('/')
+    # long programUrl
+    elif url.startswith('//www.vrt.be/vrtnu/a-z/'):
+        program = url.replace('//www.vrt.be/vrtnu/a-z/', '').rstrip('/')
+    return program
 
 
 def shorten_link(url):

--- a/resources/lib/vrtplayer.py
+++ b/resources/lib/vrtplayer.py
@@ -103,7 +103,7 @@ class VRTPlayer:
         self._kodi.show_listing(favorites_items)
 
         # Show dialog when no favorites were found
-        if not self._favorites.names():
+        if not self._favorites.titles():
             self._kodi.show_ok_dialog(heading=self._kodi.localize(30415), message=self._kodi.localize(30416))
 
     def show_tvshow_menu_items(self, category=None, use_favorites=False):
@@ -131,14 +131,14 @@ class VRTPlayer:
         channel_items = self._apihelper.get_channel_items(action=actions.PLAY, channels=['een', 'canvas', 'sporza', 'ketnet-jr', 'ketnet', 'stubru', 'mnm'])
         self._kodi.show_listing(channel_items, cache=False)
 
-    def show_episodes(self, path):
+    def show_episodes(self, program, season=None):
         ''' The VRT NU add-on episodes listing menu '''
-        episode_items, sort, ascending, content = self._apihelper.get_episode_items(path=path, show_seasons=True)
+        episode_items, sort, ascending, content = self._apihelper.get_episode_items(program=program, season=season, show_seasons=True)
         self._kodi.show_listing(episode_items, sort=sort, ascending=ascending, content=content)
 
-    def show_all_episodes(self, path):
+    def show_all_episodes(self, program):
         ''' The VRT NU add-on '* All seasons' listing menu '''
-        episode_items, sort, ascending, content = self._apihelper.get_episode_items(path=path)
+        episode_items, sort, ascending, content = self._apihelper.get_episode_items(program=program)
         self._kodi.show_listing(episode_items, sort=sort, ascending=ascending, content=content)
 
     def show_recent(self, page=0, use_favorites=False):
@@ -207,7 +207,7 @@ class VRTPlayer:
 
     def play_latest_episode(self, params):
         ''' A hidden feature in the VRT NU add-on to play the latest episode of a program '''
-        video = self._apihelper.get_latest_episode(params.get('tvshow'))
+        video = self._apihelper.get_latest_episode(params.get('program'))
         if not video:
             self._kodi.log_error('Play latest episode failed, params %s' % params)
             self._kodi.show_ok_dialog(message=self._kodi.localize(30954))

--- a/test/apihelpertests.py
+++ b/test/apihelpertests.py
@@ -24,28 +24,28 @@ class ApiHelperTests(unittest.TestCase):
     _apihelper = vrtapihelper.VRTApiHelper(_kodi, _favorites)
 
     def test_get_api_data_single_season(self):
-        title_items, sort, ascending, content = self._apihelper.get_episode_items(path='/vrtnu/a-z/het-journaal.relevant/', show_seasons=True)
+        title_items, sort, ascending, content = self._apihelper.get_episode_items(program='het-journaal', show_seasons=True)
         self.assertTrue(121 < len(title_items) < 140, 'We got %s items instead.' % len(title_items))
         self.assertEqual(sort, 'dateadded')
         self.assertFalse(ascending)
         self.assertEqual(content, 'episodes')
 
     def test_get_api_data_multiple_seasons(self):
-        title_items, sort, ascending, content = self._apihelper.get_episode_items(path='/vrtnu/a-z/thuis.relevant/', show_seasons=True)
+        title_items, sort, ascending, content = self._apihelper.get_episode_items(program='thuis', show_seasons=True)
         self.assertTrue(len(title_items) < 5)
         self.assertEqual(sort, 'label')
         self.assertFalse(ascending)
         self.assertEqual(content, 'seasons')
 
     def test_get_api_data_specific_season(self):
-        title_items, sort, ascending, content = self._apihelper.get_episode_items(path='/vrtnu/a-z/pano.relevant/', show_seasons=True)
+        title_items, sort, ascending, content = self._apihelper.get_episode_items(program='pano', show_seasons=True)
         self.assertEqual(len(title_items), 4)
         self.assertEqual(sort, 'label')
         self.assertFalse(ascending)
         self.assertEqual(content, 'seasons')
 
     def test_get_api_data_specific_season_without_broadcastdate(self):
-        title_items, sort, ascending, content = self._apihelper.get_episode_items(path='/vrtnu/a-z/postbus-x.relevant/', show_seasons=True)
+        title_items, sort, ascending, content = self._apihelper.get_episode_items(program='postbus-x', show_seasons=True)
         self.assertEqual(len(title_items), 3)
         self.assertEqual(sort, 'label')
         self.assertTrue(ascending)
@@ -85,8 +85,8 @@ class ApiHelperTests(unittest.TestCase):
 
     def test_get_tvshows(self):
         ''' Test items, sort and order '''
-        path = 'nieuws-en-actua'
-        tvshow_items = self._apihelper.get_tvshow_items(path)
+        category = 'nieuws-en-actua'
+        tvshow_items = self._apihelper.get_tvshow_items(category=category)
         self.assertTrue(tvshow_items)
 
     def test_tvshows(self):
@@ -101,6 +101,12 @@ class ApiHelperTests(unittest.TestCase):
         channel_studios = [c.get('studio') for c in CHANNELS] + bogus_brands
         for tvshow in tvshow_items:
             self.assertTrue(tvshow.video_dict['studio'] in channel_studios, '%s | %s | %s' % (tvshow.title, tvshow.video_dict['studio'], channel_studios))
+
+    def test_get_latest_episode(self):
+        video = self._apihelper.get_latest_episode(program='het-journaal')
+        self.assertTrue(len(video) == 2)
+        self.assertTrue(video.get('video_id') is not None)
+        self.assertTrue(video.get('publication_id') is not None)
 
 
 if __name__ == '__main__':

--- a/test/favoritestests.py
+++ b/test/favoritestests.py
@@ -25,21 +25,27 @@ class TestFavorites(unittest.TestCase):
     _favorites = favorites.Favorites(_kodi, _tokenresolver)
 
     def test_follow_unfollow(self):
-        program = 'Winteruur'
-        program_path = '/vrtnu/a-z/winteruur/'
-        self._favorites.follow(program, program_path)
-        self.assertTrue(self._favorites.is_favorite(program_path))
+        programs = [
+            {'program_title': 'Winteruur', 'program': 'winteruur'},
+            {'program_title': 'De Campus Cup', 'program': 'de-campus-cup'},
+            {'program_title': 'De Afspraak op vrijdag', 'program': 'de-afspraak-op-vrijdag'}
+        ]
+        for program_item in programs:
+            program_title = program_item.get('program_title')
+            program = program_item.get('program')
+            self._favorites.follow(title=program_title, program=program)
+            self.assertTrue(self._favorites.is_favorite(program))
 
-        self._favorites.unfollow(program, program_path)
-        self.assertFalse(self._favorites.is_favorite(program_path))
+            self._favorites.unfollow(title=program_title, program=program)
+            self.assertFalse(self._favorites.is_favorite(program))
 
-        self._favorites.follow(program, program_path)
-        self.assertTrue(self._favorites.is_favorite(program_path))
+            self._favorites.follow(title=program_title, program=program)
+            self.assertTrue(self._favorites.is_favorite(program))
 
-    def test_names(self):
-        names = self._favorites.names()
-        self.assertTrue(names)
-        print(names)
+    def test_programs(self):
+        programs = self._favorites.programs()
+        self.assertTrue(programs)
+        print(programs)
 
     def test_titles(self):
         titles = self._favorites.titles()

--- a/test/routertests.py
+++ b/test/routertests.py
@@ -35,11 +35,11 @@ class TestRouter(unittest.TestCase):
 
     # LISTING_EPISODES = 'listingepisodes'
     def test_episodes_menu(self):
-        router.router(['plugin://plugin.video.vrt.nu', '0', '?action=listingepisodes&video_url=/vrtnu/a-z/het-journaal.relevant/'])
+        router.router(['plugin://plugin.video.vrt.nu', '0', '?action=listingepisodes&program=het-journaal'])
 
     # LISTING_ALL_EPISODES = 'listingallepisodes'
     def test_all_episodes_menu(self):
-        router.router(['plugin://plugin.video.vrt.nu', '0', '?action=listingallepisodes&video_url=/vrtnu/a-z/thuis.relevant/'])
+        router.router(['plugin://plugin.video.vrt.nu', '0', '?action=listingallepisodes&program=thuis'])
 
     # LISTING_CATEGORIES = 'listingcategories'
     def test_categories_menu(self):
@@ -80,11 +80,11 @@ class TestRouter(unittest.TestCase):
 
     # FOLLOW = 'follow'
     def test_follow_action(self):
-        router.router(['plugin://plugin.video.vrt.nu', '0', '?action=follow&program=Thuis&path=thuis'])
+        router.router(['plugin://plugin.video.vrt.nu', '0', '?action=follow&title=Thuis&program=thuis'])
 
     # UNFOLLOW = 'unfollow'
     def test_unfollow_action(self):
-        router.router(['plugin://plugin.video.vrt.nu', '0', '?action=unfollow&program=Thuis&path=thuis'])
+        router.router(['plugin://plugin.video.vrt.nu', '0', '?action=unfollow&title=Thuis&program=thuis'])
 
     # CLEAR_COOKIES = 'deletetokens'
     def test_clear_cookies_action(self):

--- a/test/vrtplayertests.py
+++ b/test/vrtplayertests.py
@@ -27,47 +27,47 @@ class TestVRTPlayer(unittest.TestCase):
     _vrtplayer = vrtplayer.VRTPlayer(_kodi, _favorites, _apihelper)
 
     def test_show_videos_single_episode_shows_videos(self):
-        path = '/vrtnu/a-z/marathonradio.relevant/'
-        episode_items, sort, ascending, content = self._apihelper.get_episode_items(path=path)
-        self.assertTrue(episode_items, msg=path)
+        program = 'marathonradio'
+        episode_items, sort, ascending, content = self._apihelper.get_episode_items(program=program)
+        self.assertTrue(episode_items, msg=program)
         self.assertEqual(sort, 'dateadded')
         self.assertFalse(ascending)
         self.assertEqual(content, 'episodes')
 
-        self._vrtplayer.show_episodes(path)
+        self._vrtplayer.show_episodes(program)
         # self.assertTrue(self._kodi.show_listing.called)
 
     def test_show_videos_single_season_shows_videos(self):
-        path = '/vrtnu/a-z/het-weer.relevant/'
-        episode_items, sort, ascending, content = self._apihelper.get_episode_items(path=path)
-        self.assertTrue(episode_items, msg=path)
+        program = 'het-weer'
+        episode_items, sort, ascending, content = self._apihelper.get_episode_items(program=program)
+        self.assertTrue(episode_items, msg=program)
         self.assertEqual(sort, 'dateadded')
         self.assertFalse(ascending)
         self.assertEqual(content, 'episodes')
 
-        self._vrtplayer.show_episodes(path)
+        self._vrtplayer.show_episodes(program)
         # self.assertTrue(self._kodi.show_listing.called)
 
     def test_show_videos_multiple_seasons_shows_videos(self):
-        path = '/vrtnu/a-z/pano.relevant/'
-        episode_items, sort, ascending, content = self._apihelper.get_episode_items(path=path, show_seasons=True)
+        program = 'pano'
+        episode_items, sort, ascending, content = self._apihelper.get_episode_items(program=program, show_seasons=True)
         self.assertTrue(episode_items)
         self.assertEqual(sort, 'label')
         self.assertFalse(ascending)
         self.assertEqual(content, 'seasons')
 
-        self._vrtplayer.show_episodes(path)
+        self._vrtplayer.show_episodes(program)
         # self.assertTrue(self._kodi.show_listing.called)
 
     def test_show_videos_specific_seasons_shows_videos(self):
-        path = '/vrtnu/a-z/thuis.relevant/'
-        episode_items, sort, ascending, content = self._apihelper.get_episode_items(path=path, show_seasons=True)
-        self.assertTrue(episode_items, msg=path)
+        program = 'thuis'
+        episode_items, sort, ascending, content = self._apihelper.get_episode_items(program=program, show_seasons=True)
+        self.assertTrue(episode_items, msg=program)
         self.assertEqual(sort, 'label')
         self.assertFalse(ascending)
         self.assertEqual(content, 'seasons')
 
-        self._vrtplayer.show_episodes(path)
+        self._vrtplayer.show_episodes(program)
         # self.assertTrue(self._kodi.show_listing.called)
 
     def test_categories_scraping(self):
@@ -86,8 +86,8 @@ class TestVRTPlayer(unittest.TestCase):
         self.assertTrue(tvshow_items, msg=category['id'])
 
         tvshow = random.choice(tvshow_items)
-        episode_items, sort, ascending, content = self._apihelper.get_episode_items(tvshow.url_dict['video_url'])
-        self.assertTrue(episode_items, msg=tvshow.url_dict['video_url'])
+        episode_items, sort, ascending, content = self._apihelper.get_episode_items(tvshow.url_dict['program'])
+        self.assertTrue(episode_items, msg=tvshow.url_dict['program'])
         self.assertTrue(content in ['episodes', 'seasons'], "Content for '%s' is '%s'" % (tvshow.title, content))
 
     def test_categories(self):


### PR DESCRIPTION
This pull request includes:
- statichelper functions to convert program, short `programUrl`, long `programUrl` and `targetUrl` between each other:
Examples:
program: de-campus-cup
short `programUrl`: /vrtnu/a-z/de-campus-cup/
long `programUrl`: //www.vrt.be/vrtnu/a-z/de-campus-cup/
`targetUrl:` //www.vrt.be/vrtnu/a-z/de-campus-cup.relevant/
- application of these functions in favorites and vrtapihelper classes
- clearer variable names
- fix for an unnoticed "Universiteit van Vlaanderen" seasons menu bug
- all necessary unit test fixes
- cleaner plugin://plugin.video.vrt.nu/ url parameters