### PR TITLE
improve stream error handling

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -598,18 +598,22 @@ msgid "Please increase the maximum bandwidth. Maximum bandwidth is set to {max} 
 msgstr ""
 
 msgctxt "#30958"
-msgid "There is a problem with this VRT NU %s stream. Try again with InputStream Adaptive %s or try to play this program from the VRT NU website. Please report this problem at https://www.vrt.be/vrtnu/help/"
+msgid "There is a problem with this VRT NU %s stream. Try again with %s %s %s or try to play this program from the VRT NU website. Please report this problem at https://www.vrt.be/vrtnu/help/"
 msgstr ""
 
 msgctxt "#30959"
-msgid "disabled"
+msgid "and DRM"
 msgstr ""
 
 msgctxt "#30960"
-msgid "enabled"
+msgid "disabled"
 msgstr ""
 
 msgctxt "#30961"
+msgid "enabled"
+msgstr ""
+
+msgctxt "#30962"
 msgid "Using a SOCKS proxy requires the PySocks library (script.module.pysocks) installed."
 msgstr ""
 

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -478,18 +478,22 @@ msgid "Please increase the maximum bandwidth. Maximum bandwidth is set to {max} 
 msgstr "Verhoog de maximale bandbreedte alstublieft. De maximale bandbreedte is ingesteld op {max} kbps, maar deze stream heeft minimum {min} kbps nodig."
 
 msgctxt "#30958"
-msgid "There is a problem with this VRT NU %s stream. Try again with InputStream Adaptive %s or try to play this program from the VRT NU website. Please report this problem at https://www.vrt.be/vrtnu/help/"
-msgstr "Er is een probleem met deze VRT NU %s-stream. Probeer het opnieuw met InputStream Adaptive %s of probeer dit programma af te spelen vanaf de VRT NU-website. Meld dit probleem op https://www.vrt.be/vrtnu/help/"
+msgid "There is a problem with this VRT NU %s stream. Try again with %s %s %s or try to play this program from the VRT NU website. Please report this problem at https://www.vrt.be/vrtnu/help/"
+msgstr "Er is een probleem met deze VRT NU %s-stream. Probeer het opnieuw met %s %s %s of probeer dit programma af te spelen vanaf de VRT NU-website. Meld dit probleem op https://www.vrt.be/vrtnu/help/"
 
 msgctxt "#30959"
+msgid "and DRM"
+msgstr "en DRM"
+
+msgctxt "#30960"
 msgid "disabled"
 msgstr "uitgeschakeld"
 
-msgctxt "#30960"
+msgctxt "#30961"
 msgid "enabled"
 msgstr "ingeschakeld"
 
-msgctxt "#30961"
+msgctxt "#30962"
 msgid "Using a SOCKS proxy requires the PySocks library (script.module.pysocks) installed."
 msgstr "Het gebruik van SOCKS proxies vereist dat de PySocks library (script.module.pysocks) geïnstalleerd is."
 

--- a/resources/lib/kodiwrapper.py
+++ b/resources/lib/kodiwrapper.py
@@ -353,7 +353,7 @@ class KodiWrapper:
         if httpproxytype != 0 and not socks_supported:
             # Only open the dialog the first time (to avoid multiple popups)
             if socks_supported is None:
-                self.show_ok_dialog('', self.localize(30961))  # Requires PySocks
+                self.show_ok_dialog('', self.localize(30962))  # Requires PySocks
             return None
 
         proxy_types = ['http', 'socks4', 'socks4a', 'socks5', 'socks5h']


### PR DESCRIPTION
This pull request includes:
- when a HLS AES stream fails instruct the user to enable DRM and Inputstream Adaptive based on the current settings.