### PR TITLE
improve streaming settings

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -452,7 +452,7 @@ msgid "Streaming"
 msgstr ""
 
 msgctxt "#30867"
-msgid "Use DRM [COLOR gray][I](needed for protected content)[/I][/COLOR]"
+msgid "Use Widevine DRM [COLOR gray][I](for protected content)[/I][/COLOR]"
 msgstr ""
 
 msgctxt "#30868"
@@ -463,7 +463,7 @@ msgctxt "#30869"
 msgid "Maximum bandwidth (kbps)"
 msgstr ""
 
-msgctxt "#30890"
+msgctxt "#30870"
 msgid "In case you have limited bandwidth available, you may want to specify a maximum bandwidth so that a lower bitrate stream can be selected for playback."
 msgstr ""
 
@@ -560,7 +560,7 @@ msgid "InputStream Adaptive settings..."
 msgstr ""
 
 msgctxt "#30917"
-msgid "Install Widevine CDM... [COLOR gray][I](needed for protected content)[/I][/COLOR]"
+msgid "Install Widevine CDM... [COLOR gray][I](for protected content)[/I][/COLOR]"
 msgstr ""
 
 msgctxt "#30919"
@@ -606,7 +606,7 @@ msgid "There is a problem with this VRT NU %s stream. Try again with %s %s %s or
 msgstr ""
 
 msgctxt "#30959"
-msgid "and DRM"
+msgid "and Widevine DRM"
 msgstr ""
 
 msgctxt "#30960"
@@ -618,6 +618,10 @@ msgid "enabled"
 msgstr ""
 
 msgctxt "#30962"
+msgid "There is a problem with this VRT NU %s stream and Kodi %s doesn't support the alternative stream. Please upgrade to a newer Kodi version or try to play this program from the VRT NU website. Please report this problem at https://www.vrt.be/vrtnu/help/"
+msgstr ""
+
+msgctxt "#30965"
 msgid "Using a SOCKS proxy requires the PySocks library (script.module.pysocks) installed."
 msgstr ""
 

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -79,7 +79,7 @@ msgstr "Uitgelicht aanbod"
 
 msgctxt "#30025"
 msgid "Highlighted movies and programs"
-msgstr "Aanbevolen films en tvprogramma's"
+msgstr "Aanbevolen films en tv-programma's"
 
 msgctxt "#30026"
 msgid "TV guide"
@@ -323,29 +323,41 @@ msgctxt "#30839"
 msgid "Enable local HTTP caching"
 msgstr "Gebruik local HTTP caching"
 
-msgctxt "#30880"
+msgctxt "#30860"
 msgid "Playback"
 msgstr "Afspelen"
 
-msgctxt "#30881"
+msgctxt "#30861"
 msgid "Subtitles"
 msgstr "Ondertiteling"
 
-msgctxt "#30883"
+msgctxt "#30863"
 msgid "Show subtitles when available"
 msgstr "Toon ondertiteling indien beschikbaar"
 
-msgctxt "#30885"
+msgctxt "#30864"
+msgid "This enables subtitles by default for all content that includes substitles."
+msgstr "Dit zet ondertitels standaard aan voor alle inhoud met ondertitels."
+
+msgctxt "#30865"
 msgid "Streaming"
 msgstr "Streaming"
 
-msgctxt "#30887"
-msgid "Use DRM [COLOR gray][I](needed for protected content)[/I][/COLOR]"
-msgstr "Gebruik DRM [COLOR gray][I](nodig voor beschermde video's)[/I][/COLOR]"
+msgctxt "#30867"
+msgid "Use Widevine DRM [COLOR gray][I](for protected content)[/I][/COLOR]"
+msgstr "Gebruik Widevine DRM [COLOR gray][I](voor beveiligde video's)[/I][/COLOR]"
 
-msgctxt "#30889"
+msgctxt "#30868"
+msgid "Most live streams are available in 720p HD-quality, but may require DRM to be enabled."
+msgstr "De meeste livestreams zijn beschikbaar in 720p HD-kwaliteit, maar hiervoor moet mogelijk DRM worden ingeschakeld."
+
+msgctxt "#30869"
 msgid "Maximum bandwidth (kbps)"
 msgstr "Maximale bandbreedte (kbps)"
+
+msgctxt "#30870"
+msgid "In case you have limited bandwidth available, you may want to specify a maximum bandwidth so that a lower bitrate stream can be selected for playback."
+msgstr "Als de bandbreedte van je verbinding gelimiteerd is, wilt u misschien een maximale bandbreedte instellen zodat een stream met lagere bitrate-stream wordt geselecteerd."
 
 msgctxt "#30880"
 msgid "Channels"
@@ -413,15 +425,15 @@ msgstr "Cache"
 
 msgctxt "#30903"
 msgid "Clear VRT tokens"
-msgstr "Verwijder VRT tokens"
+msgstr "Verwijder VRT-tokens"
 
 msgctxt "#30905"
 msgid "Refresh favorites"
-msgstr "Ververs gevolgde programma's"
+msgstr "Ververs favoriete tv-programma's"
 
 msgctxt "#30907"
 msgid "Invalidate local HTTP caches"
-msgstr "Invalideer local HTTP caches"
+msgstr "Maak lokale HTTP caches ongeldig"
 
 msgctxt "#30909"
 msgid "Streaming"
@@ -440,8 +452,8 @@ msgid "InputStream Adaptive settings..."
 msgstr "InputStream Adaptive instellingen..."
 
 msgctxt "#30917"
-msgid "Install Widevine CDM... [COLOR gray][I](needed for protected content)[/I][/COLOR]"
-msgstr "Installeer Widevine CDM... [COLOR gray][I](nodig voor beschermde video's)[/I][/COLOR]"
+msgid "Install Widevine CDM... [COLOR gray][I](for protected content)[/I][/COLOR]"
+msgstr "Installeer Widevine CDM... [COLOR gray][I](voor beveiligde video's)[/I][/COLOR]"
 
 msgctxt "#30919"
 msgid "Logging"
@@ -486,8 +498,8 @@ msgid "There is a problem with this VRT NU %s stream. Try again with %s %s %s or
 msgstr "Er is een probleem met deze VRT NU %s-stream. Probeer het opnieuw met %s %s %s of probeer dit programma af te spelen vanaf de VRT NU-website. Meld dit probleem op https://www.vrt.be/vrtnu/help/"
 
 msgctxt "#30959"
-msgid "and DRM"
-msgstr "en DRM"
+msgid "and Widevine DRM"
+msgstr "en Widevine DRM"
 
 msgctxt "#30960"
 msgid "disabled"
@@ -498,6 +510,10 @@ msgid "enabled"
 msgstr "ingeschakeld"
 
 msgctxt "#30962"
+msgid "There is a problem with this VRT NU %s stream and Kodi %s doesn't support the alternative stream. Please upgrade to a newer Kodi version or try to play this program from the VRT NU website. Please report this problem at https://www.vrt.be/vrtnu/help/"
+msgstr "Er is een probleem met deze VRT NU %s-stream en Kodi %s ondersteunt de alternatieve stream niet. Schakel over op een nieuwere versie van Kodi of probeer dit programma af te spelen vanaf de VRT NU-website. Meld dit probleem op https://www.vrt.be/vrtnu/help/"
+
+msgctxt "#30965"
 msgid "Using a SOCKS proxy requires the PySocks library (script.module.pysocks) installed."
 msgstr "Het gebruik van SOCKS proxies vereist dat de PySocks library (script.module.pysocks) geïnstalleerd is."
 

--- a/resources/lib/kodiwrapper.py
+++ b/resources/lib/kodiwrapper.py
@@ -357,7 +357,7 @@ class KodiWrapper:
         if httpproxytype != 0 and not socks_supported:
             # Only open the dialog the first time (to avoid multiple popups)
             if socks_supported is None:
-                self.show_ok_dialog('', self.localize(30962))  # Requires PySocks
+                self.show_ok_dialog('', self.localize(30965))  # Requires PySocks
             return None
 
         proxy_types = ['http', 'socks4', 'socks4a', 'socks5', 'socks5h']
@@ -398,7 +398,11 @@ class KodiWrapper:
 
     def can_play_drm(self):
         ''' Whether this Kodi can do DRM using InputStream Adaptive '''
-        return self.get_setting('useinputstreamadaptive', 'true') == 'true' and self.kodi_version() > 17
+        return self.get_setting('usedrm', 'true') == 'true' and self.get_setting('useinputstreamadaptive', 'true') == 'true' and self.supports_drm()
+
+    def supports_drm(self):
+        ''' Whether this Kodi version supports DRM decryption using InputStream Adaptive '''
+        return self.kodi_version() > 17
 
     def get_userdata_path(self):
         ''' Return the profile's userdata path '''

--- a/resources/lib/streamservice.py
+++ b/resources/lib/streamservice.py
@@ -206,7 +206,7 @@ class StreamService:
             # Select streaming protocol
             if not drm_stream and self._kodi.has_inputstream_adaptive():
                 protocol = 'mpeg_dash'
-            elif drm_stream and self._can_play_drm and self._kodi.get_setting('usedrm', 'true') == 'true':
+            elif drm_stream and self._can_play_drm:
                 protocol = 'mpeg_dash'
             elif vudrm_token:
                 protocol = 'hls_aes'
@@ -270,10 +270,12 @@ class StreamService:
                 30959=and DRM, 30960=disabled, 30961=enabled
         '''
         # HLS AES DRM failed
-        if protocol == 'hls_aes' and not self._kodi.has_inputstream_adaptive() and self._kodi.get_setting('usedrm', 'true') == 'false':
+        if protocol == 'hls_aes' and not self._kodi.supports_drm():
+            message = self._kodi.localize(30962) % (protocol.upper(), self._kodi.kodi_version())
+        elif protocol == 'hls_aes' and not self._kodi.has_inputstream_adaptive() and self._kodi.get_setting('usedrm', 'true') == 'false':
             message = self._kodi.localize(30958) % (protocol.upper(), 'InputStream Adaptive', self._kodi.localize(30959), self._kodi.localize(30961))
         elif protocol == 'hls_aes' and self._kodi.has_inputstream_adaptive():
-            message = self._kodi.localize(30958) % (protocol.upper(), 'DRM', '', self._kodi.localize(30961))
+            message = self._kodi.localize(30958) % (protocol.upper(), 'Widevine DRM', '', self._kodi.localize(30961))
         elif protocol == 'hls_aes' and self._kodi.get_setting('usedrm', 'true') == 'true':
             message = self._kodi.localize(30958) % (protocol.upper(), 'InputStream Adaptive', '', self._kodi.localize(30961))
         else:

--- a/resources/lib/vrtapihelper.py
+++ b/resources/lib/vrtapihelper.py
@@ -127,7 +127,7 @@ class VRTApiHelper:
         else:
             thumbnail = 'DefaultAddonVideo.png'
         if self._favorites.is_activated():
-            program_title = quote(tvshow.get('title').encode('utf-8'), '')
+            program_title = quote(tvshow.get('title').encode('utf-8'), safe=':/'.encode('utf-8'))
             if self._favorites.is_favorite(program):
                 context_menu = [(self._kodi.localize(30412), 'RunPlugin(%s)' % self._kodi.url_for('unfollow', program=program, title=program_title))]
                 label += ' [COLOR yellow]°[/COLOR]'
@@ -357,7 +357,7 @@ class VRTApiHelper:
 
         label, sort, ascending = self._make_label(episode, titletype, options=display_options)
         if self._favorites.is_activated():
-            program_title = quote(episode.get('program').encode('utf-8'), '')
+            program_title = quote(episode.get('program').encode('utf-8'), safe=':/'.encode('utf-8'))
             if self._favorites.is_favorite(program):
                 context_menu = [(self._kodi.localize(30412), 'RunPlugin(%s)' % self._kodi.url_for('unfollow', program=program, title=program_title))]
                 label += ' [COLOR yellow]°[/COLOR]'

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -21,7 +21,7 @@
         <setting label="30861" type="lsep"/>
         <setting label="30863" help="30864" type="bool" id="showsubtitles" default="true"/>
         <setting label="30865" type="lsep"/> <!-- InputStream Adaptive -->
-        <setting label="30867" help="30868" type="bool" id="usedrm" default="false"/>
+        <setting label="30867" help="30868" type="bool" id="usedrm" visible="String.StartsWith(System.BuildVersion,18) | String.StartsWith(System.BuildVersion,19)" default="false"/>
         <setting label="30869" help="30870" type="select" id="max_bandwidth" default="0" values="0|256|512|1024|1536|2048|2560|3072|4096|6144|8192|10240|15360|20480|25600|30720"/>
     </category>
     <category label="30880"> <!--Channels -->
@@ -45,10 +45,10 @@
         <setting label="30905" help="30906" type="action" id="refresh_favorites" action="RunPlugin(plugin://plugin.video.vrt.nu/favorites/refresh)"/>
         <setting label="30907" help="30908" type="action" id="invalidate_caches" action="RunPlugin(plugin://plugin.video.vrt.nu/cache/delete)"/>
         <setting label="30909" type="lsep"/> <!-- InputStream Adaptive -->
-        <setting label="30911" visible="!System.HasAddon(inputstream.adaptive)"/>
+        <setting label="30911" type="action" visible="!System.HasAddon(inputstream.adaptive)" enable="false"/>
         <setting label="30913" help="30914" type="bool" id="useinputstreamadaptive" default="true" visible="System.HasAddon(inputstream.adaptive)"/>
-        <setting label="30915" help="30916" type="action" id="adaptive_settings" option="close" action="Addon.OpenSettings(inputstream.adaptive)" visible="System.HasAddon(inputstream.adaptive)" enable="eq(-1,true)" subsetting="true"/>
-        <setting label="30917" help="30918" type="action" id="widevine_install" option="close" action="RunPlugin(plugin://plugin.video.vrt.nu/widevine/install)" visible="System.HasAddon(inputstream.adaptive)" enable="eq(-2,true)" subsetting="true"/>
+        <setting label="30915" help="30916" type="action" id="adaptive_settings" option="close" action="Addon.OpenSettings(inputstream.adaptive)" visible="System.HasAddon(inputstream.adaptive) + [String.StartsWith(System.BuildVersion,18) | String.StartsWith(System.BuildVersion,19)]" enable="eq(-1,true)" subsetting="true"/>
+        <setting label="30917" help="30918" type="action" id="widevine_install" option="close" action="RunPlugin(plugin://plugin.video.vrt.nu/widevine/install)" visible="System.HasAddon(inputstream.adaptive) + [String.StartsWith(System.BuildVersion,18) | String.StartsWith(System.BuildVersion,19)]" enable="eq(-2,true)" subsetting="true"/>
         <setting label="30919" type="lsep"/> <!-- Logging -->
         <setting label="30921" help="30922" type="select" id="max_log_level" values="Quiet|Info|Verbose|Debug" default="Info"/>
     </category>


### PR DESCRIPTION
This pull request includes:
- Hide (Widevine) DRM settings on Kodi versions that don't support (Widevine) DRM
- Improve stream error handling for HLS AES (just to be safe)
- Fixed some typos in strings.po
- Fixed some wrong msgctxt id's
- Workaround for urllib quote complaining about utf-8 on python 2: https://bugs.python.org/issue23885