### PR TITLE
More cleanups to new routing interface

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -4,8 +4,6 @@
 
 ''' This is the actual VRT NU video plugin entry point '''
 
-# pylint: disable=missing-docstring
-
 from __future__ import absolute_import, division, unicode_literals
 import sys
 import routing
@@ -17,183 +15,180 @@ kodi = kodiwrapper.KodiWrapper(globals())
 
 @plugin.route('/')
 def main_menu():
+    ''' The VRT NU plugin main menu '''
     from resources.lib import vrtplayer
-    _vrtplayer = vrtplayer.VRTPlayer(kodi)
-    _vrtplayer.show_main_menu_items()
+    vrtplayer.VRTPlayer(kodi).show_main_menu_items()
 
 
 @plugin.route('/cache/delete')
 @plugin.route('/cache/delete/<cache_file>')
 def delete_cache(cache_file=None):
+    ''' The API interface to delete caches '''
     if cache_file:
         kodi.refresh_caches(cache_file)
-        return
-    kodi.invalidate_caches()
-
-
-@plugin.route('/widevine/install')
-def install_widevine():
-    kodi.install_widevine()
+    else:
+        kodi.invalidate_caches()
 
 
 @plugin.route('/tokens/delete')
 def delete_tokens():
+    ''' The API interface to delete all VRT tokens '''
     from resources.lib import tokenresolver
-    _tokenresolver = tokenresolver.TokenResolver(kodi)
-    _tokenresolver.delete_tokens()
+    tokenresolver.TokenResolver(kodi).delete_tokens()
+
+
+@plugin.route('/widevine/install')
+def install_widevine():
+    ''' The API interface to install Widevine '''
+    kodi.install_widevine()
 
 
 @plugin.route('/follow/<title>/<program>')
 def follow(title, program):
+    ''' The API interface to follow a program used by the context menu '''
     from resources.lib import favorites
-    _favorites = favorites.Favorites(kodi)
-    _favorites.follow(title=title, program=program)
+    favorites.Favorites(kodi).follow(title=title, program=program)
 
 
 @plugin.route('/unfollow/<title>/<program>')
 def unfollow(title, program):
+    ''' The API interface to unfollow a program used by the context menu '''
     from resources.lib import favorites
-    _favorites = favorites.Favorites(kodi)
-    _favorites.unfollow(title=title, program=program)
-
-
-@plugin.route('/play/id/<video_id>')
-@plugin.route('/play/id/<publication_id>/<video_id>')
-def play_id(video_id, publication_id=None):
-    from resources.lib import vrtplayer
-    _vrtplayer = vrtplayer.VRTPlayer(kodi)
-
-    if video_id and publication_id:
-        _vrtplayer.play(dict(publication_id=publication_id, video_id=video_id))
-    elif video_id:
-        _vrtplayer.play(dict(video_id=video_id))
-
-
-@plugin.route('/play/url/<path:video_url>')
-def play_url(video_url):
-    from resources.lib import vrtplayer
-    _vrtplayer = vrtplayer.VRTPlayer(kodi)
-    _vrtplayer.play(dict(video_url=video_url))
-
-
-@plugin.route('/play/lastepisode/<program>')
-def play_last(program):
-    from resources.lib import vrtplayer
-    _vrtplayer = vrtplayer.VRTPlayer(kodi)
-    _vrtplayer.play_latest_episode(program)
+    favorites.Favorites(kodi).unfollow(title=title, program=program)
 
 
 @plugin.route('/favorites')
 def favorites_menu():
+    ''' The favorites My program menu '''
     from resources.lib import vrtplayer
-    _vrtplayer = vrtplayer.VRTPlayer(kodi)
-    _vrtplayer.show_favorites_menu_items()
+    vrtplayer.VRTPlayer(kodi).show_favorites_menu_items()
 
 
 @plugin.route('/favorites/programs')
 def favorites_programs():
+    ''' The favorites A-Z listing '''
     from resources.lib import vrtplayer
-    _vrtplayer = vrtplayer.VRTPlayer(kodi)
-    _vrtplayer.show_tvshow_menu_items(use_favorites=True)
+    vrtplayer.VRTPlayer(kodi).show_tvshow_menu_items(use_favorites=True)
 
 
 @plugin.route('/favorites/recent')
 @plugin.route('/favorites/recent/<page>')
 def favorites_recent(page=1):
+    ''' The favorites recent listing '''
     from resources.lib import vrtplayer
-    _vrtplayer = vrtplayer.VRTPlayer(kodi)
-    _vrtplayer.show_recent(page=page, use_favorites=True)
+    vrtplayer.VRTPlayer(kodi).show_recent(page=page, use_favorites=True)
 
 
 @plugin.route('/favorites/offline')
 @plugin.route('/favorites/offline/<page>')
 def favorites_offline(page=1):
+    ''' The favorites offline listing '''
     from resources.lib import vrtplayer
-    _vrtplayer = vrtplayer.VRTPlayer(kodi)
-    _vrtplayer.show_offline(page=page, use_favorites=True)
+    vrtplayer.VRTPlayer(kodi).show_offline(page=page, use_favorites=True)
 
 
 @plugin.route('/favorites/refresh')
 def favorites_refresh():
+    ''' The API interface to refresh the favorites cache '''
     from resources.lib import favorites
-    _favorites = favorites.Favorites(kodi)
-    _favorites.get_favorites(ttl=0)
+    favorites.Favorites(kodi).get_favorites(ttl=0)
 
 
 @plugin.route('/programs')
 @plugin.route('/programs/<program>')
 @plugin.route('/programs/<program>/<season>')
 def programs(program=None, season=None):
+    ''' The programs A-Z / seasons / episode listing '''
     from resources.lib import vrtplayer
-    _vrtplayer = vrtplayer.VRTPlayer(kodi)
     if program:
-        _vrtplayer.show_episodes(program, season)
-        return
-    _vrtplayer.show_tvshow_menu_items()
+        vrtplayer.VRTPlayer(kodi).show_episodes(program, season)
+    else:
+        vrtplayer.VRTPlayer(kodi).show_tvshow_menu_items()
 
 
 @plugin.route('/categories')
 @plugin.route('/categories/<category>')
 def categories(category=None):
+    ''' The categories menu and listing '''
     from resources.lib import vrtplayer
-    _vrtplayer = vrtplayer.VRTPlayer(kodi)
     if category:
-        _vrtplayer.show_tvshow_menu_items(category=category)
-        return
-    _vrtplayer.show_category_menu_items()
+        vrtplayer.VRTPlayer(kodi).show_tvshow_menu_items(category=category)
+    else:
+        vrtplayer.VRTPlayer(kodi).show_category_menu_items()
 
 
 @plugin.route('/channels')
 @plugin.route('/channels/<channel>')
 def channels(channel=None):
+    ''' The channels menu and listing '''
     from resources.lib import vrtplayer
-    _vrtplayer = vrtplayer.VRTPlayer(kodi)
-    _vrtplayer.show_channels_menu_items(channel=channel)
+    vrtplayer.VRTPlayer(kodi).show_channels_menu_items(channel=channel)
 
 
 @plugin.route('/livetv')
 def livetv():
+    ''' The livetv menu '''
     from resources.lib import vrtplayer
-    _vrtplayer = vrtplayer.VRTPlayer(kodi)
-    _vrtplayer.show_livestream_items()
+    vrtplayer.VRTPlayer(kodi).show_livestream_items()
 
 
 @plugin.route('/recent')
 @plugin.route('/recent/<page>')
 def recent(page=1):
+    ''' The most recent items listing '''
     from resources.lib import vrtplayer
-    _vrtplayer = vrtplayer.VRTPlayer(kodi)
-    _vrtplayer.show_recent(page=page)
+    vrtplayer.VRTPlayer(kodi).show_recent(page=page)
 
 
 @plugin.route('/offline')
 @plugin.route('/offline/<page>')
 def offline(page=1):
+    ''' The soon ogline listing '''
     from resources.lib import vrtplayer
-    _vrtplayer = vrtplayer.VRTPlayer(kodi)
-    _vrtplayer.show_offline(page=page)
+    vrtplayer.VRTPlayer(kodi).show_offline(page=page)
 
 
 @plugin.route('/tvguide')
 @plugin.route('/tvguide/<date>')
 @plugin.route('/tvguide/<date>/<channel>')
 def tv_guide(date=None, channel=None):
+    ''' The TV guide menu and listings '''
     from resources.lib import tvguide
-    _tvguide = tvguide.TVGuide(kodi)
-    _tvguide.show_tvguide(date=date, channel=channel)
+    tvguide.TVGuide(kodi).show_tvguide(date=date, channel=channel)
 
 
 @plugin.route('/search')
 @plugin.route('/search/<search_string>')
 @plugin.route('/search/<search_string>/<page>')
 def search(search_string=None, page=1):
+    ''' The Search interface and query listing '''
     from resources.lib import vrtplayer
-    _vrtplayer = vrtplayer.VRTPlayer(kodi)
-    _vrtplayer.search(search_string=search_string, page=page)
+    vrtplayer.VRTPlayer(kodi).search(search_string=search_string, page=page)
 
 
-def test(path):
-    plugin.run(path)
+@plugin.route('/play/id/<video_id>')
+@plugin.route('/play/id/<publication_id>/<video_id>')
+def play_id(video_id, publication_id=None):
+    ''' The API interface to play a video by video_id and/or publication_id '''
+    from resources.lib import vrtplayer
+    if video_id and publication_id:
+        vrtplayer.VRTPlayer(kodi).play(dict(publication_id=publication_id, video_id=video_id))
+    elif video_id:
+        vrtplayer.VRTPlayer(kodi).play(dict(video_id=video_id))
+
+
+@plugin.route('/play/url/<path:video_url>')
+def play_url(video_url):
+    ''' The API interface to play a video by using a URL '''
+    from resources.lib import vrtplayer
+    vrtplayer.VRTPlayer(kodi).play(dict(video_url=video_url))
+
+
+@plugin.route('/play/lastepisode/<program>')
+def play_last(program):
+    ''' The API interface to play the latest episode of a program '''
+    from resources.lib import vrtplayer
+    vrtplayer.VRTPlayer(kodi).play_latest_episode(program)
 
 
 if __name__ == '__main__':

--- a/resources/lib/streamservice.py
+++ b/resources/lib/streamservice.py
@@ -7,7 +7,6 @@
 from __future__ import absolute_import, division, unicode_literals
 import json
 import re
-
 from resources.lib.helperobjects import ApiData, StreamURLS
 
 try:  # Python 3

--- a/resources/lib/vrtplayer.py
+++ b/resources/lib/vrtplayer.py
@@ -5,8 +5,9 @@
 ''' Implements a VRTPlayer class '''
 
 from __future__ import absolute_import, division, unicode_literals
-from resources.lib import favorites, statichelper, streamservice, tokenresolver, vrtapihelper
+from resources.lib import favorites, vrtapihelper
 from resources.lib.helperobjects import TitleItem
+from resources.lib.statichelper import realpage
 
 
 class VRTPlayer:
@@ -147,7 +148,7 @@ class VRTPlayer:
         ''' The VRT NU add-on 'Most recent' and 'My most recent' listing menu '''
         # My programs menus may need more up-to-date favorites
         self._favorites.get_favorites(ttl=5 * 60 if use_favorites else 60 * 60)
-        page = statichelper.realpage(page)
+        page = realpage(page)
         episode_items, sort, ascending, content = self._apihelper.get_episode_items(page=page, use_favorites=use_favorites, variety='recent')
 
         # Add 'More...' entry at the end
@@ -170,7 +171,7 @@ class VRTPlayer:
         ''' The VRT NU add-on 'Soon offline' and 'My soon offline' listing menu '''
         # My programs menus may need more up-to-date favorites
         self._favorites.get_favorites(ttl=5 * 60 if use_favorites else 60 * 60)
-        page = statichelper.realpage(page)
+        page = realpage(page)
         episode_items, sort, ascending, content = self._apihelper.get_episode_items(page=page, use_favorites=use_favorites, variety='offline')
 
         # Add 'More...' entry at the end
@@ -192,7 +193,7 @@ class VRTPlayer:
     def search(self, search_string=None, page=None):
         ''' The VRT NU add-on Search functionality and results '''
         self._favorites.get_favorites(ttl=60 * 60)
-        page = statichelper.realpage(page)
+        page = realpage(page)
 
         if search_string is None:
             search_string = self._kodi.get_search_string()
@@ -232,6 +233,7 @@ class VRTPlayer:
 
     def play(self, params):
         ''' A wrapper for playing video items '''
+        from resources.lib import streamservice, tokenresolver
         _tokenresolver = tokenresolver.TokenResolver(self._kodi)
         _streamservice = streamservice.StreamService(self._kodi, _tokenresolver)
         stream = _streamservice.get_stream(params)

--- a/test/routingtests.py
+++ b/test/routingtests.py
@@ -18,136 +18,136 @@ xbmcvfs = __import__('xbmcvfs')
 class TestRouter(unittest.TestCase):
 
     def test_main_menu(self):
-        addon.test(['plugin://plugin.video.vrt.nu/', '0', ''])
+        addon.plugin.run(['plugin://plugin.video.vrt.nu/', '0', ''])
         self.assertEqual(addon.plugin.url_for(addon.main_menu), 'plugin://plugin.video.vrt.nu/')
 
     # Favorites menu: '/favorites'
     def test_favorites(self):
-        addon.test(['plugin://plugin.video.vrt.nu/favorites', '0', ''])
-        addon.test(['plugin://plugin.video.vrt.nu/favorites/programs', '0', ''])
-        addon.test(['plugin://plugin.video.vrt.nu/favorites/recent', '0', ''])
-        addon.test(['plugin://plugin.video.vrt.nu/favorites/recent/2', '0', ''])
+        addon.plugin.run(['plugin://plugin.video.vrt.nu/favorites', '0', ''])
+        addon.plugin.run(['plugin://plugin.video.vrt.nu/favorites/programs', '0', ''])
+        addon.plugin.run(['plugin://plugin.video.vrt.nu/favorites/recent', '0', ''])
+        addon.plugin.run(['plugin://plugin.video.vrt.nu/favorites/recent/2', '0', ''])
         self.assertEqual(addon.plugin.url_for(addon.favorites_recent, page=2), 'plugin://plugin.video.vrt.nu/favorites/recent/2')
-        addon.test(['plugin://plugin.video.vrt.nu/favorites/offline', '0', ''])
+        addon.plugin.run(['plugin://plugin.video.vrt.nu/favorites/offline', '0', ''])
 
     # A-Z menu: '/programs'
     def test_az_menu(self):
-        addon.test(['plugin://plugin.video.vrt.nu/programs', '0', ''])
+        addon.plugin.run(['plugin://plugin.video.vrt.nu/programs', '0', ''])
         self.assertEqual(addon.plugin.url_for(addon.programs), 'plugin://plugin.video.vrt.nu/programs')
 
     # Episodes menu: '/programs/<program>'
     def test_episodes_menu(self):
-        addon.test(['plugin://plugin.video.vrt.nu/programs/thuis', '0', ''])
+        addon.plugin.run(['plugin://plugin.video.vrt.nu/programs/thuis', '0', ''])
         self.assertEqual(addon.plugin.url_for(addon.programs, program='thuis'), 'plugin://plugin.video.vrt.nu/programs/thuis')
-        addon.test(['plugin://plugin.video.vrt.nu/programs/de-campus-cup', '0', ''])
+        addon.plugin.run(['plugin://plugin.video.vrt.nu/programs/de-campus-cup', '0', ''])
         self.assertEqual(addon.plugin.url_for(addon.programs, program='de-campus-cup'), 'plugin://plugin.video.vrt.nu/programs/de-campus-cup')
 
     # Categories menu: '/categories'
     def test_categories_menu(self):
-        addon.test(['plugin://plugin.video.vrt.nu/categories', '0', ''])
+        addon.plugin.run(['plugin://plugin.video.vrt.nu/categories', '0', ''])
         self.assertEqual(addon.plugin.url_for(addon.categories), 'plugin://plugin.video.vrt.nu/categories')
 
     # Categories programs menu: '/categories/<category>'
     def test_categories_tvshow_menu(self):
-        addon.test(['plugin://plugin.video.vrt.nu/categories/docu', '0', ''])
+        addon.plugin.run(['plugin://plugin.video.vrt.nu/categories/docu', '0', ''])
         self.assertEqual(addon.plugin.url_for(addon.categories, category='docu'), 'plugin://plugin.video.vrt.nu/categories/docu')
-        addon.test(['plugin://plugin.video.vrt.nu/categories/kinderen', '0', ''])
+        addon.plugin.run(['plugin://plugin.video.vrt.nu/categories/kinderen', '0', ''])
         self.assertEqual(addon.plugin.url_for(addon.categories, category='kinderen'), 'plugin://plugin.video.vrt.nu/categories/kinderen')
 
     # Channels menu = '/channels/<channel>'
     def test_channels_menu(self):
-        addon.test(['plugin://plugin.video.vrt.nu/channels', '0', ''])
+        addon.plugin.run(['plugin://plugin.video.vrt.nu/channels', '0', ''])
         self.assertEqual(addon.plugin.url_for(addon.channels), 'plugin://plugin.video.vrt.nu/channels')
-        addon.test(['plugin://plugin.video.vrt.nu/channels/ketnet', '0', ''])
+        addon.plugin.run(['plugin://plugin.video.vrt.nu/channels/ketnet', '0', ''])
         self.assertEqual(addon.plugin.url_for(addon.channels, channel='ketnet'), 'plugin://plugin.video.vrt.nu/channels/ketnet')
 
     # Live TV menu: '/livetv'
     def test_livetv_menu(self):
-        addon.test(['plugin://plugin.video.vrt.nu/livetv', '0', ''])
+        addon.plugin.run(['plugin://plugin.video.vrt.nu/livetv', '0', ''])
         self.assertEqual(addon.plugin.url_for(addon.livetv), 'plugin://plugin.video.vrt.nu/livetv')
 
     # Most recent menu: '/recent/<page>'
     def test_recent_menu(self):
-        addon.test(['plugin://plugin.video.vrt.nu/recent', '0', ''])
+        addon.plugin.run(['plugin://plugin.video.vrt.nu/recent', '0', ''])
         self.assertEqual(addon.plugin.url_for(addon.recent), 'plugin://plugin.video.vrt.nu/recent')
-        addon.test(['plugin://plugin.video.vrt.nu/recent/2', '0', ''])
+        addon.plugin.run(['plugin://plugin.video.vrt.nu/recent/2', '0', ''])
         self.assertEqual(addon.plugin.url_for(addon.recent, page=2), 'plugin://plugin.video.vrt.nu/recent/2')
 
     # Soon offline menu: '/offline/<page>'
     def test_offline_menu(self):
-        addon.test(['plugin://plugin.video.vrt.nu/offline', '0', ''])
+        addon.plugin.run(['plugin://plugin.video.vrt.nu/offline', '0', ''])
         self.assertEqual(addon.plugin.url_for(addon.offline), 'plugin://plugin.video.vrt.nu/offline')
 
     # TV guide menu: '/tvguide/<date>/<channel>'
     def test_tvguide_date_menu(self):
-        addon.test(['plugin://plugin.video.vrt.nu/tvguide', '0', ''])
+        addon.plugin.run(['plugin://plugin.video.vrt.nu/tvguide', '0', ''])
         self.assertEqual(addon.plugin.url_for(addon.tv_guide), 'plugin://plugin.video.vrt.nu/tvguide')
-        addon.test(['plugin://plugin.video.vrt.nu/tvguide/today', '0', ''])
+        addon.plugin.run(['plugin://plugin.video.vrt.nu/tvguide/today', '0', ''])
         self.assertEqual(addon.plugin.url_for(addon.tv_guide, date='today'), 'plugin://plugin.video.vrt.nu/tvguide/today')
-        addon.test(['plugin://plugin.video.vrt.nu/tvguide/today/canvas', '0', ''])
+        addon.plugin.run(['plugin://plugin.video.vrt.nu/tvguide/today/canvas', '0', ''])
         self.assertEqual(addon.plugin.url_for(addon.tv_guide, date='today', channel='canvas'), 'plugin://plugin.video.vrt.nu/tvguide/today/canvas')
 
     # Search VRT NU menu: '/search/<search_string>/<page>'
     def test_search_menu(self):
-        addon.test(['plugin://plugin.video.vrt.nu/search', '0', ''])
+        addon.plugin.run(['plugin://plugin.video.vrt.nu/search', '0', ''])
         self.assertEqual(addon.plugin.url_for(addon.search), 'plugin://plugin.video.vrt.nu/search')
-        addon.test(['plugin://plugin.video.vrt.nu/search/dag', '0', ''])
+        addon.plugin.run(['plugin://plugin.video.vrt.nu/search/dag', '0', ''])
         self.assertEqual(addon.plugin.url_for(addon.search, search_string='dag'), 'plugin://plugin.video.vrt.nu/search/dag')
-        addon.test(['plugin://plugin.video.vrt.nu/search/dag/2', '0', ''])
+        addon.plugin.run(['plugin://plugin.video.vrt.nu/search/dag/2', '0', ''])
         self.assertEqual(addon.plugin.url_for(addon.search, search_string='dag', page=2), 'plugin://plugin.video.vrt.nu/search/dag/2')
 
     # Follow method: '/follow/<program_title>/<program>'
     def test_follow_route(self):
-        addon.test(['plugin://plugin.video.vrt.nu/follow/Thuis/thuis', '0', ''])
+        addon.plugin.run(['plugin://plugin.video.vrt.nu/follow/Thuis/thuis', '0', ''])
         self.assertEqual(addon.plugin.url_for(addon.follow, title='Thuis', program='thuis'), 'plugin://plugin.video.vrt.nu/follow/Thuis/thuis')
 
     # Unfollow method: '/unfollow/<program_title>/<program>'
     def test_unfollow_route(self):
-        addon.test(['plugin://plugin.video.vrt.nu/unfollow/Thuis/thuis', '0', ''])
+        addon.plugin.run(['plugin://plugin.video.vrt.nu/unfollow/Thuis/thuis', '0', ''])
         self.assertEqual(addon.plugin.url_for(addon.unfollow, title='Thuis', program='thuis'), 'plugin://plugin.video.vrt.nu/unfollow/Thuis/thuis')
 
     # Delete tokens method: '/tokens/delete'
     def test_clear_cookies_route(self):
-        addon.test(['plugin://plugin.video.vrt.nu/tokens/delete', '0', ''])
+        addon.plugin.run(['plugin://plugin.video.vrt.nu/tokens/delete', '0', ''])
         self.assertEqual(addon.plugin.url_for(addon.delete_tokens), 'plugin://plugin.video.vrt.nu/tokens/delete')
 
     # Delete cache method: '/cache/delete'
     def test_invalidate_caches_route(self):
-        addon.test(['plugin://plugin.video.vrt.nu/cache/delete', '0', ''])
+        addon.plugin.run(['plugin://plugin.video.vrt.nu/cache/delete', '0', ''])
         self.assertEqual(addon.plugin.url_for(addon.delete_cache), 'plugin://plugin.video.vrt.nu/cache/delete')
 
     # Refresh favorites method: '/favorites/refresh'
     def test_refresh_favorites_route(self):
-        addon.test(['plugin://plugin.video.vrt.nu/favorites/refresh', '0', ''])
+        addon.plugin.run(['plugin://plugin.video.vrt.nu/favorites/refresh', '0', ''])
         self.assertEqual(addon.plugin.url_for(addon.favorites_refresh), 'plugin://plugin.video.vrt.nu/favorites/refresh')
 
     # Play on demand by id = '/play/id/<publication_id>/<video_id>'
     # Achterflap episode 8 available until 31/12/2025
     def test_play_on_demand_by_id_route(self):
-        addon.test(['plugin://plugin.video.vrt.nu/play/id/pbs-pub-1a170972-dea3-4ea3-8c27-62d2442ee8a3/vid-f80fa527-6759-45a7-908d-ec6f0a7b164e', '0', ''])
+        addon.plugin.run(['plugin://plugin.video.vrt.nu/play/id/pbs-pub-1a170972-dea3-4ea3-8c27-62d2442ee8a3/vid-f80fa527-6759-45a7-908d-ec6f0a7b164e', '0', ''])
         self.assertEqual(addon.plugin.url_for(addon.play_id, publication_id='pbs-pub-1a170972-dea3-4ea3-8c27-62d2442ee8a3', video_id='vid-f80fa527-6759-45a7-908d-ec6f0a7b164e'), 'plugin://plugin.video.vrt.nu/play/id/pbs-pub-1a170972-dea3-4ea3-8c27-62d2442ee8a3/vid-f80fa527-6759-45a7-908d-ec6f0a7b164e')
 
     # Play livestream by id = '/play/id/<video_id>'
     # Canvas livestream
     def test_play_livestream_by_id_route(self):
-        addon.test(['plugin://plugin.video.vrt.nu/play/id/vualto_canvas_geo', '0', ''])
+        addon.plugin.run(['plugin://plugin.video.vrt.nu/play/id/vualto_canvas_geo', '0', ''])
         self.assertEqual(addon.plugin.url_for(addon.play_id, video_id='vualto_canvas_geo'), 'plugin://plugin.video.vrt.nu/play/id/vualto_canvas_geo')
 
     # Play on demand by url = '/play/url/<vrtnuwebsite_url>'
     # Achterflap episode 8 available until 31/12/2025
     def test_play_on_demand_by_url_route(self):
-        addon.test(['plugin://plugin.video.vrt.nu/play/url/https://www.vrt.be/vrtnu/a-z/achterflap/1/achterflap-s1a8/', '0', ''])
+        addon.plugin.run(['plugin://plugin.video.vrt.nu/play/url/https://www.vrt.be/vrtnu/a-z/achterflap/1/achterflap-s1a8/', '0', ''])
         self.assertEqual(addon.plugin.url_for(addon.play_url, video_url='https://www.vrt.be/vrtnu/a-z/achterflap/1/achterflap-s1a8/'), 'plugin://plugin.video.vrt.nu/play/url/https://www.vrt.be/vrtnu/a-z/achterflap/1/achterflap-s1a8/')
 
     # Play livestream by url = '/play/url/<vrtnuwebsite_url>'
     # Canvas livestream
     def test_play_livestream_by_url_route(self):
-        addon.test(['plugin://plugin.video.vrt.nu/play/url/https://www.vrt.be/vrtnu/kanalen/canvas/', '0', ''])
+        addon.plugin.run(['plugin://plugin.video.vrt.nu/play/url/https://www.vrt.be/vrtnu/kanalen/canvas/', '0', ''])
         self.assertEqual(addon.plugin.url_for(addon.play_url, video_url='https://www.vrt.be/vrtnu/kanalen/canvas/'), 'plugin://plugin.video.vrt.nu/play/url/https://www.vrt.be/vrtnu/kanalen/canvas/')
 
     # Play last episode method = '/play/lastepisode/<program>'
     def test_play_lastepisode_route(self):
-        addon.test(['plugin://plugin.video.vrt.nu/play/lastepisode/het-journaal', '0', ''])
+        addon.plugin.run(['plugin://plugin.video.vrt.nu/play/lastepisode/het-journaal', '0', ''])
         self.assertEqual(addon.plugin.url_for(addon.play_last, program='het-journaal'), 'plugin://plugin.video.vrt.nu/play/lastepisode/het-journaal')
 
 


### PR DESCRIPTION
This PR includes:
- Adding docstrings to all routes
- Don't instantiate single-purpose objects
- Don't import libraries that are usd infequently in vrtplayer.py
- Remove test() function from addon.py for testing routing