### PR TITLE
Add favorites support to TV Guide

### DIFF
--- a/resources/lib/statichelper.py
+++ b/resources/lib/statichelper.py
@@ -50,19 +50,23 @@ def program_to_url(program, url_type):
 
 
 def url_to_program(url):
-    ''' Convert a targetUrl (e.g. //www.vrt.be/vrtnu/a-z/de-campus-cup.relevant/), a short programUrl (e.g. /vrtnu/a-z/de-campus-cup/)
-        or a long programUrl (e.g. //www.vrt.be/vrtnu/a-z/de-campus-cup/) to a program url component (e.g. de-campus-cup)
+    ''' Convert
+          - a targetUrl (e.g. //www.vrt.be/vrtnu/a-z/de-campus-cup.relevant/),
+          - a short programUrl (e.g. /vrtnu/a-z/de-campus-cup/) or
+          - a long programUrl (e.g. //www.vrt.be/vrtnu/a-z/de-campus-cup/)
+        to a program url component (e.g. de-campus-cup).
+        Any season or episode information is removed as well.
     '''
     program = None
-    # targetUrl
-    if url.startswith('//www.vrt.be/vrtnu/a-z/') and url.endswith('.relevant/'):
-        program = url.replace('//www.vrt.be/vrtnu/a-z/', '').replace('.relevant/', '')
-    # short programUrl
+    if url.startswith('//www.vrt.be/vrtnu/a-z/'):
+        # long programUrl or targetUrl
+        program = url.split('/')[5]
+        if program.endswith('.relevant'):
+            # targetUrl
+            program = program.replace('.relevant', '')
     elif url.startswith('/vrtnu/a-z/'):
-        program = url.replace('/vrtnu/a-z/', '').rstrip('/')
-    # long programUrl
-    elif url.startswith('//www.vrt.be/vrtnu/a-z/'):
-        program = url.replace('//www.vrt.be/vrtnu/a-z/', '').rstrip('/')
+        # short programUrl
+        program = url.split('/')[3]
     return program
 
 

--- a/resources/lib/vrtapihelper.py
+++ b/resources/lib/vrtapihelper.py
@@ -127,12 +127,12 @@ class VRTApiHelper:
         else:
             thumbnail = 'DefaultAddonVideo.png'
         if self._favorites.is_activated():
-            program_title = tvshow.get('title').encode('utf-8')
+            program_title = quote(tvshow.get('title').encode('utf-8'), '')
             if self._favorites.is_favorite(program):
-                context_menu = [(self._kodi.localize(30412), 'RunPlugin(%s)' % self._kodi.url_for('unfollow', program=program, title=quote(program_title, '')))]
+                context_menu = [(self._kodi.localize(30412), 'RunPlugin(%s)' % self._kodi.url_for('unfollow', program=program, title=program_title))]
                 label += ' [COLOR yellow]°[/COLOR]'
             else:
-                context_menu = [(self._kodi.localize(30411), 'RunPlugin(%s)' % self._kodi.url_for('follow', program=program, title=quote(program_title, '')))]
+                context_menu = [(self._kodi.localize(30411), 'RunPlugin(%s)' % self._kodi.url_for('follow', program=program, title=program_title))]
         else:
             context_menu = []
         context_menu.append((self._kodi.localize(30413), 'RunPlugin(%s)' % self._kodi.url_for('delete_cache', cache_file=cache_file)))
@@ -357,12 +357,12 @@ class VRTApiHelper:
 
         label, sort, ascending = self._make_label(episode, titletype, options=display_options)
         if self._favorites.is_activated():
-            program_title = episode.get('program').encode('utf-8')
+            program_title = quote(episode.get('program').encode('utf-8'), '')
             if self._favorites.is_favorite(program):
-                context_menu = [(self._kodi.localize(30412), 'RunPlugin(%s)' % self._kodi.url_for('unfollow', program=program, title=quote(program_title, '')))]
+                context_menu = [(self._kodi.localize(30412), 'RunPlugin(%s)' % self._kodi.url_for('unfollow', program=program, title=program_title))]
                 label += ' [COLOR yellow]°[/COLOR]'
             else:
-                context_menu = [(self._kodi.localize(30411), 'RunPlugin(%s)' % self._kodi.url_for('follow', program=program, title=quote(program_title, '')))]
+                context_menu = [(self._kodi.localize(30411), 'RunPlugin(%s)' % self._kodi.url_for('follow', program=program, title=program_title))]
         else:
             context_menu = []
         context_menu.append((self._kodi.localize(30413), 'RunPlugin(%s)' % self._kodi.url_for('delete_cache', cache_file=cache_file)))

--- a/test/vrtplayertests.py
+++ b/test/vrtplayertests.py
@@ -87,7 +87,7 @@ class TestVRTPlayer(unittest.TestCase):
         tvshow = random.choice(tvshow_items)
         if tvshow.path.startswith('plugin://plugin.video.vrt.nu/programs/'):
             # When random program has episodes
-            episode_items, sort, ascending, content = self._apihelper.get_episode_items(tvshow.path.split('/')[4])
+            episode_items, sort, ascending, content = self._apihelper.get_episode_items(tvshow.path.split('/')[4].replace('.relevant', ''))
             self.assertTrue(episode_items, msg=tvshow.path.split('/')[4])
             self.assertTrue(sort in ['dateadded', 'episode', 'label', 'unsorted'])
             self.assertTrue(ascending is True or ascending is False)


### PR DESCRIPTION
This adds basic favorites support to the TV Guide. This is however only
possible for episodes that have already aired, because we need the
program name from the URL that is provided.

This fixes #336 