### PR TITLE
Mix tvshows and oneoff episodes

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -119,7 +119,7 @@ msgid "My documentaries"
 msgstr ""
 
 msgctxt "#30045"
-msgid "All [I]oneoff[/I] documentaries on VRT NU"
+msgid "All [I]one-off[/I] documentaries on VRT NU"
 msgstr ""
 
 msgctxt "#30046"
@@ -400,122 +400,126 @@ msgid "Add My documentaries"
 msgstr ""
 
 msgctxt "#30829"
-msgid "Show fanart"
+msgid "Show one-off videos in between program folders"
 msgstr ""
 
 msgctxt "#30831"
-msgid "Show episode permalink in plot"
-msgstr ""
-
-msgctxt "#30832"
-msgid "When enabled, the video description will include a permanent link that points to this episode. This is useful for quickly opening an episode or movie on a mobile device."
+msgid "Show fanart"
 msgstr ""
 
 msgctxt "#30833"
-msgid "Cache"
+msgid "Show episode permalink in plot"
+msgstr ""
+
+msgctxt "#30834"
+msgid "When enabled, the video description will include a permanent link that points to this episode. This is useful for quickly opening an episode or movie on a mobile device."
 msgstr ""
 
 msgctxt "#30835"
-msgid "Enable menu caching"
-msgstr ""
-
-msgctxt "#30836"
-msgid "When enabled, menus are being cached so they work more quickly. Only in very specific use-cases this is problematic as new episodes may not appear when they are expected."
+msgid "Cache"
 msgstr ""
 
 msgctxt "#30837"
+msgid "Enable menu caching"
+msgstr ""
+
+msgctxt "#30838"
+msgid "When enabled, menus are being cached so they work more quickly. Only in very specific use-cases this is problematic as new episodes may not appear when they are expected."
+msgstr ""
+
+msgctxt "#30839"
 msgid "Enable local HTTP caching"
 msgstr ""
 
-msgctxt "#30840"
+msgctxt "#30860"
 msgid "Playback"
 msgstr ""
 
-msgctxt "#30841"
+msgctxt "#30861"
 msgid "Subtitles"
 msgstr ""
 
-msgctxt "#30843"
+msgctxt "#30863"
 msgid "Show subtitles when available"
 msgstr ""
 
-msgctxt "#30844"
+msgctxt "#30864"
 msgid "This enables subtitles by default for all content that includes substitles."
 msgstr ""
 
-msgctxt "#30845"
+msgctxt "#30865"
 msgid "Streaming"
 msgstr ""
 
-msgctxt "#30847"
+msgctxt "#30867"
 msgid "Use DRM [COLOR gray][I](needed for protected content)[/I][/COLOR]"
 msgstr ""
 
-msgctxt "#30848"
+msgctxt "#30868"
 msgid "Most live streams are available in 720p HD-quality, but may require DRM to be enabled."
 msgstr ""
 
-msgctxt "#30849"
+msgctxt "#30869"
 msgid "Maximum bandwidth (kbps)"
 msgstr ""
 
-msgctxt "#30850"
+msgctxt "#30890"
 msgid "In case you have limited bandwidth available, you may want to specify a maximum bandwidth so that a lower bitrate stream can be selected for playback."
 msgstr ""
 
-msgctxt "#30860"
+msgctxt "#30880"
 msgid "Channels"
 msgstr ""
 
-msgctxt "#30861"
+msgctxt "#30881"
 msgid "Select channels to use for 'Most recent' and 'Soon offline' listings"
 msgstr ""
 
-msgctxt "#30863"
+msgctxt "#30883"
 msgid "Eén"
 msgstr ""
 
-msgctxt "#30864"
+msgctxt "#30884"
 msgid "Canvas"
 msgstr ""
 
-msgctxt "#30865"
+msgctxt "#30885"
 msgid "Ketnet"
 msgstr ""
 
-msgctxt "#30866"
+msgctxt "#30886"
 msgid "Ketnet Junior"
 msgstr ""
 
-msgctxt "#30867"
+msgctxt "#30887"
 msgid "Sporza"
 msgstr ""
 
-msgctxt "#30868"
+msgctxt "#30888"
 msgid "Radio 1"
 msgstr ""
 
-msgctxt "#30869"
+msgctxt "#30889"
 msgid "Radio 2"
 msgstr ""
 
-msgctxt "#30870"
+msgctxt "#30890"
 msgid "Klara"
 msgstr ""
 
-msgctxt "#30871"
+msgctxt "#30891"
 msgid "Studio Brussel"
 msgstr ""
 
-msgctxt "#30872"
+msgctxt "#30892"
 msgid "MNM"
 msgstr ""
 
-msgctxt "#30873"
+msgctxt "#30893"
 msgid "VRT NXT"
 msgstr ""
 
-msgctxt "#30874"
+msgctxt "#30894"
 msgid "VRT NWS"
 msgstr ""
 

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -120,8 +120,8 @@ msgid "My documentaries"
 msgstr "Mijn documentaires"
 
 msgctxt "#30045"
-msgid "All [I]oneoff[/I] documentaries on VRT NU"
-msgstr "Alle [I]oneoff[/I] documentaires op VRT NU"
+msgid "All [I]one-off[/I] documentaries on VRT NU"
+msgstr "Alle [I]one-off[/I] documentaires op VRT NU"
 
 msgctxt "#30046"
 msgid "My most recent"
@@ -295,107 +295,111 @@ msgctxt "#30827"
 msgid "Add My documentaries"
 msgstr "Toon Mijn documentaires"
 
-msgctxt "#30825"
+msgctxt "#30829"
+msgid "Show one-off videos in between program folders"
+msgstr "Toon one-off videos tussen tv-programmafolders"
+
+msgctxt "#30831"
 msgid "Show fanart"
 msgstr "Toon fanart"
 
-msgctxt "#30827"
+msgctxt "#30833"
 msgid "Show episode permalink in plot"
 msgstr "Toon aflevering permalink in beschrijving"
 
-msgctxt "#30828"
+msgctxt "#30834"
 msgid "When enabled, the video description will include a permanent link that points to this episode. This is useful for quickly opening an episode or movie on a mobile device."
 msgstr "Indien actief zal de beschrijving van iedere video een permanent link bevatten die je rechtstreeks naar de VRT NU website brengt. Dit is handig om snel een aflevering of film to openen op een mobiel toestel."
 
-msgctxt "#30829"
+msgctxt "#30835"
 msgid "Cache"
 msgstr "Cache"
 
-msgctxt "#30831"
+msgctxt "#30837"
 msgid "Enable menu caching"
 msgstr "Gebruik menu caching"
 
-msgctxt "#30833"
+msgctxt "#30839"
 msgid "Enable local HTTP caching"
 msgstr "Gebruik local HTTP caching"
 
-msgctxt "#30840"
+msgctxt "#30880"
 msgid "Playback"
 msgstr "Afspelen"
 
-msgctxt "#30841"
+msgctxt "#30881"
 msgid "Subtitles"
 msgstr "Ondertiteling"
 
-msgctxt "#30843"
+msgctxt "#30883"
 msgid "Show subtitles when available"
 msgstr "Toon ondertiteling indien beschikbaar"
 
-msgctxt "#30845"
+msgctxt "#30885"
 msgid "Streaming"
 msgstr "Streaming"
 
-msgctxt "#30847"
+msgctxt "#30887"
 msgid "Use DRM [COLOR gray][I](needed for protected content)[/I][/COLOR]"
 msgstr "Gebruik DRM [COLOR gray][I](nodig voor beschermde video's)[/I][/COLOR]"
 
-msgctxt "#30849"
+msgctxt "#30889"
 msgid "Maximum bandwidth (kbps)"
 msgstr "Maximale bandbreedte (kbps)"
 
-msgctxt "#30860"
+msgctxt "#30880"
 msgid "Channels"
 msgstr "Kanalen"
 
-msgctxt "#30861"
+msgctxt "#30881"
 msgid "Select channels to use for 'Most recent' and 'Soon offline' listings"
 msgstr "Selecteer kanalen voor de 'Meest recent' en 'Binnenkort offline' lijsten"
 
-msgctxt "#30863"
+msgctxt "#30883"
 msgid "Eén"
 msgstr "Eén"
 
-msgctxt "#30864"
+msgctxt "#30884"
 msgid "Canvas"
 msgstr "Canvas"
 
-msgctxt "#30865"
+msgctxt "#30885"
 msgid "Ketnet"
 msgstr "Ketnet"
 
-msgctxt "#30866"
+msgctxt "#30886"
 msgid "Ketnet Junior"
 msgstr "Ketnet Junior"
 
-msgctxt "#30867"
+msgctxt "#30887"
 msgid "Sporza"
 msgstr "Sporza"
 
-msgctxt "#30868"
+msgctxt "#30888"
 msgid "Radio 1"
 msgstr "Radio 1"
 
-msgctxt "#30869"
+msgctxt "#30889"
 msgid "Radio 2"
 msgstr "Radio 2"
 
-msgctxt "#30870"
+msgctxt "#30890"
 msgid "Klara"
 msgstr "Klara"
 
-msgctxt "#30871"
+msgctxt "#30891"
 msgid "Studio Brussel"
 msgstr "Studio Brussel"
 
-msgctxt "#30872"
+msgctxt "#30892"
 msgid "MNM"
 msgstr "MNM"
 
-msgctxt "#30873"
+msgctxt "#30893"
 msgid "VRT NXT"
 msgstr "VRT NXT"
 
-msgctxt "#30874"
+msgctxt "#30894"
 msgid "VRT NWS"
 msgstr "VRT NWS"
 

--- a/resources/lib/favorites.py
+++ b/resources/lib/favorites.py
@@ -35,8 +35,8 @@ class Favorites:
         ''' Get a cached copy or a newer favorites from VRT, or fall back to a cached file '''
         if not self.is_activated():
             return
-        api_json = self._kodi.get_cache('favorites.json', ttl)
-        if not api_json:
+        favorites_json = self._kodi.get_cache('favorites.json', ttl)
+        if not favorites_json:
             xvrttoken = self._tokenresolver.get_xvrttoken(token_variant='user')
             if xvrttoken:
                 headers = {
@@ -48,13 +48,13 @@ class Favorites:
                 self._kodi.log_notice('URL post: https://video-user-data.vrt.be/favorites', 'Verbose')
                 import json
                 try:
-                    api_json = json.load(urlopen(req))
+                    favorites_json = json.load(urlopen(req))
                 except Exception:
                     # Force favorites from cache
-                    api_json = self._kodi.get_cache('favorites.json', ttl=None)
+                    favorites_json = self._kodi.get_cache('favorites.json', ttl=None)
                 else:
-                    self._kodi.update_cache('favorites.json', api_json)
-        self._favorites = api_json
+                    self._kodi.update_cache('favorites.json', favorites_json)
+        self._favorites = favorites_json
 
     def set_favorite(self, program, title, value=True):
         ''' Set a program as favorite, and update local copy '''

--- a/resources/lib/helperobjects.py
+++ b/resources/lib/helperobjects.py
@@ -66,3 +66,6 @@ class TitleItem:
         self.info_dict = info_dict
         self.context_menu = context_menu
         self.is_playable = is_playable
+
+    def __str__(self):
+        return 'TitleItem[%s]' % self.title

--- a/resources/lib/kodiwrapper.py
+++ b/resources/lib/kodiwrapper.py
@@ -537,9 +537,7 @@ class KodiWrapper:
 
     def refresh_caches(self, cache_file=None):
         ''' Invalidate the needed caches and refresh container '''
-        from resources.lib.statichelper import oneoff_filename
         self.invalidate_caches(expr=cache_file)
-        self.invalidate_caches(expr=oneoff_filename(cache_file))
         self.container_refresh()
 
     def invalidate_cache(self, path):
@@ -554,6 +552,7 @@ class KodiWrapper:
             files = fnmatch.filter(files, expr)
         for f in files:
             self.delete_file(self._cache_path + f)
+        self.delete_file(self._cache_path + 'oneoff.json')
 
     def container_refresh(self):
         ''' Refresh the current container '''

--- a/resources/lib/kodiwrapper.py
+++ b/resources/lib/kodiwrapper.py
@@ -153,6 +153,10 @@ class KodiWrapper:
         if not ascending:
             sort = 'unsorted'
 
+        # NOTE: When showing tvshow listings and 'showoneoff' was set, force 'unsorted'
+        if self.get_setting('showoneoff', 'true') == 'true' and sort == 'label':
+            sort = 'unsorted'
+
         # Add all sort methods to GUI (start with preferred)
         xbmcplugin.addSortMethod(handle=self._handle, sortMethod=sort_methods[sort])
         for key in sorted(sort_methods):
@@ -533,7 +537,9 @@ class KodiWrapper:
 
     def refresh_caches(self, cache_file=None):
         ''' Invalidate the needed caches and refresh container '''
+        from resources.lib.statichelper import oneoff_filename
         self.invalidate_caches(expr=cache_file)
+        self.invalidate_caches(expr=oneoff_filename(cache_file))
         self.container_refresh()
 
     def invalidate_cache(self, path):

--- a/resources/lib/statichelper.py
+++ b/resources/lib/statichelper.py
@@ -120,9 +120,3 @@ def realpage(page):
     if page < 1:
         return 1
     return page
-
-
-def oneoff_filename(filename):
-    ''' Create a oneoff filename alternative '''
-    import os.path
-    return '%s-oneoff%s' % os.path.splitext(os.path.basename(filename))

--- a/resources/lib/statichelper.py
+++ b/resources/lib/statichelper.py
@@ -120,3 +120,9 @@ def realpage(page):
     if page < 1:
         return 1
     return page
+
+
+def oneoff_filename(filename):
+    ''' Create a oneoff filename alternative '''
+    import os.path
+    return '%s-oneoff%s' % os.path.splitext(os.path.basename(filename))

--- a/resources/lib/streamservice.py
+++ b/resources/lib/streamservice.py
@@ -266,7 +266,8 @@ class StreamService:
 
     def _handle_bad_stream_error(self, protocol):
         ''' Show a localized error message in Kodi GUI for a failing VRT NU stream based on protocol: hls, hls_aes, mpeg_dash)
-            message: VRT NU stream <stream_type> problem, try again with (InputStream Adaptive) (and) (DRM) enabled/disabled: 30959=and DRM, 30960=disabled, 30961=enabled
+            message: VRT NU stream <stream_type> problem, try again with (InputStream Adaptive) (and) (DRM) enabled/disabled:
+                30959=and DRM, 30960=disabled, 30961=enabled
         '''
         # HLS AES DRM failed
         if protocol == 'hls_aes' and not self._kodi.has_inputstream_adaptive() and self._kodi.get_setting('usedrm', 'true') == 'false':

--- a/resources/lib/tvguide.py
+++ b/resources/lib/tvguide.py
@@ -126,19 +126,19 @@ class TVGuide:
         now = datetime.now(dateutil.tz.tzlocal())
         epg = self.parse(date, now)
         datelong = self._kodi.localize_datelong(epg)
-        api_url = epg.strftime(self.VRT_TVGUIDE)
+        epg_url = epg.strftime(self.VRT_TVGUIDE)
 
         if date in ('today', 'yesterday', 'tomorrow'):
             cache_file = 'schedule.%s.json' % date
             # Try the cache if it is fresh
             schedule = self._kodi.get_cache(cache_file, ttl=60 * 60)
             if not schedule:
-                self._kodi.log_notice('URL get: ' + api_url, 'Verbose')
-                schedule = json.load(urlopen(api_url))
+                self._kodi.log_notice('URL get: ' + epg_url, 'Verbose')
+                schedule = json.load(urlopen(epg_url))
                 self._kodi.update_cache(cache_file, schedule)
         else:
-            self._kodi.log_notice('URL get: ' + api_url, 'Verbose')
-            schedule = json.load(urlopen(api_url))
+            self._kodi.log_notice('URL get: ' + epg_url, 'Verbose')
+            schedule = json.load(urlopen(epg_url))
 
         name = channel
         try:
@@ -209,9 +209,9 @@ class TVGuide:
         # Try the cache if it is fresh
         schedule = self._kodi.get_cache('schedule.today.json', ttl=60 * 60)
         if not schedule:
-            api_url = epg.strftime(self.VRT_TVGUIDE)
-            self._kodi.log_notice('URL get: ' + api_url, 'Verbose')
-            schedule = json.load(urlopen(api_url))
+            epg_url = epg.strftime(self.VRT_TVGUIDE)
+            self._kodi.log_notice('URL get: ' + epg_url, 'Verbose')
+            schedule = json.load(urlopen(epg_url))
             self._kodi.update_cache('schedule.today.json', schedule)
         name = channel
         try:

--- a/resources/lib/vrtapihelper.py
+++ b/resources/lib/vrtapihelper.py
@@ -67,11 +67,14 @@ class VRTApiHelper:
 
         # Get oneoffs
         if self._kodi.get_setting('showoneoff', 'true') == 'true':
-            oneoff_cache = statichelper.oneoff_filename(cache_file)
-            search_json = self._kodi.get_cache(oneoff_cache, ttl=60 * 60)  # Try the cache if it is fresh
+            oneoff_cache = 'oneoff.json'
+            search_json = self._kodi.get_cache(oneoff_cache, ttl=30 * 60)  # Try the cache if it is fresh
             if not search_json:
                 import json
-                params['facets[programType]'] = 'oneoff'
+                params = {
+                    'facets[programType]': 'oneoff',
+                    'size': '300',
+                }
                 search_url = self._VRTNU_SEARCH_URL + '?' + urlencode(params)
                 self._kodi.log_notice('URL get: ' + unquote(search_url), 'Verbose')
                 search_json = json.load(urlopen(search_url))
@@ -266,6 +269,9 @@ class VRTApiHelper:
 
         if use_favorites:
             favorite_programs = self._favorites.programs()
+
+        # NOTE: Sort the episodes ourselves, because Kodi does not allow to set to 'ascending'
+        episodes = sorted(episodes, key=lambda k: k['title'])
 
         episode_items = []
         for episode in episodes:

--- a/resources/lib/vrtplayer.py
+++ b/resources/lib/vrtplayer.py
@@ -19,9 +19,6 @@ class VRTPlayer:
         self._favorites = favorites.Favorites(_kodi)
         self._apihelper = vrtapihelper.VRTApiHelper(_kodi, self._favorites)
 
-        self._addmymovies = _kodi.get_setting('addmymovies', 'true') == 'true'
-        self._addmydocu = _kodi.get_setting('addmydocu', 'true') == 'true'
-
     def show_main_menu_items(self):
         ''' The VRT NU add-on main menu '''
         self._favorites.get_favorites(ttl=60 * 60)
@@ -99,7 +96,7 @@ class VRTPlayer:
                       info_dict=dict(plot=self._kodi.localize(30049))),
         ]
 
-        if self._addmymovies:
+        if self._kodi.get_setting('addmymovies', 'true') == 'true':
             favorites_items.append(
                 TitleItem(title=self._kodi.localize(30042),  # My movies
                           path=self._kodi.url_for('categories', category='films'),
@@ -107,7 +104,7 @@ class VRTPlayer:
                           info_dict=dict(plot=self._kodi.localize(30043))),
             )
 
-        if self._addmydocu:
+        if self._kodi.get_setting('addmydocu', 'true') == 'true':
             favorites_items.append(
                 TitleItem(title=self._kodi.localize(30044),  # My documentaries
                           path=self._kodi.url_for('favorites_docu'),
@@ -136,17 +133,13 @@ class VRTPlayer:
 
     def show_category_menu_items(self, category=None):
         ''' The VRT NU add-on 'Categories' listing menu '''
-        if category == 'films':
-            self._favorites.get_favorites(ttl=60 * 60)
-            episode_items, sort, ascending, content = self._apihelper.get_episode_items(category=category, season='allseasons')
-            self._kodi.show_listing(episode_items, sort=sort, ascending=ascending, content=content)
-        elif category:
+        if category:
             self._favorites.get_favorites(ttl=60 * 60)
             tvshow_items = self._apihelper.get_tvshow_items(category=category)
             self._kodi.show_listing(tvshow_items, sort='label', content='tvshows')
         else:
             category_items = self._apihelper.get_category_items()
-            self._kodi.show_listing(category_items, sort='label', content='files')
+            self._kodi.show_listing(category_items, sort='unsorted', content='files')
 
     def show_channels_menu_items(self, channel=None):
         ''' The VRT NU add-on 'Channels' listing menu '''
@@ -162,11 +155,7 @@ class VRTPlayer:
 
     def show_featured_menu_items(self, feature=None):
         ''' The VRT NU add-on 'Featured content' listing menu '''
-        if feature == 'kortfilm':
-            self._favorites.get_favorites(ttl=60 * 60)
-            episode_items, sort, ascending, content = self._apihelper.get_episode_items(feature=feature, season='allseasons')
-            self._kodi.show_listing(episode_items, sort=sort, ascending=ascending, content=content)
-        elif feature:
+        if feature:
             self._favorites.get_favorites(ttl=60 * 60)
             tvshow_items = self._apihelper.get_tvshow_items(feature=feature)
             self._kodi.show_listing(tvshow_items, sort='label', content='tvshows')

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -10,33 +10,34 @@
         <setting label="30823" help="30824" type="bool" id="usefavorites" default="true"/>
         <setting label="30825" help="30826" type="bool" id="addmymovies" default="true" enable="eq(-1,true)" subsetting="true"/>
         <setting label="30827" help="30828" type="bool" id="addmydocu" default="true" enable="eq(-2,true)" subsetting="true"/>
-        <setting label="30829" help="30830" type="bool" id="showfanart" default="true"/>
-        <setting label="30831" help="30832" type="bool" id="showpermalink" default="false"/>
-        <setting label="30833" type="lsep"/> <!-- Cache -->
-        <setting label="30835" help="30836" type="bool" id="usemenucaching" default="true"/>
-        <setting label="30837" help="30837" type="bool" id="usehttpcaching" default="true"/>
+        <setting label="30829" help="30830" type="bool" id="showoneoff" default="true"/>
+        <setting label="30831" help="30832" type="bool" id="showfanart" default="true"/>
+        <setting label="30833" help="30834" type="bool" id="showpermalink" default="false"/>
+        <setting label="30835" type="lsep"/> <!-- Cache -->
+        <setting label="30837" help="30838" type="bool" id="usemenucaching" default="true"/>
+        <setting label="30839" help="30840" type="bool" id="usehttpcaching" default="true"/>
     </category>
-    <category label="30840"> <!-- Playback -->
-        <setting label="30841" type="lsep"/>
-        <setting label="30843" help="30844" type="bool" id="showsubtitles" default="true"/>
-        <setting label="30845" type="lsep"/> <!-- InputStream Adaptive -->
-        <setting label="30847" help="30848" type="bool" id="usedrm" default="false"/>
-        <setting label="30849" help="30850" type="select" id="max_bandwidth" default="0" values="0|256|512|1024|1536|2048|2560|3072|4096|6144|8192|10240|15360|20480|25600|30720"/>
-    </category>
-    <category label="30860"> <!--Channels -->
+    <category label="30860"> <!-- Playback -->
         <setting label="30861" type="lsep"/>
-        <setting label="30863" type="bool" id="een" default="true"/> <!-- Eén -->
-        <setting label="30864" type="bool" id="canvas" default="true"/> <!-- Canvas -->
-        <setting label="30865" type="bool" id="ketnet" default="false"/> <!-- Ketnet -->
-        <setting label="30866" type="bool" id="ketnet-jr" default="false"/> <!-- Ketnet Junior -->
-        <setting label="30867" type="bool" id="sporza" default="true"/> <!-- Sporza -->
-        <setting label="30868" type="bool" id="radio1" default="true"/> <!-- Radio 1 -->
-        <setting label="30869" type="bool" id="radio2" default="true"/> <!-- Radio 2 -->
-        <setting label="30870" type="bool" id="klara" default="true"/> <!-- Klara -->
-        <setting label="30871" type="bool" id="stubru" default="true"/> <!-- Studio Brussel -->
-        <setting label="30872" type="bool" id="mnm" default="true"/> <!-- MNM -->
-        <setting label="30873" type="bool" id="vrtnws" default="true"/> <!-- VRT NWS -->
-        <setting label="30874" type="bool" id="vrtnxt" default="true"/> <!-- VRT NXT -->
+        <setting label="30863" help="30864" type="bool" id="showsubtitles" default="true"/>
+        <setting label="30865" type="lsep"/> <!-- InputStream Adaptive -->
+        <setting label="30867" help="30868" type="bool" id="usedrm" default="false"/>
+        <setting label="30869" help="30870" type="select" id="max_bandwidth" default="0" values="0|256|512|1024|1536|2048|2560|3072|4096|6144|8192|10240|15360|20480|25600|30720"/>
+    </category>
+    <category label="30880"> <!--Channels -->
+        <setting label="30881" type="lsep"/>
+        <setting label="30883" type="bool" id="een" default="true"/> <!-- Eén -->
+        <setting label="30884" type="bool" id="canvas" default="true"/> <!-- Canvas -->
+        <setting label="30885" type="bool" id="ketnet" default="false"/> <!-- Ketnet -->
+        <setting label="30886" type="bool" id="ketnet-jr" default="false"/> <!-- Ketnet Junior -->
+        <setting label="30887" type="bool" id="sporza" default="true"/> <!-- Sporza -->
+        <setting label="30888" type="bool" id="radio1" default="true"/> <!-- Radio 1 -->
+        <setting label="30889" type="bool" id="radio2" default="true"/> <!-- Radio 2 -->
+        <setting label="30890" type="bool" id="klara" default="true"/> <!-- Klara -->
+        <setting label="30891" type="bool" id="stubru" default="true"/> <!-- Studio Brussel -->
+        <setting label="30892" type="bool" id="mnm" default="true"/> <!-- MNM -->
+        <setting label="30893" type="bool" id="vrtnws" default="true"/> <!-- VRT NWS -->
+        <setting label="30894" type="bool" id="vrtnxt" default="true"/> <!-- VRT NXT -->
     </category>
     <category label="30900"> <!-- Troubleshooting -->
         <setting label="30901" type="lsep"/> <!-- Cache -->

--- a/test/vrtplayertests.py
+++ b/test/vrtplayertests.py
@@ -85,11 +85,18 @@ class TestVRTPlayer(unittest.TestCase):
         self.assertTrue(tvshow_items, msg=category['id'])
 
         tvshow = random.choice(tvshow_items)
-        episode_items, sort, ascending, content = self._apihelper.get_episode_items(tvshow.path.split('/')[4])
-        self.assertTrue(episode_items, msg=tvshow.path.split('/')[4])
-        self.assertTrue(sort in ['dateadded', 'episode', 'label', 'unsorted'])
-        self.assertTrue(ascending is True or ascending is False)
-        self.assertTrue(content in ['episodes', 'seasons'], "Content for '%s' is '%s'" % (tvshow.title, content))
+        if tvshow.path.startswith('plugin://plugin.video.vrt.nu/programs/'):
+            # When random program has episodes
+            episode_items, sort, ascending, content = self._apihelper.get_episode_items(tvshow.path.split('/')[4])
+            self.assertTrue(episode_items, msg=tvshow.path.split('/')[4])
+            self.assertTrue(sort in ['dateadded', 'episode', 'label', 'unsorted'])
+            self.assertTrue(ascending is True or ascending is False)
+            self.assertTrue(content in ['episodes', 'seasons'], "Content for '%s' is '%s'" % (tvshow.title, content))
+        elif tvshow.path.startswith('plugin://plugin.video.vrt.nu/play/id/'):
+            # When random program is playable item
+            pass
+        else:
+            self.fail('We did not expect this, either we find episodes or it is a playable item')
 
     def test_categories(self):
         ''' Test to ensure our hardcoded categories conforms to scraped categories '''


### PR DESCRIPTION
This implements showing oneoff programs in the list of tvshows. This
adds the convenience of not requiring to dig one level deeper to get to
the video.

This PR includes:
- Mixing multi-episode programs and one-off episodes (movies and documentaries)
- Add a one-off cache that is used for all oneoff-queries (number of oneoff programs is about 30)
- Indicate which programs are being followed using a °-character)

This fixes #329 