### PR TITLE
Assorted fixes

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -24,10 +24,7 @@ def main_menu():
 @plugin.route('/cache/delete/<cache_file>')
 def delete_cache(cache_file=None):
     ''' The API interface to delete caches '''
-    if cache_file:
-        kodi.refresh_caches(cache_file)
-    else:
-        kodi.invalidate_caches()
+    kodi.refresh_caches(cache_file=cache_file)
 
 
 @plugin.route('/tokens/delete')

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -99,7 +99,7 @@ msgstr ""
 
 ### FAVORITES
 msgctxt "#30040"
-msgid "My A-Z"
+msgid "My favourite programs"
 msgstr ""
 
 msgctxt "#30041"

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -100,8 +100,8 @@ msgstr "Doorzoek de hele VRT NU bibliotheek"
 
 ### FAVORITES
 msgctxt "#30040"
-msgid "My A-Z"
-msgstr "Mijn tv-programma's"
+msgid "My favourite programs"
+msgstr "Mijn favoriete tv-programma's"
 
 msgctxt "#30041"
 msgid "Alphabetically sorted list of My TV programs"

--- a/resources/lib/favorites.py
+++ b/resources/lib/favorites.py
@@ -35,7 +35,6 @@ class Favorites:
         ''' Get a cached copy or a newer favorites from VRT, or fall back to a cached file '''
         if not self.is_activated():
             return
-        import json
         api_json = self._kodi.get_cache('favorites.json', ttl)
         if not api_json:
             xvrttoken = self._tokenresolver.get_xvrttoken(token_variant='user')
@@ -47,6 +46,7 @@ class Favorites:
                 }
                 req = Request('https://video-user-data.vrt.be/favorites', headers=headers)
                 self._kodi.log_notice('URL post: https://video-user-data.vrt.be/favorites', 'Verbose')
+                import json
                 try:
                     api_json = json.load(urlopen(req))
                 except Exception:
@@ -58,7 +58,6 @@ class Favorites:
 
     def set_favorite(self, title, program, value=True):
         ''' Set a program as favorite, and update local copy '''
-        import json
 
         self.get_favorites(ttl=60 * 60)
         if value is self.is_favorite(program):
@@ -77,6 +76,7 @@ class Favorites:
             'Referer': 'https://www.vrt.be/vrtnu',
         }
         payload = dict(isFavorite=value, programUrl=statichelper.program_to_url(program, 'short'), title=title)
+        import json
         data = json.dumps(payload).encode('utf-8')
         self._kodi.log_notice('URL post: https://video-user-data.vrt.be/favorites/%s' % self.uuid(program), 'Verbose')
         req = Request('https://video-user-data.vrt.be/favorites/%s' % self.uuid(program), data=data, headers=headers)

--- a/resources/lib/helperobjects.py
+++ b/resources/lib/helperobjects.py
@@ -58,11 +58,11 @@ class StreamURLS:
 class TitleItem:
     ''' This helper object holds all information to be used with Kodi xbmc's ListItem object '''
 
-    def __init__(self, title, path, is_playable, art_dict=None, video_dict=None, context_menu=None):
+    def __init__(self, title, path, art_dict=None, info_dict=None, context_menu=None, is_playable=False):
         ''' The constructor for the TitleItem class '''
         self.title = title
         self.path = path
-        self.is_playable = is_playable
         self.art_dict = art_dict
-        self.video_dict = video_dict
+        self.info_dict = info_dict
         self.context_menu = context_menu
+        self.is_playable = is_playable

--- a/resources/lib/kodiwrapper.py
+++ b/resources/lib/kodiwrapper.py
@@ -184,9 +184,9 @@ class KodiWrapper:
             if title_item.art_dict:
                 list_item.setArt(title_item.art_dict)
 
-            if title_item.video_dict:
+            if title_item.info_dict:
                 # type is one of: video, music, pictures, game
-                list_item.setInfo(type='video', infoLabels=title_item.video_dict)
+                list_item.setInfo(type='video', infoLabels=title_item.info_dict)
 
             if title_item.context_menu:
                 list_item.addContextMenuItems(title_item.context_menu)
@@ -531,9 +531,9 @@ class KodiWrapper:
             self.log_notice("Cache '%s' has not changed, updating mtime only." % path, 'Debug')
             os.utime(path)
 
-    def refresh_caches(self, url):
+    def refresh_caches(self, cache_file=None):
         ''' Invalidate the needed caches and refresh container '''
-        self.invalidate_caches(expr=url)
+        self.invalidate_caches(expr=cache_file)
         self.container_refresh()
 
     def invalidate_cache(self, path):

--- a/resources/lib/metadatacreator.py
+++ b/resources/lib/metadatacreator.py
@@ -29,72 +29,72 @@ class MetadataCreator:
         self.tvshowtitle = None
         self.year = None
 
-    def get_video_dict(self):
+    def get_info_dict(self):
         ''' Return an infoLabels dictionary for Kodi '''
         from datetime import datetime
         import dateutil.tz
         from resources.lib import CHANNELS
 
         epoch = datetime.fromtimestamp(0, dateutil.tz.UTC)
-        video_dict = dict()
+        info_dict = dict()
 
         if self.brands:
             try:
                 channel = next(c for c in CHANNELS if c.get('name') == self.brands[0])
-                video_dict['studio'] = channel.get('studio')
+                info_dict['studio'] = channel.get('studio')
             except StopIteration:
                 # Retain original (unknown) brand, unless it is empty
-                video_dict['studio'] = self.brands[0] or 'VRT'
+                info_dict['studio'] = self.brands[0] or 'VRT'
         else:
             # No brands ? Use VRT instead
-            video_dict['studio'] = 'VRT'
+            info_dict['studio'] = 'VRT'
 
         if self.datetime:
-            video_dict['aired'] = self.datetime.strftime('%Y-%m-%d %H:%M:%S')
-            video_dict['date'] = self.datetime.strftime('%Y-%m-%d')
+            info_dict['aired'] = self.datetime.strftime('%Y-%m-%d %H:%M:%S')
+            info_dict['date'] = self.datetime.strftime('%Y-%m-%d')
         elif self.ontime and self.ontime != epoch:
-            video_dict['aired'] = self.ontime.strftime('%Y-%m-%d %H:%M:%S')
-            video_dict['date'] = self.ontime.strftime('%Y-%m-%d')
+            info_dict['aired'] = self.ontime.strftime('%Y-%m-%d %H:%M:%S')
+            info_dict['date'] = self.ontime.strftime('%Y-%m-%d')
 
         if self.ontime and self.ontime != epoch:
-            video_dict['dateadded'] = self.ontime.strftime('%Y-%m-%d %H:%M:%S')
+            info_dict['dateadded'] = self.ontime.strftime('%Y-%m-%d %H:%M:%S')
         elif self.datetime:
-            video_dict['dateadded'] = self.datetime.strftime('%Y-%m-%d %H:%M:%S')
+            info_dict['dateadded'] = self.datetime.strftime('%Y-%m-%d %H:%M:%S')
 
         if self.duration:
-            video_dict['duration'] = self.duration
+            info_dict['duration'] = self.duration
 
         if self.episode:
-            video_dict['episode'] = self.episode
+            info_dict['episode'] = self.episode
 
         # mediatype is one of: video, movie, tvshow, season, episode or musicvideo
         if self.mediatype:
-            video_dict['mediatype'] = self.mediatype
+            info_dict['mediatype'] = self.mediatype
 
         if self.permalink:
-            video_dict['showlink'] = [self.permalink]
+            info_dict['showlink'] = [self.permalink]
 
         if self.plot:
-            video_dict['plot'] = self.plot.strip()
+            info_dict['plot'] = self.plot.strip()
 
         if self.plotoutline:
-            video_dict['plotoutline'] = self.plotoutline.strip()
+            info_dict['plotoutline'] = self.plotoutline.strip()
 
         if self.season:
-            video_dict['season'] = self.season
+            info_dict['season'] = self.season
 
         # NOTE: Does not seem to have any effect
         if self.subtitle:
-            video_dict['tagline'] = self.subtitle
+            info_dict['tagline'] = self.subtitle
 
         if self.title:
-            video_dict['title'] = self.title
+            info_dict['title'] = self.title
 
         if self.tvshowtitle:
-            video_dict['tvshowtitle'] = self.tvshowtitle
-            video_dict['set'] = self.tvshowtitle
+            info_dict['tvshowtitle'] = self.tvshowtitle
+            info_dict['set'] = self.tvshowtitle
 
         if self.year:
-            video_dict['year'] = self.year
+            info_dict['year'] = self.year
 
-        return video_dict
+        return info_dict

--- a/resources/lib/tvguide.py
+++ b/resources/lib/tvguide.py
@@ -88,9 +88,8 @@ class TVGuide:
             date_items.append(TitleItem(
                 title=title,
                 path=self._kodi.url_for('tv_guide', date=date),
-                is_playable=False,
                 art_dict=dict(thumb='DefaultYear.png', icon='DefaultYear.png', fanart='DefaultYear.png'),
-                video_dict=dict(plot=self._kodi.localize_datelong(day)),
+                info_dict=dict(plot=self._kodi.localize_datelong(day)),
                 context_menu=[(self._kodi.localize(30413), 'RunPlugin(%s)' % self._kodi.url_for('delete_cache', cache_file=cache_file))],
             ))
         return date_items
@@ -117,9 +116,8 @@ class TVGuide:
             channel_items.append(TitleItem(
                 title=channel.get('label'),
                 path=self._kodi.url_for('tv_guide', date=date, channel=channel.get('name')),
-                is_playable=False,
                 art_dict=dict(thumb=icon, icon=icon, fanart=fanart),
-                video_dict=dict(plot=plot, studio=channel.get('studio')),
+                info_dict=dict(plot=plot, studio=channel.get('studio')),
             ))
         return channel_items
 
@@ -191,9 +189,9 @@ class TVGuide:
             episode_items.append(TitleItem(
                 title=metadata.title,
                 path=path,
-                is_playable=True,
                 art_dict=dict(thumb=thumb, icon='DefaultAddonVideo.png', fanart=thumb),
-                video_dict=metadata.get_video_dict(),
+                info_dict=metadata.get_info_dict(),
+                is_playable=True,
             ))
         return episode_items
 

--- a/resources/lib/vrtapihelper.py
+++ b/resources/lib/vrtapihelper.py
@@ -100,9 +100,8 @@ class VRTApiHelper:
             tvshow_items.append(TitleItem(
                 title=label,
                 path=self._kodi.url_for('programs', program=program),
-                is_playable=False,
                 art_dict=dict(thumb=thumbnail, icon='DefaultAddonVideo.png', fanart=thumbnail),
-                video_dict=metadata.get_video_dict(),
+                info_dict=metadata.get_info_dict(),
                 context_menu=context_menu,
             ))
         return tvshow_items
@@ -327,10 +326,10 @@ class VRTApiHelper:
             episode_items.append(TitleItem(
                 title=label,
                 path=self._kodi.url_for('play_id', publication_id=episode.get('publicationId'), video_id=episode.get('videoId')),
-                is_playable=True,
                 art_dict=dict(thumb=thumb, icon='DefaultAddonVideo.png', fanart=fanart),
-                video_dict=metadata.get_video_dict(),
+                info_dict=metadata.get_info_dict(),
                 context_menu=context_menu,
+                is_playable=True,
             ))
 
         return episode_items, sort, ascending, 'episodes'
@@ -374,9 +373,8 @@ class VRTApiHelper:
             season_items.append(TitleItem(
                 title=self._kodi.localize(30096),
                 path=self._kodi.url_for('programs', program=program, season='allseasons'),
-                is_playable=False,
                 art_dict=dict(thumb=fanart, icon='DefaultSets.png', fanart=fanart),
-                video_dict=metadata.get_video_dict(),
+                info_dict=metadata.get_info_dict(),
             ))
 
         # NOTE: Sort the episodes ourselves, because Kodi does not allow to set to 'ascending'
@@ -399,9 +397,8 @@ class VRTApiHelper:
             season_items.append(TitleItem(
                 title=label,
                 path=self._kodi.url_for('programs', program=program, season=season_key),
-                is_playable=False,
                 art_dict=dict(thumb=thumbnail, icon='DefaultSets.png', fanart=fanart),
-                video_dict=metadata.get_video_dict(),
+                info_dict=metadata.get_info_dict(),
             ))
         return season_items, sort, ascending, 'seasons'
 
@@ -531,6 +528,7 @@ class VRTApiHelper:
                 label = channel.get('label')
                 plot = '[B]%s[/B]' % channel.get('label')
                 is_playable = False
+                info_dict = dict(title=label, plot=plot, studio=channel.get('studio'), mediatype='video')
                 context_menu = []
             elif channel.get('live_stream') or channel.get('live_stream_id'):
                 if channel.get('live_stream_id'):
@@ -548,6 +546,8 @@ class VRTApiHelper:
                     plot = '%s\n\n%s' % (self._kodi.localize(30102).format(**channel), _tvguide.live_description(channel.get('name')))
                 else:
                     plot = self._kodi.localize(30102).format(**channel)
+                # NOTE: Playcount is required to not have live streams as "Watched"
+                info_dict = dict(title=label, plot=plot, studio=channel.get('studio'), mediatype='video', playcount=0)
                 context_menu = [(self._kodi.localize(30413), 'RunPlugin(%s)' % self._kodi.url_for('delete_cache', cache_file='channel.%s.json' % channel))]
             else:
                 # Not a playable channel
@@ -556,15 +556,10 @@ class VRTApiHelper:
             channel_items.append(TitleItem(
                 title=label,
                 path=path,
-                is_playable=is_playable,
                 art_dict=dict(thumb=icon, icon=icon, fanart=fanart),
-                video_dict=dict(
-                    title=label,
-                    plot=plot,
-                    studio=channel.get('studio'),
-                    mediatype='video',
-                ),
+                info_dict=info_dict,
                 context_menu=context_menu,
+                is_playable=is_playable,
             ))
 
         return channel_items
@@ -579,9 +574,8 @@ class VRTApiHelper:
             featured_items.append(TitleItem(
                 title=featured_name,
                 path=self._kodi.url_for('featured', feature=feature.get('id')),
-                is_playable=False,
                 art_dict=dict(thumb='DefaultCountry.png', icon='DefaultCountry.png', fanart='DefaultCountry.png'),
-                video_dict=dict(plot='[B]%s[/B]' % featured_name, studio='VRT'),
+                info_dict=dict(plot='[B]%s[/B]' % featured_name, studio='VRT'),
             ))
         return featured_items
 
@@ -619,9 +613,8 @@ class VRTApiHelper:
             category_items.append(TitleItem(
                 title=category_name,
                 path=self._kodi.url_for('categories', category=category.get('id')),
-                is_playable=False,
                 art_dict=dict(thumb=thumbnail, icon='DefaultGenre.png', fanart=thumbnail),
-                video_dict=dict(plot='[B]%s[/B]' % category_name, studio='VRT'),
+                info_dict=dict(plot='[B]%s[/B]' % category_name, studio='VRT'),
             ))
         return category_items
 

--- a/resources/lib/vrtplayer.py
+++ b/resources/lib/vrtplayer.py
@@ -32,60 +32,50 @@ class VRTPlayer:
             main_items.append(TitleItem(
                 title=self._kodi.localize(30010),  # My programs
                 path=self._kodi.url_for('favorites_menu'),
-                is_playable=False,
                 art_dict=dict(thumb='icons/settings/profiles.png', icon='icons/settings/profiles.png', fanart='icons/settings/profiles.png'),
-                video_dict=dict(plot=self._kodi.localize(30011))
+                info_dict=dict(plot=self._kodi.localize(30011))
             ))
 
         main_items.extend([
             TitleItem(title=self._kodi.localize(30012),  # A-Z listing
                       path=self._kodi.url_for('programs'),
-                      is_playable=False,
                       art_dict=dict(thumb='DefaultMovieTitle.png', icon='DefaultMovieTitle.png', fanart='DefaultMovieTitle.png'),
-                      video_dict=dict(plot=self._kodi.localize(30013))),
+                      info_dict=dict(plot=self._kodi.localize(30013))),
             TitleItem(title=self._kodi.localize(30014),  # Categories
                       path=self._kodi.url_for('categories'),
-                      is_playable=False,
                       art_dict=dict(thumb='DefaultGenre.png', icon='DefaultGenre.png', fanart='DefaultGenre.png'),
-                      video_dict=dict(plot=self._kodi.localize(30015))),
+                      info_dict=dict(plot=self._kodi.localize(30015))),
             TitleItem(title=self._kodi.localize(30016),  # Channels
-                      is_playable=False,
                       path=self._kodi.url_for('channels'),
                       art_dict=dict(thumb='DefaultTags.png', icon='DefaultTags.png', fanart='DefaultTags.png'),
-                      video_dict=dict(plot=self._kodi.localize(30017))),
+                      info_dict=dict(plot=self._kodi.localize(30017))),
             TitleItem(title=self._kodi.localize(30018),  # Live TV
                       path=self._kodi.url_for('livetv'),
-                      is_playable=False,
                       # art_dict=dict(thumb='DefaultAddonPVRClient.png', icon='DefaultAddonPVRClient.png', fanart='DefaultAddonPVRClient.png'),
                       art_dict=dict(thumb='DefaultTVShows.png', icon='DefaultTVShows.png', fanart='DefaultTVShows.png'),
-                      video_dict=dict(plot=self._kodi.localize(30019))),
+                      info_dict=dict(plot=self._kodi.localize(30019))),
             TitleItem(title=self._kodi.localize(30020),  # Recent items
                       path=self._kodi.url_for('recent'),
-                      is_playable=False,
                       art_dict=dict(thumb='DefaultRecentlyAddedEpisodes.png',
                                     icon='DefaultRecentlyAddedEpisodes.png',
                                     fanart='DefaultRecentlyAddedEpisodes.png'),
-                      video_dict=dict(plot=self._kodi.localize(30021))),
+                      info_dict=dict(plot=self._kodi.localize(30021))),
             TitleItem(title=self._kodi.localize(30022),  # Soon offline
                       path=self._kodi.url_for('offline'),
-                      is_playable=False,
                       art_dict=dict(thumb='DefaultYear.png', icon='DefaultYear.png', fanart='DefaultYear.png'),
-                      video_dict=dict(plot=self._kodi.localize(30023))),
+                      info_dict=dict(plot=self._kodi.localize(30023))),
             TitleItem(title=self._kodi.localize(30024),  # Featured content
                       path=self._kodi.url_for('featured'),
-                      is_playable=False,
                       art_dict=dict(thumb='DefaultCountry.png', icon='DefaultCountry.png', fanart='DefaultCountry.png'),
-                      video_dict=dict(plot=self._kodi.localize(30025))),
+                      info_dict=dict(plot=self._kodi.localize(30025))),
             TitleItem(title=self._kodi.localize(30026),  # TV guide
                       path=self._kodi.url_for('tv_guide'),
-                      is_playable=False,
                       art_dict=dict(thumb='DefaultAddonTvInfo.png', icon='DefaultAddonTvInfo.png', fanart='DefaultAddonTvInfo.png'),
-                      video_dict=dict(plot=self._kodi.localize(30027))),
+                      info_dict=dict(plot=self._kodi.localize(30027))),
             TitleItem(title=self._kodi.localize(30028),  # Search
                       path=self._kodi.url_for('search'),
-                      is_playable=False,
                       art_dict=dict(thumb='DefaultAddonsSearch.png', icon='DefaultAddonsSearch.png', fanart='DefaultAddonsSearch.png'),
-                      video_dict=dict(plot=self._kodi.localize(30029))),
+                      info_dict=dict(plot=self._kodi.localize(30029))),
         ])
         self._kodi.show_listing(main_items)
 
@@ -95,43 +85,35 @@ class VRTPlayer:
         favorites_items = [
             TitleItem(title=self._kodi.localize(30040),  # My A-Z listing
                       path=self._kodi.url_for('favorites_programs'),
-                      is_playable=False,
                       art_dict=dict(thumb='DefaultMovieTitle.png', icon='DefaultMovieTitle.png', fanart='DefaultMovieTitle.png'),
-                      video_dict=dict(plot=self._kodi.localize(30041))),
+                      info_dict=dict(plot=self._kodi.localize(30041))),
+            TitleItem(title=self._kodi.localize(30046),  # My recent items
+                      path=self._kodi.url_for('favorites_recent'),
+                      art_dict=dict(thumb='DefaultRecentlyAddedEpisodes.png',
+                                    icon='DefaultRecentlyAddedEpisodes.png',
+                                    fanart='DefaultRecentlyAddedEpisodes.png'),
+                      info_dict=dict(plot=self._kodi.localize(30047))),
+            TitleItem(title=self._kodi.localize(30048),  # My soon offline
+                      path=self._kodi.url_for('favorites_offline'),
+                      art_dict=dict(thumb='DefaultYear.png', icon='DefaultYear.png', fanart='DefaultYear.png'),
+                      info_dict=dict(plot=self._kodi.localize(30049))),
         ]
 
         if self._addmymovies:
             favorites_items.append(
                 TitleItem(title=self._kodi.localize(30042),  # My movies
                           path=self._kodi.url_for('categories', category='films'),
-                          is_playable=False,
                           art_dict=dict(thumb='DefaultAddonVideo.png', icon='DefaultAddonVideo.png', fanart='DefaultAddonVideo.png'),
-                          video_dict=dict(plot=self._kodi.localize(30043))),
+                          info_dict=dict(plot=self._kodi.localize(30043))),
             )
 
         if self._addmydocu:
             favorites_items.append(
                 TitleItem(title=self._kodi.localize(30044),  # My documentaries
                           path=self._kodi.url_for('favorites_docu'),
-                          is_playable=False,
                           art_dict=dict(thumb='DefaultMovies.png', icon='DefaultMovies.png', fanart='DefaultMovies.png'),
-                          video_dict=dict(plot=self._kodi.localize(30045))),
+                          info_dict=dict(plot=self._kodi.localize(30045))),
             )
-
-        favorites_items.extend([
-            TitleItem(title=self._kodi.localize(30046),  # My recent items
-                      path=self._kodi.url_for('favorites_recent'),
-                      is_playable=False,
-                      art_dict=dict(thumb='DefaultRecentlyAddedEpisodes.png',
-                                    icon='DefaultRecentlyAddedEpisodes.png',
-                                    fanart='DefaultRecentlyAddedEpisodes.png'),
-                      video_dict=dict(plot=self._kodi.localize(30047))),
-            TitleItem(title=self._kodi.localize(30048),  # My soon offline
-                      path=self._kodi.url_for('favorites_offline'),
-                      is_playable=False,
-                      art_dict=dict(thumb='DefaultYear.png', icon='DefaultYear.png', fanart='DefaultYear.png'),
-                      video_dict=dict(plot=self._kodi.localize(30049))),
-        ])
 
         self._kodi.show_listing(favorites_items)
 
@@ -219,9 +201,8 @@ class VRTPlayer:
             episode_items.append(TitleItem(
                 title=self._kodi.localize(30300),
                 path=self._kodi.url_for(recent, page=page + 1),
-                is_playable=False,
                 art_dict=dict(thumb='DefaultRecentlyAddedEpisodes.png', icon='DefaultRecentlyAddedEpisodes.png', fanart='DefaultRecentlyAddedEpisodes.png'),
-                video_dict=dict(),
+                info_dict=dict(),
             ))
 
         self._kodi.show_listing(episode_items, sort=sort, ascending=ascending, content=content, cache=False)
@@ -242,9 +223,8 @@ class VRTPlayer:
             episode_items.append(TitleItem(
                 title=self._kodi.localize(30300),
                 path=self._kodi.url_for(offline, page=page + 1),
-                is_playable=False,
                 art_dict=dict(thumb='DefaultYear.png', icon='DefaultYear.png', fanart='DefaultYear.png'),
-                video_dict=dict(),
+                info_dict=dict(),
             ))
 
         self._kodi.show_listing(episode_items, sort=sort, ascending=ascending, content=content)
@@ -272,9 +252,8 @@ class VRTPlayer:
             search_items.append(TitleItem(
                 title=self._kodi.localize(30300),
                 path=self._kodi.url_for('search', search_string=search_string, page=page + 1),
-                is_playable=False,
                 art_dict=dict(thumb='DefaultAddonSearch.png', icon='DefaultAddonSearch.png', fanart='DefaultAddonSearch.png'),
-                video_dict=dict(),
+                info_dict=dict(),
             ))
 
         self._kodi.container_update(replace=True)

--- a/test/apihelpertests.py
+++ b/test/apihelpertests.py
@@ -99,7 +99,7 @@ class ApiHelperTests(unittest.TestCase):
         bogus_brands = ['lang-zullen-we-lezen', 'VRT']
         channel_studios = [c.get('studio') for c in CHANNELS] + bogus_brands
         for tvshow in tvshow_items:
-            self.assertTrue(tvshow.video_dict['studio'] in channel_studios, '%s | %s | %s' % (tvshow.title, tvshow.video_dict['studio'], channel_studios))
+            self.assertTrue(tvshow.info_dict['studio'] in channel_studios, '%s | %s | %s' % (tvshow.title, tvshow.info_dict['studio'], channel_studios))
 
     def test_get_latest_episode(self):
         video = self._apihelper.get_latest_episode(program='het-journaal')

--- a/test/routingtests.py
+++ b/test/routingtests.py
@@ -14,151 +14,160 @@ xbmcgui = __import__('xbmcgui')
 xbmcplugin = __import__('xbmcplugin')
 xbmcvfs = __import__('xbmcvfs')
 
+plugin = addon.plugin
+
 
 class TestRouter(unittest.TestCase):
 
     def test_main_menu(self):
-        addon.plugin.run(['plugin://plugin.video.vrt.nu/', '0', ''])
-        self.assertEqual(addon.plugin.url_for(addon.main_menu), 'plugin://plugin.video.vrt.nu/')
+        plugin.run(['plugin://plugin.video.vrt.nu/', '0', ''])
+        self.assertEqual(plugin.url_for(addon.main_menu), 'plugin://plugin.video.vrt.nu/')
 
     # Favorites menu: '/favorites'
     def test_favorites(self):
-        addon.plugin.run(['plugin://plugin.video.vrt.nu/favorites', '0', ''])
-        addon.plugin.run(['plugin://plugin.video.vrt.nu/favorites/programs', '0', ''])
-        addon.plugin.run(['plugin://plugin.video.vrt.nu/favorites/recent', '0', ''])
-        addon.plugin.run(['plugin://plugin.video.vrt.nu/favorites/recent/2', '0', ''])
-        self.assertEqual(addon.plugin.url_for(addon.favorites_recent, page=2), 'plugin://plugin.video.vrt.nu/favorites/recent/2')
-        addon.plugin.run(['plugin://plugin.video.vrt.nu/favorites/offline', '0', ''])
+        plugin.run(['plugin://plugin.video.vrt.nu/favorites', '0', ''])
+        plugin.run(['plugin://plugin.video.vrt.nu/favorites/programs', '0', ''])
+        plugin.run(['plugin://plugin.video.vrt.nu/favorites/recent', '0', ''])
+        plugin.run(['plugin://plugin.video.vrt.nu/favorites/recent/2', '0', ''])
+        self.assertEqual(plugin.url_for(addon.favorites_recent, page=2), 'plugin://plugin.video.vrt.nu/favorites/recent/2')
+        plugin.run(['plugin://plugin.video.vrt.nu/favorites/offline', '0', ''])
 
     # A-Z menu: '/programs'
     def test_az_menu(self):
-        addon.plugin.run(['plugin://plugin.video.vrt.nu/programs', '0', ''])
-        self.assertEqual(addon.plugin.url_for(addon.programs), 'plugin://plugin.video.vrt.nu/programs')
+        plugin.run(['plugin://plugin.video.vrt.nu/programs', '0', ''])
+        self.assertEqual(plugin.url_for(addon.programs), 'plugin://plugin.video.vrt.nu/programs')
 
     # Episodes menu: '/programs/<program>'
     def test_episodes_menu(self):
-        addon.plugin.run(['plugin://plugin.video.vrt.nu/programs/thuis', '0', ''])
-        self.assertEqual(addon.plugin.url_for(addon.programs, program='thuis'), 'plugin://plugin.video.vrt.nu/programs/thuis')
-        addon.plugin.run(['plugin://plugin.video.vrt.nu/programs/de-campus-cup', '0', ''])
-        self.assertEqual(addon.plugin.url_for(addon.programs, program='de-campus-cup'), 'plugin://plugin.video.vrt.nu/programs/de-campus-cup')
+        plugin.run(['plugin://plugin.video.vrt.nu/programs/thuis', '0', ''])
+        self.assertEqual(plugin.url_for(addon.programs, program='thuis'), 'plugin://plugin.video.vrt.nu/programs/thuis')
+        plugin.run(['plugin://plugin.video.vrt.nu/programs/de-campus-cup', '0', ''])
+        self.assertEqual(plugin.url_for(addon.programs, program='de-campus-cup'), 'plugin://plugin.video.vrt.nu/programs/de-campus-cup')
 
     # Categories menu: '/categories'
     def test_categories_menu(self):
-        addon.plugin.run(['plugin://plugin.video.vrt.nu/categories', '0', ''])
-        self.assertEqual(addon.plugin.url_for(addon.categories), 'plugin://plugin.video.vrt.nu/categories')
+        plugin.run(['plugin://plugin.video.vrt.nu/categories', '0', ''])
+        self.assertEqual(plugin.url_for(addon.categories), 'plugin://plugin.video.vrt.nu/categories')
 
     # Categories programs menu: '/categories/<category>'
     def test_categories_tvshow_menu(self):
-        addon.plugin.run(['plugin://plugin.video.vrt.nu/categories/docu', '0', ''])
-        self.assertEqual(addon.plugin.url_for(addon.categories, category='docu'), 'plugin://plugin.video.vrt.nu/categories/docu')
-        addon.plugin.run(['plugin://plugin.video.vrt.nu/categories/kinderen', '0', ''])
-        self.assertEqual(addon.plugin.url_for(addon.categories, category='kinderen'), 'plugin://plugin.video.vrt.nu/categories/kinderen')
+        plugin.run(['plugin://plugin.video.vrt.nu/categories/docu', '0', ''])
+        self.assertEqual(plugin.url_for(addon.categories, category='docu'), 'plugin://plugin.video.vrt.nu/categories/docu')
+        plugin.run(['plugin://plugin.video.vrt.nu/categories/kinderen', '0', ''])
+        self.assertEqual(plugin.url_for(addon.categories, category='kinderen'), 'plugin://plugin.video.vrt.nu/categories/kinderen')
 
     # Featured menu: '/featured'
     def test_featured_menu(self):
-        addon.plugin.run(['plugin://plugin.video.vrt.nu/featured', '0', ''])
-        self.assertEqual(addon.plugin.url_for(addon.featured), 'plugin://plugin.video.vrt.nu/featured')
+        plugin.run(['plugin://plugin.video.vrt.nu/featured', '0', ''])
+        self.assertEqual(plugin.url_for(addon.featured), 'plugin://plugin.video.vrt.nu/featured')
 
     # Featured programs menu: '/featured/<cfeatured>'
     def test_featured_tvshow_menu(self):
-        addon.plugin.run(['plugin://plugin.video.vrt.nu/featured/kortfilm', '0', ''])
-        self.assertEqual(addon.plugin.url_for(addon.featured, feature='kortfilm'), 'plugin://plugin.video.vrt.nu/featured/kortfilm')
+        plugin.run(['plugin://plugin.video.vrt.nu/featured/kortfilm', '0', ''])
+        self.assertEqual(plugin.url_for(addon.featured, feature='kortfilm'), 'plugin://plugin.video.vrt.nu/featured/kortfilm')
 
     # Channels menu = '/channels/<channel>'
     def test_channels_menu(self):
-        addon.plugin.run(['plugin://plugin.video.vrt.nu/channels', '0', ''])
-        self.assertEqual(addon.plugin.url_for(addon.channels), 'plugin://plugin.video.vrt.nu/channels')
-        addon.plugin.run(['plugin://plugin.video.vrt.nu/channels/ketnet', '0', ''])
-        self.assertEqual(addon.plugin.url_for(addon.channels, channel='ketnet'), 'plugin://plugin.video.vrt.nu/channels/ketnet')
+        plugin.run(['plugin://plugin.video.vrt.nu/channels', '0', ''])
+        self.assertEqual(plugin.url_for(addon.channels), 'plugin://plugin.video.vrt.nu/channels')
+        plugin.run(['plugin://plugin.video.vrt.nu/channels/ketnet', '0', ''])
+        self.assertEqual(plugin.url_for(addon.channels, channel='ketnet'), 'plugin://plugin.video.vrt.nu/channels/ketnet')
 
     # Live TV menu: '/livetv'
     def test_livetv_menu(self):
-        addon.plugin.run(['plugin://plugin.video.vrt.nu/livetv', '0', ''])
-        self.assertEqual(addon.plugin.url_for(addon.livetv), 'plugin://plugin.video.vrt.nu/livetv')
+        plugin.run(['plugin://plugin.video.vrt.nu/livetv', '0', ''])
+        self.assertEqual(plugin.url_for(addon.livetv), 'plugin://plugin.video.vrt.nu/livetv')
 
     # Most recent menu: '/recent/<page>'
     def test_recent_menu(self):
-        addon.plugin.run(['plugin://plugin.video.vrt.nu/recent', '0', ''])
-        self.assertEqual(addon.plugin.url_for(addon.recent), 'plugin://plugin.video.vrt.nu/recent')
-        addon.plugin.run(['plugin://plugin.video.vrt.nu/recent/2', '0', ''])
-        self.assertEqual(addon.plugin.url_for(addon.recent, page=2), 'plugin://plugin.video.vrt.nu/recent/2')
+        plugin.run(['plugin://plugin.video.vrt.nu/recent', '0', ''])
+        self.assertEqual(plugin.url_for(addon.recent), 'plugin://plugin.video.vrt.nu/recent')
+        plugin.run(['plugin://plugin.video.vrt.nu/recent/2', '0', ''])
+        self.assertEqual(plugin.url_for(addon.recent, page=2), 'plugin://plugin.video.vrt.nu/recent/2')
 
     # Soon offline menu: '/offline/<page>'
     def test_offline_menu(self):
-        addon.plugin.run(['plugin://plugin.video.vrt.nu/offline', '0', ''])
-        self.assertEqual(addon.plugin.url_for(addon.offline), 'plugin://plugin.video.vrt.nu/offline')
+        plugin.run(['plugin://plugin.video.vrt.nu/offline', '0', ''])
+        self.assertEqual(plugin.url_for(addon.offline), 'plugin://plugin.video.vrt.nu/offline')
 
     # TV guide menu: '/tvguide/<date>/<channel>'
     def test_tvguide_date_menu(self):
-        addon.plugin.run(['plugin://plugin.video.vrt.nu/tvguide', '0', ''])
-        self.assertEqual(addon.plugin.url_for(addon.tv_guide), 'plugin://plugin.video.vrt.nu/tvguide')
-        addon.plugin.run(['plugin://plugin.video.vrt.nu/tvguide/today', '0', ''])
-        self.assertEqual(addon.plugin.url_for(addon.tv_guide, date='today'), 'plugin://plugin.video.vrt.nu/tvguide/today')
-        addon.plugin.run(['plugin://plugin.video.vrt.nu/tvguide/today/canvas', '0', ''])
-        self.assertEqual(addon.plugin.url_for(addon.tv_guide, date='today', channel='canvas'), 'plugin://plugin.video.vrt.nu/tvguide/today/canvas')
+        plugin.run(['plugin://plugin.video.vrt.nu/tvguide', '0', ''])
+        self.assertEqual(plugin.url_for(addon.tv_guide), 'plugin://plugin.video.vrt.nu/tvguide')
+        plugin.run(['plugin://plugin.video.vrt.nu/tvguide/today', '0', ''])
+        self.assertEqual(plugin.url_for(addon.tv_guide, date='today'), 'plugin://plugin.video.vrt.nu/tvguide/today')
+        plugin.run(['plugin://plugin.video.vrt.nu/tvguide/today/canvas', '0', ''])
+        self.assertEqual(plugin.url_for(addon.tv_guide, date='today', channel='canvas'), 'plugin://plugin.video.vrt.nu/tvguide/today/canvas')
 
     # Search VRT NU menu: '/search/<search_string>/<page>'
     def test_search_menu(self):
-        addon.plugin.run(['plugin://plugin.video.vrt.nu/search', '0', ''])
-        self.assertEqual(addon.plugin.url_for(addon.search), 'plugin://plugin.video.vrt.nu/search')
-        addon.plugin.run(['plugin://plugin.video.vrt.nu/search/dag', '0', ''])
-        self.assertEqual(addon.plugin.url_for(addon.search, search_string='dag'), 'plugin://plugin.video.vrt.nu/search/dag')
-        addon.plugin.run(['plugin://plugin.video.vrt.nu/search/dag/2', '0', ''])
-        self.assertEqual(addon.plugin.url_for(addon.search, search_string='dag', page=2), 'plugin://plugin.video.vrt.nu/search/dag/2')
+        plugin.run(['plugin://plugin.video.vrt.nu/search', '0', ''])
+        self.assertEqual(plugin.url_for(addon.search), 'plugin://plugin.video.vrt.nu/search')
+        plugin.run(['plugin://plugin.video.vrt.nu/search/dag', '0', ''])
+        self.assertEqual(plugin.url_for(addon.search, search_string='dag'), 'plugin://plugin.video.vrt.nu/search/dag')
+        plugin.run(['plugin://plugin.video.vrt.nu/search/dag/2', '0', ''])
+        self.assertEqual(plugin.url_for(addon.search, search_string='dag', page=2), 'plugin://plugin.video.vrt.nu/search/dag/2')
 
     # Follow method: '/follow/<program_title>/<program>'
     def test_follow_route(self):
-        addon.plugin.run(['plugin://plugin.video.vrt.nu/follow/Thuis/thuis', '0', ''])
-        self.assertEqual(addon.plugin.url_for(addon.follow, title='Thuis', program='thuis'), 'plugin://plugin.video.vrt.nu/follow/Thuis/thuis')
+        plugin.run(['plugin://plugin.video.vrt.nu/follow/Thuis/thuis', '0', ''])
+        self.assertEqual(plugin.url_for(addon.follow, title='Thuis', program='thuis'), 'plugin://plugin.video.vrt.nu/follow/Thuis/thuis')
 
     # Unfollow method: '/unfollow/<program_title>/<program>'
     def test_unfollow_route(self):
-        addon.plugin.run(['plugin://plugin.video.vrt.nu/unfollow/Thuis/thuis', '0', ''])
-        self.assertEqual(addon.plugin.url_for(addon.unfollow, title='Thuis', program='thuis'), 'plugin://plugin.video.vrt.nu/unfollow/Thuis/thuis')
+        plugin.run(['plugin://plugin.video.vrt.nu/unfollow/Thuis/thuis', '0', ''])
+        self.assertEqual(plugin.url_for(addon.unfollow, title='Thuis', program='thuis'), 'plugin://plugin.video.vrt.nu/unfollow/Thuis/thuis')
 
     # Delete tokens method: '/tokens/delete'
     def test_clear_cookies_route(self):
-        addon.plugin.run(['plugin://plugin.video.vrt.nu/tokens/delete', '0', ''])
-        self.assertEqual(addon.plugin.url_for(addon.delete_tokens), 'plugin://plugin.video.vrt.nu/tokens/delete')
+        plugin.run(['plugin://plugin.video.vrt.nu/tokens/delete', '0', ''])
+        self.assertEqual(plugin.url_for(addon.delete_tokens), 'plugin://plugin.video.vrt.nu/tokens/delete')
 
     # Delete cache method: '/cache/delete'
     def test_invalidate_caches_route(self):
-        addon.plugin.run(['plugin://plugin.video.vrt.nu/cache/delete', '0', ''])
-        self.assertEqual(addon.plugin.url_for(addon.delete_cache), 'plugin://plugin.video.vrt.nu/cache/delete')
+        plugin.run(['plugin://plugin.video.vrt.nu/cache/delete', '0', ''])
+        self.assertEqual(plugin.url_for(addon.delete_cache), 'plugin://plugin.video.vrt.nu/cache/delete')
 
     # Refresh favorites method: '/favorites/refresh'
     def test_refresh_favorites_route(self):
-        addon.plugin.run(['plugin://plugin.video.vrt.nu/favorites/refresh', '0', ''])
-        self.assertEqual(addon.plugin.url_for(addon.favorites_refresh), 'plugin://plugin.video.vrt.nu/favorites/refresh')
+        plugin.run(['plugin://plugin.video.vrt.nu/favorites/refresh', '0', ''])
+        self.assertEqual(plugin.url_for(addon.favorites_refresh), 'plugin://plugin.video.vrt.nu/favorites/refresh')
 
     # Play on demand by id = '/play/id/<publication_id>/<video_id>'
     # Achterflap episode 8 available until 31/12/2025
     def test_play_on_demand_by_id_route(self):
-        addon.plugin.run(['plugin://plugin.video.vrt.nu/play/id/pbs-pub-1a170972-dea3-4ea3-8c27-62d2442ee8a3/vid-f80fa527-6759-45a7-908d-ec6f0a7b164e', '0', ''])
-        self.assertEqual(addon.plugin.url_for(addon.play_id, publication_id='pbs-pub-1a170972-dea3-4ea3-8c27-62d2442ee8a3', video_id='vid-f80fa527-6759-45a7-908d-ec6f0a7b164e'), 'plugin://plugin.video.vrt.nu/play/id/pbs-pub-1a170972-dea3-4ea3-8c27-62d2442ee8a3/vid-f80fa527-6759-45a7-908d-ec6f0a7b164e')
+        plugin.run(['plugin://plugin.video.vrt.nu/play/id/pbs-pub-1a170972-dea3-4ea3-8c27-62d2442ee8a3/vid-f80fa527-6759-45a7-908d-ec6f0a7b164e', '0', ''])
+        self.assertEqual(plugin.url_for(addon.play_id,
+                                        publication_id='pbs-pub-1a170972-dea3-4ea3-8c27-62d2442ee8a3',
+                                        video_id='vid-f80fa527-6759-45a7-908d-ec6f0a7b164e'),
+                         'plugin://plugin.video.vrt.nu/play/id/pbs-pub-1a170972-dea3-4ea3-8c27-62d2442ee8a3/vid-f80fa527-6759-45a7-908d-ec6f0a7b164e')
 
     # Play livestream by id = '/play/id/<video_id>'
     # Canvas livestream
     def test_play_livestream_by_id_route(self):
-        addon.plugin.run(['plugin://plugin.video.vrt.nu/play/id/vualto_canvas_geo', '0', ''])
-        self.assertEqual(addon.plugin.url_for(addon.play_id, video_id='vualto_canvas_geo'), 'plugin://plugin.video.vrt.nu/play/id/vualto_canvas_geo')
+        plugin.run(['plugin://plugin.video.vrt.nu/play/id/vualto_canvas_geo', '0', ''])
+        self.assertEqual(plugin.url_for(addon.play_id, video_id='vualto_canvas_geo'), 'plugin://plugin.video.vrt.nu/play/id/vualto_canvas_geo')
 
     # Play on demand by url = '/play/url/<vrtnuwebsite_url>'
     # Achterflap episode 8 available until 31/12/2025
     def test_play_on_demand_by_url_route(self):
-        addon.plugin.run(['plugin://plugin.video.vrt.nu/play/url/https://www.vrt.be/vrtnu/a-z/achterflap/1/achterflap-s1a8/', '0', ''])
-        self.assertEqual(addon.plugin.url_for(addon.play_url, video_url='https://www.vrt.be/vrtnu/a-z/achterflap/1/achterflap-s1a8/'), 'plugin://plugin.video.vrt.nu/play/url/https://www.vrt.be/vrtnu/a-z/achterflap/1/achterflap-s1a8/')
+        plugin.run(['plugin://plugin.video.vrt.nu/play/url/https://www.vrt.be/vrtnu/a-z/achterflap/1/achterflap-s1a8/', '0', ''])
+        self.assertEqual(plugin.url_for(addon.play_url,
+                                        video_url='https://www.vrt.be/vrtnu/a-z/achterflap/1/achterflap-s1a8/'),
+                         'plugin://plugin.video.vrt.nu/play/url/https://www.vrt.be/vrtnu/a-z/achterflap/1/achterflap-s1a8/')
 
     # Play livestream by url = '/play/url/<vrtnuwebsite_url>'
     # Canvas livestream
     def test_play_livestream_by_url_route(self):
-        addon.plugin.run(['plugin://plugin.video.vrt.nu/play/url/https://www.vrt.be/vrtnu/kanalen/canvas/', '0', ''])
-        self.assertEqual(addon.plugin.url_for(addon.play_url, video_url='https://www.vrt.be/vrtnu/kanalen/canvas/'), 'plugin://plugin.video.vrt.nu/play/url/https://www.vrt.be/vrtnu/kanalen/canvas/')
+        plugin.run(['plugin://plugin.video.vrt.nu/play/url/https://www.vrt.be/vrtnu/kanalen/canvas/', '0', ''])
+        self.assertEqual(plugin.url_for(addon.play_url,
+                                        video_url='https://www.vrt.be/vrtnu/kanalen/canvas/'),
+                         'plugin://plugin.video.vrt.nu/play/url/https://www.vrt.be/vrtnu/kanalen/canvas/')
 
     # Play last episode method = '/play/lastepisode/<program>'
     def test_play_lastepisode_route(self):
-        addon.plugin.run(['plugin://plugin.video.vrt.nu/play/lastepisode/het-journaal', '0', ''])
-        self.assertEqual(addon.plugin.url_for(addon.play_last, program='het-journaal'), 'plugin://plugin.video.vrt.nu/play/lastepisode/het-journaal')
+        plugin.run(['plugin://plugin.video.vrt.nu/play/lastepisode/het-journaal', '0', ''])
+        self.assertEqual(plugin.url_for(addon.play_last, program='het-journaal'), 'plugin://plugin.video.vrt.nu/play/lastepisode/het-journaal')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR includes:
- Simplify /cache/delete interface
- Delay import json
- Make is_playable=False default in TitleItem
- Add playcount=0 InfoLabel for live streams so they are not watched
- Renamed "My A-Z" to "My favourite programs"
- Move My movies and My documentaries to the end of "My programs" menu
- Ensure unit tests are not over 160 rows
- Renamed "video_dict" to "info_dict"

This fixes #326 