### PR TITLE
Do not clear username if login failed

### DIFF
--- a/resources/lib/helperobjects.py
+++ b/resources/lib/helperobjects.py
@@ -39,7 +39,8 @@ class Credentials:
 
     def reset(self):
         ''' Reset the credentials in the settings '''
-        self.username = self._kodi.set_setting('username', None)
+        # NOTE: Do not reset the username, this can be edited by the user and doesn't need to be retyped
+        # self.username = self._kodi.set_setting('username', None)
         self.password = self._kodi.set_setting('password', None)
 
 


### PR DESCRIPTION
So currently when you type in a username and password, you can visually
verify the username is correct, but the password is a bunch of
asterisks. So if the login failed we assume the username was correct
(and can be verified by the user) but since the password is not visible
and cannot be edited we reset only the password.

This is a bit more userfriendly. An option to show the password would be
even better so we don't need to reset anything (just mark as invalid).