### PR TITLE
Add a channel live tv entry in channel listing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,8 @@ reset = \e[0m
 
 .PHONY: test
 
+all: test zip
+
 package: zip
 
 test: sanity unit
@@ -46,7 +48,7 @@ unit:
 	PYTHONPATH=$(CURDIR) python test/favoritestests.py
 	@echo -e "$(white)=$(blue) Unit tests finished successfully.$(reset)"
 
-zip: test clean
+zip: clean
 	@echo -e "$(white)=$(blue) Building new package$(reset)"
 	@rm -f ../$(zip_name)
 	cd ..; zip -r $(zip_name) $(include_paths) -x $(exclude_files)

--- a/resources/lib/kodiwrapper.py
+++ b/resources/lib/kodiwrapper.py
@@ -23,7 +23,8 @@ sort_methods = dict(
     duration=xbmcplugin.SORT_METHOD_DURATION,
     episode=xbmcplugin.SORT_METHOD_EPISODE,
     # genre=xbmcplugin.SORT_METHOD_GENRE,
-    label=xbmcplugin.SORT_METHOD_LABEL_IGNORE_THE,
+    # label=xbmcplugin.SORT_METHOD_LABEL_IGNORE_THE,
+    label=xbmcplugin.SORT_METHOD_LABEL,
     # none=xbmcplugin.SORT_METHOD_UNSORTED,
     # FIXME: We would like to be able to sort by unprefixed title (ignore date/episode prefix)
     # title=xbmcplugin.SORT_METHOD_TITLE_IGNORE_THE,

--- a/resources/lib/vrtapihelper.py
+++ b/resources/lib/vrtapihelper.py
@@ -517,7 +517,7 @@ class VRTApiHelper:
 
         channel_items = []
         for channel in CHANNELS:
-            if channel.get('name') not in channels:
+            if channels and channel.get('name') not in channels:
                 continue
 
             icon = icon_path % channel
@@ -529,9 +529,12 @@ class VRTApiHelper:
                 plot = '[B]%s[/B]' % channel.get('label')
                 is_playable = False
                 context_menu = []
-            else:
-                url_dict = dict(action=action)
+            elif channel.get('live_stream') or channel.get('live_stream_id'):
                 label = self._kodi.localize(30101).format(**channel)
+                # A single Live channel means it is the entry for channel's TV Show listing, so make it stand out
+                if channels and len(channels) == 1:
+                    label = '«%s»' % label
+                url_dict = dict(action=action)
                 is_playable = True
                 if channel.get('name') in ['een', 'canvas', 'ketnet']:
                     if self._showfanart:
@@ -544,6 +547,9 @@ class VRTApiHelper:
                 if channel.get('live_stream_id'):
                     url_dict['video_id'] = channel.get('live_stream_id')
                 context_menu = [('Refresh', 'RunPlugin(%s)' % self._kodi.container_url(refresh='true'))]
+            else:
+                # Not a playable channel
+                continue
 
             channel_items.append(TitleItem(
                 title=label,

--- a/resources/lib/vrtplayer.py
+++ b/resources/lib/vrtplayer.py
@@ -119,16 +119,17 @@ class VRTPlayer:
     def show_channels_menu_items(self, channel=None):
         ''' The VRT NU add-on 'Channels' listing menu '''
         if channel:
+            # Add Live TV channel entry
+            channel_item = self._apihelper.get_channel_items(action=actions.PLAY, channels=[channel])
             tvshow_items = self._apihelper.get_tvshow_items(channel=channel)
-            self._kodi.show_listing(tvshow_items, sort='label', content='tvshows')
+            self._kodi.show_listing(channel_item + tvshow_items, sort='unsorted', content='tvshows')
         else:
-            from resources.lib import CHANNELS
-            channel_items = self._apihelper.get_channel_items(action=actions.LISTING_CHANNELS, channels=[c.get('name') for c in CHANNELS])
+            channel_items = self._apihelper.get_channel_items(action=actions.LISTING_CHANNELS)
             self._kodi.show_listing(channel_items, cache=False)
 
     def show_livestream_items(self):
         ''' The VRT NU add-on 'Live TV' listing menu '''
-        channel_items = self._apihelper.get_channel_items(action=actions.PLAY, channels=['een', 'canvas', 'sporza', 'ketnet-jr', 'ketnet', 'stubru', 'mnm'])
+        channel_items = self._apihelper.get_channel_items(action=actions.PLAY)
         self._kodi.show_listing(channel_items, cache=False)
 
     def show_episodes(self, path):

--- a/test/streamservicetests.py
+++ b/test/streamservicetests.py
@@ -2,7 +2,6 @@
 
 # GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-# pylint: disable=unused-variable
 # pylint: disable=missing-docstring
 
 from __future__ import absolute_import, division, print_function, unicode_literals

--- a/test/vrtplayertests.py
+++ b/test/vrtplayertests.py
@@ -2,7 +2,6 @@
 
 # GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-# pylint: disable=unused-variable
 # pylint: disable=missing-docstring
 
 from __future__ import absolute_import, division, print_function, unicode_literals
@@ -88,6 +87,8 @@ class TestVRTPlayer(unittest.TestCase):
         tvshow = random.choice(tvshow_items)
         episode_items, sort, ascending, content = self._apihelper.get_episode_items(tvshow.url_dict['video_url'])
         self.assertTrue(episode_items, msg=tvshow.url_dict['video_url'])
+        self.assertTrue(sort in ['dateadded', 'episode', 'label', 'unsorted'])
+        self.assertTrue(ascending is True or ascending is False)
         self.assertTrue(content in ['episodes', 'seasons'], "Content for '%s' is '%s'" % (tvshow.title, content))
 
     def test_categories(self):


### PR DESCRIPTION
This PR includes:
- A Live TV entry in the Channel's tvshow listing (as detailed in #313)
- Let `make zip`  create a zip without testing
- Leave `make` or `make all` to do everything
- Remove 2 pylint ignores

This fixes #313