### PR TITLE
Add a Refresh context menu

### DIFF
--- a/resources/lib/__init__.py
+++ b/resources/lib/__init__.py
@@ -139,3 +139,16 @@ class actions:
     REFRESH_FAVORITES = 'refreshfavorites'
     SEARCH = 'search'
     UNFOLLOW = 'unfollow'
+
+
+CACHES = dict(
+    listingallepisodes=[],  # Refresh, but no cache
+    listingaztvshows=['programs.json'],
+    listingcategorytvshows=['category.{category}.json'],
+    listingchannels=['channel.{channel}.json'],
+    listingepisodes=[],  # Refresh, but no cache
+    listinglive=[],  # Refresh, but no cache
+    listingoffline=['{prefix}offline-{page}.json'],
+    listingrecent=['{prefix}recent-{page}.json'],
+    listingtvguide=['schedule.{date}.json'],
+)

--- a/resources/lib/favorites.py
+++ b/resources/lib/favorites.py
@@ -133,7 +133,7 @@ class Favorites:
 
     def invalidate_caches(self):
         ''' Invalidate caches that rely on favorites '''
-        # NOTE/ Do not invalidate favorites cache as we manage it ourselves
+        # NOTE: Do not invalidate favorites cache as we manage it ourselves
         # self._kodi.invalidate_caches('favorites.json')
         self._kodi.invalidate_caches('my-offline-*.json')
         self._kodi.invalidate_caches('my-recent-*.json')

--- a/resources/lib/tvguide.py
+++ b/resources/lib/tvguide.py
@@ -93,6 +93,7 @@ class TVGuide:
                 is_playable=False,
                 art_dict=dict(thumb='DefaultYear.png', icon='DefaultYear.png', fanart='DefaultYear.png'),
                 video_dict=dict(plot=self._kodi.localize_datelong(day)),
+                context_menu=[('Refresh', 'RunPlugin(%s)' % self._kodi.container_url(refresh='true'))],
             ))
         return date_items
 

--- a/resources/lib/vrtapihelper.py
+++ b/resources/lib/vrtapihelper.py
@@ -92,6 +92,7 @@ class VRTApiHelper:
                     context_menu = [(self._kodi.localize(30411), 'RunPlugin(plugin://plugin.video.vrt.nu?%s)' % urlencode(params))]
             else:
                 context_menu = []
+            context_menu.append(('Refresh', 'RunPlugin(%s)' % self._kodi.container_url(refresh='true')))
             # Cut vrtbase url off since it will be added again when searching for episodes
             # (with a-z we dont have the full url)
             video_url = statichelper.add_https_method(tvshow.get('targetUrl')).replace(self._VRT_BASE, '')
@@ -308,6 +309,7 @@ class VRTApiHelper:
                     context_menu = [(self._kodi.localize(30411), 'RunPlugin(plugin://plugin.video.vrt.nu?%s)' % urlencode(params))]
             else:
                 context_menu = []
+            context_menu.append(('Refresh', 'RunPlugin(%s)' % self._kodi.container_url(refresh='true')))
 
             if self._showfanart:
                 thumb = statichelper.add_https_method(episode.get('videoThumbnailUrl', 'DefaultAddonVideo.png'))
@@ -526,6 +528,7 @@ class VRTApiHelper:
                 label = channel.get('label')
                 plot = '[B]%s[/B]' % channel.get('label')
                 is_playable = False
+                context_menu = []
             else:
                 url_dict = dict(action=action)
                 label = self._kodi.localize(30101).format(**channel)
@@ -540,6 +543,7 @@ class VRTApiHelper:
                     url_dict['video_url'] = channel.get('live_stream')
                 if channel.get('live_stream_id'):
                     url_dict['video_id'] = channel.get('live_stream_id')
+                context_menu = [('Refresh', 'RunPlugin(%s)' % self._kodi.container_url(refresh='true'))]
 
             channel_items.append(TitleItem(
                 title=label,
@@ -552,6 +556,7 @@ class VRTApiHelper:
                     studio=channel.get('studio'),
                     mediatype='video',
                 ),
+                context_menu=context_menu,
             ))
 
         return channel_items

--- a/service.py
+++ b/service.py
@@ -19,7 +19,7 @@ class VrtMonitor(xbmc.Monitor):
 
     def onSettingsChanged(self):
         ''' Handler for changes to settings '''
-        _kodi = kodiwrapper.KodiWrapper(None, None)
+        _kodi = kodiwrapper.KodiWrapper(None, None, dict())
         _kodi.log_notice('VRT NU Addon: settings changed')
         _kodi.container_refresh()
 

--- a/test/apihelpertests.py
+++ b/test/apihelpertests.py
@@ -18,7 +18,7 @@ xbmcvfs = __import__('xbmcvfs')
 
 class ApiHelperTests(unittest.TestCase):
 
-    _kodi = kodiwrapper.KodiWrapper(None, 'plugin://plugin.video.vrt.nu')
+    _kodi = kodiwrapper.KodiWrapper(None, 'plugin://plugin.video.vrt.nu', dict())
     _tokenresolver = tokenresolver.TokenResolver(_kodi)
     _favorites = favorites.Favorites(_kodi, _tokenresolver)
     _apihelper = vrtapihelper.VRTApiHelper(_kodi, _favorites)

--- a/test/favoritestests.py
+++ b/test/favoritestests.py
@@ -20,7 +20,7 @@ xbmcaddon.ADDON_SETTINGS['usefavorites'] = 'true'
 
 class TestFavorites(unittest.TestCase):
 
-    _kodi = kodiwrapper.KodiWrapper(None, 'plugin://plugin.video.vrt.nu')
+    _kodi = kodiwrapper.KodiWrapper(None, 'plugin://plugin.video.vrt.nu', dict())
     _tokenresolver = tokenresolver.TokenResolver(_kodi)
     _favorites = favorites.Favorites(_kodi, _tokenresolver)
 

--- a/test/searchtests.py
+++ b/test/searchtests.py
@@ -18,7 +18,7 @@ xbmcvfs = __import__('xbmcvfs')
 
 class TestSearch(unittest.TestCase):
 
-    _kodi = kodiwrapper.KodiWrapper(None, 'plugin.video.vrt.nu')
+    _kodi = kodiwrapper.KodiWrapper(None, 'plugin.video.vrt.nu', dict())
     _tokenresolver = tokenresolver.TokenResolver(_kodi)
     _favorites = favorites.Favorites(_kodi, _tokenresolver)
     _apihelper = vrtapihelper.VRTApiHelper(_kodi, _favorites)

--- a/test/streamservicetests.py
+++ b/test/streamservicetests.py
@@ -30,7 +30,7 @@ yesterday = now + timedelta(days=-1)
 
 class StreamServiceTests(unittest.TestCase):
 
-    _kodi = kodiwrapper.KodiWrapper(None, 'plugin://plugin.video.vrt.nu')
+    _kodi = kodiwrapper.KodiWrapper(None, 'plugin://plugin.video.vrt.nu', dict())
     _tokenresolver = tokenresolver.TokenResolver(_kodi)
     _streamservice = streamservice.StreamService(_kodi, _tokenresolver)
 

--- a/test/tvguidetests.py
+++ b/test/tvguidetests.py
@@ -23,7 +23,7 @@ channels = ['een', 'canvas', 'ketnet']
 
 class TestTVGuide(unittest.TestCase):
 
-    _kodi = kodiwrapper.KodiWrapper(None, 'plugin.video.vrt.nu')
+    _kodi = kodiwrapper.KodiWrapper(None, 'plugin.video.vrt.nu', dict())
     _tvguide = tvguide.TVGuide(_kodi)
 
     def test_tvguide_date_menu(self):

--- a/test/vrtplayertests.py
+++ b/test/vrtplayertests.py
@@ -20,7 +20,7 @@ xbmcvfs = __import__('xbmcvfs')
 
 class TestVRTPlayer(unittest.TestCase):
 
-    _kodi = kodiwrapper.KodiWrapper(None, 'plugin://plugin.video.vrt.nu')
+    _kodi = kodiwrapper.KodiWrapper(None, 'plugin://plugin.video.vrt.nu', dict())
     _tokenresolver = tokenresolver.TokenResolver(_kodi)
     _favorites = favorites.Favorites(_kodi, _tokenresolver)
     _apihelper = vrtapihelper.VRTApiHelper(_kodi, _favorites)


### PR DESCRIPTION
The original implementation was very invasive and touched almost every
API to pass a parameter `use_cache` so the specific cache would be
invalidated.

This is easier but as effective.

This fixes #302 