### PR TITLE
Only order 'unsorted' when tvshows + oneoff

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.vrt.nu" name="VRT NU" version="2.0.0" provider-name="Martijn Moreel, dagwieers">
     <requires>
+        <import addon="resource.images.studios.coloured" version="0.0.16" optional="true"/>
         <import addon="resource.images.studios.white" version="0.0.21"/>
         <import addon="script.module.beautifulsoup4" version="4.5.3"/>
         <import addon="script.module.dateutil" version="2.6.0"/>

--- a/resources/lib/kodiwrapper.py
+++ b/resources/lib/kodiwrapper.py
@@ -154,7 +154,7 @@ class KodiWrapper:
             sort = 'unsorted'
 
         # NOTE: When showing tvshow listings and 'showoneoff' was set, force 'unsorted'
-        if self.get_setting('showoneoff', 'true') == 'true' and sort == 'label':
+        if self.get_setting('showoneoff', 'true') == 'true' and sort == 'label' and content == 'tvshows':
             sort = 'unsorted'
 
         # Add all sort methods to GUI (start with preferred)

--- a/resources/lib/tvguide.py
+++ b/resources/lib/tvguide.py
@@ -91,7 +91,7 @@ class TVGuide:
             date_items.append(TitleItem(
                 title=title,
                 path=self._kodi.url_for('tv_guide', date=date),
-                art_dict=dict(thumb='DefaultYear.png', icon='DefaultYear.png', fanart='DefaultYear.png'),
+                art_dict=dict(thumb='DefaultYear.png', fanart='DefaultYear.png'),
                 info_dict=dict(plot=self._kodi.localize_datelong(day)),
                 context_menu=[(self._kodi.localize(30413), 'RunPlugin(%s)' % self._kodi.url_for('delete_cache', cache_file=cache_file))],
             ))
@@ -103,23 +103,18 @@ class TVGuide:
         epg = self.parse(date, now)
         datelong = self._kodi.localize_datelong(epg)
 
-        fanart_path = 'resource://resource.images.studios.white/%(studio)s.png'
-        icon_path = 'resource://resource.images.studios.white/%(studio)s.png'
-        # NOTE: Wait for resource.images.studios.coloured v0.16 to be released
-        # icon_path = 'resource://resource.images.studios.coloured/%(studio)s.png'
-
         channel_items = []
         for channel in CHANNELS:
             if channel.get('name') not in ('een', 'canvas', 'ketnet'):
                 continue
 
-            icon = icon_path % channel
-            fanart = fanart_path % channel
+            fanart = 'resource://resource.images.studios.coloured/%(studio)s.png' % channel
+            thumb = 'resource://resource.images.studios.white/%(studio)s.png' % channel
             plot = '%s\n%s' % (self._kodi.localize(30301).format(**channel), datelong)
             channel_items.append(TitleItem(
                 title=channel.get('label'),
                 path=self._kodi.url_for('tv_guide', date=date, channel=channel.get('name')),
-                art_dict=dict(thumb=icon, icon=icon, fanart=fanart),
+                art_dict=dict(thumb=thumb, fanart=fanart),
                 info_dict=dict(plot=plot, studio=channel.get('studio')),
             ))
         return channel_items
@@ -161,7 +156,6 @@ class TVGuide:
             end_date = dateutil.parser.parse(episode.get('endTime'))
             metadata.datetime = start_date
             url = episode.get('url')
-            metadata.title = title
             metadata.tvshowtitle = title
             label = '%s - %s' % (start, title)
             # NOTE: Do not use startTime and endTime as we don't want duration with seconds granularity
@@ -200,6 +194,7 @@ class TVGuide:
                 else:
                     label = '[COLOR gray]%s[/COLOR]' % label
             context_menu.append((self._kodi.localize(30413), 'RunPlugin(%s)' % self._kodi.url_for('delete_cache', cache_file=cache_file)))
+            metadata.title = label
             episode_items.append(TitleItem(
                 title=label,
                 path=path,

--- a/resources/lib/vrtapihelper.py
+++ b/resources/lib/vrtapihelper.py
@@ -517,8 +517,8 @@ class VRTApiHelper:
 
         if titletype in ('offline', 'recent'):
             ascending = False
-            sort = 'dateadded'
             label = '[B]%s[/B] - %s' % (result.get('program'), label)
+            sort = 'dateadded'
 
         elif titletype in ('reeksaflopend', 'reeksoplopend'):
 
@@ -528,30 +528,29 @@ class VRTApiHelper:
             # NOTE: This is disable on purpose as 'showSeason' is not reliable
             if options.get('showSeason') is False and options.get('showEpisodeNumber') and result.get('seasonName') and result.get('episodeNumber'):
                 try:
-                    sort = 'dateadded'
                     label = 'S%02dE%02d: %s' % (int(result.get('seasonName')), int(result.get('episodeNumber')), label)
+                    sort = 'dateadded'
                 except Exception:
                     # Season may not always be a perfect number
                     sort = 'episode'
             elif options.get('showEpisodeNumber') and result.get('episodeNumber') and ascending:
-                # NOTE: Sort the episodes ourselves, because Kodi does not allow to set to 'descending'
-                # sort = 'episode'
-                sort = 'label'
-                label = '%s %s: %s' % (self._kodi.localize(30095), result.get('episodeNumber'), label)
+                # NOTE: Do not prefix with "Episode X" when sorting by episode
+                # label = '%s %s: %s' % (self._kodi.localize(30095), result.get('episodeNumber'), label)
+                sort = 'episode'
             elif options.get('showBroadcastDate') and result.get('formattedBroadcastShortDate'):
-                sort = 'dateadded'
                 label = '%s - %s' % (result.get('formattedBroadcastShortDate'), label)
+                sort = 'dateadded'
             else:
                 sort = 'dateadded'
 
         elif titletype == 'daily':
             ascending = False
-            sort = 'dateadded'
             label = '%s - %s' % (result.get('formattedBroadcastShortDate'), label)
+            sort = 'dateadded'
 
         elif titletype == 'oneoff':
-            sort = 'label'
             label = result.get('program', label)
+            sort = 'label'
 
         return label, sort, ascending
 
@@ -560,18 +559,13 @@ class VRTApiHelper:
         from resources.lib import tvguide
         _tvguide = tvguide.TVGuide(self._kodi)
 
-        fanart_path = 'resource://resource.images.studios.white/%(studio)s.png'
-        icon_path = 'resource://resource.images.studios.white/%(studio)s.png'
-        # NOTE: Wait for resource.images.studios.coloured v0.16 to be released
-        # icon_path = 'resource://resource.images.studios.coloured/%(studio)s.png'
-
         channel_items = []
         for channel in CHANNELS:
             if channels and channel.get('name') not in channels:
                 continue
 
-            icon = icon_path % channel
-            fanart = fanart_path % channel
+            fanart = 'resource://resource.images.studios.coloured/%(studio)s.png' % channel
+            thumb = 'resource://resource.images.studios.white/%(studio)s.png' % channel
 
             if not live:
                 path = self._kodi.url_for('channels', channel=channel.get('name'))
@@ -606,7 +600,7 @@ class VRTApiHelper:
             channel_items.append(TitleItem(
                 title=label,
                 path=path,
-                art_dict=dict(thumb=icon, icon=icon, fanart=fanart),
+                art_dict=dict(thumb=thumb, fanart=fanart),
                 info_dict=info_dict,
                 context_menu=context_menu,
                 is_playable=is_playable,
@@ -624,7 +618,7 @@ class VRTApiHelper:
             featured_items.append(TitleItem(
                 title=featured_name,
                 path=self._kodi.url_for('featured', feature=feature.get('id')),
-                art_dict=dict(thumb='DefaultCountry.png', icon='DefaultCountry.png', fanart='DefaultCountry.png'),
+                art_dict=dict(thumb='DefaultCountry.png', fanart='DefaultCountry.png'),
                 info_dict=dict(plot='[B]%s[/B]' % featured_name, studio='VRT'),
             ))
         return featured_items

--- a/resources/lib/vrtplayer.py
+++ b/resources/lib/vrtplayer.py
@@ -29,49 +29,47 @@ class VRTPlayer:
             main_items.append(TitleItem(
                 title=self._kodi.localize(30010),  # My programs
                 path=self._kodi.url_for('favorites_menu'),
-                art_dict=dict(thumb='icons/settings/profiles.png', icon='icons/settings/profiles.png', fanart='icons/settings/profiles.png'),
+                art_dict=dict(thumb='icons/settings/profiles.png', fanart='icons/settings/profiles.png'),
                 info_dict=dict(plot=self._kodi.localize(30011))
             ))
 
         main_items.extend([
             TitleItem(title=self._kodi.localize(30012),  # A-Z listing
                       path=self._kodi.url_for('programs'),
-                      art_dict=dict(thumb='DefaultMovieTitle.png', icon='DefaultMovieTitle.png', fanart='DefaultMovieTitle.png'),
+                      art_dict=dict(thumb='DefaultMovieTitle.png', fanart='DefaultMovieTitle.png'),
                       info_dict=dict(plot=self._kodi.localize(30013))),
             TitleItem(title=self._kodi.localize(30014),  # Categories
                       path=self._kodi.url_for('categories'),
-                      art_dict=dict(thumb='DefaultGenre.png', icon='DefaultGenre.png', fanart='DefaultGenre.png'),
+                      art_dict=dict(thumb='DefaultGenre.png', fanart='DefaultGenre.png'),
                       info_dict=dict(plot=self._kodi.localize(30015))),
             TitleItem(title=self._kodi.localize(30016),  # Channels
                       path=self._kodi.url_for('channels'),
-                      art_dict=dict(thumb='DefaultTags.png', icon='DefaultTags.png', fanart='DefaultTags.png'),
+                      art_dict=dict(thumb='DefaultTags.png', fanart='DefaultTags.png'),
                       info_dict=dict(plot=self._kodi.localize(30017))),
             TitleItem(title=self._kodi.localize(30018),  # Live TV
                       path=self._kodi.url_for('livetv'),
-                      # art_dict=dict(thumb='DefaultAddonPVRClient.png', icon='DefaultAddonPVRClient.png', fanart='DefaultAddonPVRClient.png'),
-                      art_dict=dict(thumb='DefaultTVShows.png', icon='DefaultTVShows.png', fanart='DefaultTVShows.png'),
+                      # art_dict=dict(thumb='DefaultAddonPVRClient.png', fanart='DefaultAddonPVRClient.png'),
+                      art_dict=dict(thumb='DefaultTVShows.png', fanart='DefaultTVShows.png'),
                       info_dict=dict(plot=self._kodi.localize(30019))),
             TitleItem(title=self._kodi.localize(30020),  # Recent items
                       path=self._kodi.url_for('recent'),
-                      art_dict=dict(thumb='DefaultRecentlyAddedEpisodes.png',
-                                    icon='DefaultRecentlyAddedEpisodes.png',
-                                    fanart='DefaultRecentlyAddedEpisodes.png'),
+                      art_dict=dict(thumb='DefaultRecentlyAddedEpisodes.png', fanart='DefaultRecentlyAddedEpisodes.png'),
                       info_dict=dict(plot=self._kodi.localize(30021))),
             TitleItem(title=self._kodi.localize(30022),  # Soon offline
                       path=self._kodi.url_for('offline'),
-                      art_dict=dict(thumb='DefaultYear.png', icon='DefaultYear.png', fanart='DefaultYear.png'),
+                      art_dict=dict(thumb='DefaultYear.png', fanart='DefaultYear.png'),
                       info_dict=dict(plot=self._kodi.localize(30023))),
             TitleItem(title=self._kodi.localize(30024),  # Featured content
                       path=self._kodi.url_for('featured'),
-                      art_dict=dict(thumb='DefaultCountry.png', icon='DefaultCountry.png', fanart='DefaultCountry.png'),
+                      art_dict=dict(thumb='DefaultCountry.png', fanart='DefaultCountry.png'),
                       info_dict=dict(plot=self._kodi.localize(30025))),
             TitleItem(title=self._kodi.localize(30026),  # TV guide
                       path=self._kodi.url_for('tv_guide'),
-                      art_dict=dict(thumb='DefaultAddonTvInfo.png', icon='DefaultAddonTvInfo.png', fanart='DefaultAddonTvInfo.png'),
+                      art_dict=dict(thumb='DefaultAddonTvInfo.png', fanart='DefaultAddonTvInfo.png'),
                       info_dict=dict(plot=self._kodi.localize(30027))),
             TitleItem(title=self._kodi.localize(30028),  # Search
                       path=self._kodi.url_for('search'),
-                      art_dict=dict(thumb='DefaultAddonsSearch.png', icon='DefaultAddonsSearch.png', fanart='DefaultAddonsSearch.png'),
+                      art_dict=dict(thumb='DefaultAddonsSearch.png', fanart='DefaultAddonsSearch.png'),
                       info_dict=dict(plot=self._kodi.localize(30029))),
         ])
         self._kodi.show_listing(main_items)
@@ -82,17 +80,15 @@ class VRTPlayer:
         favorites_items = [
             TitleItem(title=self._kodi.localize(30040),  # My A-Z listing
                       path=self._kodi.url_for('favorites_programs'),
-                      art_dict=dict(thumb='DefaultMovieTitle.png', icon='DefaultMovieTitle.png', fanart='DefaultMovieTitle.png'),
+                      art_dict=dict(thumb='DefaultMovieTitle.png', fanart='DefaultMovieTitle.png'),
                       info_dict=dict(plot=self._kodi.localize(30041))),
             TitleItem(title=self._kodi.localize(30046),  # My recent items
                       path=self._kodi.url_for('favorites_recent'),
-                      art_dict=dict(thumb='DefaultRecentlyAddedEpisodes.png',
-                                    icon='DefaultRecentlyAddedEpisodes.png',
-                                    fanart='DefaultRecentlyAddedEpisodes.png'),
+                      art_dict=dict(thumb='DefaultRecentlyAddedEpisodes.png', fanart='DefaultRecentlyAddedEpisodes.png'),
                       info_dict=dict(plot=self._kodi.localize(30047))),
             TitleItem(title=self._kodi.localize(30048),  # My soon offline
                       path=self._kodi.url_for('favorites_offline'),
-                      art_dict=dict(thumb='DefaultYear.png', icon='DefaultYear.png', fanart='DefaultYear.png'),
+                      art_dict=dict(thumb='DefaultYear.png', fanart='DefaultYear.png'),
                       info_dict=dict(plot=self._kodi.localize(30049))),
         ]
 
@@ -100,7 +96,7 @@ class VRTPlayer:
             favorites_items.append(
                 TitleItem(title=self._kodi.localize(30042),  # My movies
                           path=self._kodi.url_for('categories', category='films'),
-                          art_dict=dict(thumb='DefaultAddonVideo.png', icon='DefaultAddonVideo.png', fanart='DefaultAddonVideo.png'),
+                          art_dict=dict(thumb='DefaultAddonVideo.png', fanart='DefaultAddonVideo.png'),
                           info_dict=dict(plot=self._kodi.localize(30043))),
             )
 
@@ -108,7 +104,7 @@ class VRTPlayer:
             favorites_items.append(
                 TitleItem(title=self._kodi.localize(30044),  # My documentaries
                           path=self._kodi.url_for('favorites_docu'),
-                          art_dict=dict(thumb='DefaultMovies.png', icon='DefaultMovies.png', fanart='DefaultMovies.png'),
+                          art_dict=dict(thumb='DefaultMovies.png', fanart='DefaultMovies.png'),
                           info_dict=dict(plot=self._kodi.localize(30045))),
             )
 
@@ -190,7 +186,7 @@ class VRTPlayer:
             episode_items.append(TitleItem(
                 title=self._kodi.localize(30300),
                 path=self._kodi.url_for(recent, page=page + 1),
-                art_dict=dict(thumb='DefaultRecentlyAddedEpisodes.png', icon='DefaultRecentlyAddedEpisodes.png', fanart='DefaultRecentlyAddedEpisodes.png'),
+                art_dict=dict(thumb='DefaultRecentlyAddedEpisodes.png', fanart='DefaultRecentlyAddedEpisodes.png'),
                 info_dict=dict(),
             ))
 
@@ -212,7 +208,7 @@ class VRTPlayer:
             episode_items.append(TitleItem(
                 title=self._kodi.localize(30300),
                 path=self._kodi.url_for(offline, page=page + 1),
-                art_dict=dict(thumb='DefaultYear.png', icon='DefaultYear.png', fanart='DefaultYear.png'),
+                art_dict=dict(thumb='DefaultYear.png', fanart='DefaultYear.png'),
                 info_dict=dict(),
             ))
 
@@ -241,7 +237,7 @@ class VRTPlayer:
             search_items.append(TitleItem(
                 title=self._kodi.localize(30300),
                 path=self._kodi.url_for('search', search_string=search_string, page=page + 1),
-                art_dict=dict(thumb='DefaultAddonSearch.png', icon='DefaultAddonSearch.png', fanart='DefaultAddonSearch.png'),
+                art_dict=dict(thumb='DefaultAddonSearch.png', fanart='DefaultAddonSearch.png'),
                 info_dict=dict(),
             ))
 

--- a/test/apihelpertests.py
+++ b/test/apihelpertests.py
@@ -24,7 +24,7 @@ class ApiHelperTests(unittest.TestCase):
 
     def test_get_api_data_single_season(self):
         title_items, sort, ascending, content = self._apihelper.get_episode_items(program='het-journaal')
-        self.assertTrue(121 < len(title_items) < 140, 'We got %s items instead.' % len(title_items))
+        self.assertTrue(120 <= len(title_items) <= 140, 'We got %s items instead.' % len(title_items))
         self.assertEqual(sort, 'dateadded')
         self.assertFalse(ascending)
         self.assertEqual(content, 'episodes')


### PR DESCRIPTION
This PR includes:
- Only order as unsorted when tvshows + oneoff
- Optional support for coloured studio icons
- Remove redundant 'icon' from setArt
- Order by episode when showEpisodeNumber is set