### PR TITLE
Add basic search menu and store search queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,4 +81,5 @@ msbuild.wrn
 # Credentials
 test/userdata/cache/
 test/userdata/credentials.json
+test/userdata/search_history.json
 test/userdata/*.tkn

--- a/addon.py
+++ b/addon.py
@@ -160,19 +160,33 @@ def featured(feature=None):
 @plugin.route('/tvguide')
 @plugin.route('/tvguide/<date>')
 @plugin.route('/tvguide/<date>/<channel>')
-def tv_guide(date=None, channel=None):
+def tvguide(date=None, channel=None):
     ''' The TV guide menu and listings '''
-    from resources.lib import tvguide
-    tvguide.TVGuide(kodi).show_tvguide(date=date, channel=channel)
+    from resources.lib import tvguide as tvguide_module
+    tvguide_module.TVGuide(kodi).show_tvguide(date=date, channel=channel)
 
 
 @plugin.route('/search')
-@plugin.route('/search/<search_string>')
-@plugin.route('/search/<search_string>/<page>')
-def search(search_string=None, page=1):
+def search():
+    ''' The Search menu and history '''
+    from resources.lib import search as search_module
+    search_module.Search(kodi).search_menu()
+
+
+@plugin.route('/search/clear')
+def clear_search():
+    ''' Clear the search history '''
+    from resources.lib import search as search_module
+    search_module.Search(kodi).clear()
+
+
+@plugin.route('/search/query')
+@plugin.route('/search/query/<keywords>')
+@plugin.route('/search/query/<keywords>/<page>')
+def search_query(keywords=None, page=1):
     ''' The Search interface and query listing '''
-    from resources.lib import vrtplayer
-    vrtplayer.VRTPlayer(kodi).search(search_string=search_string, page=page)
+    from resources.lib import search as search_module
+    search_module.Search(kodi).search(keywords=keywords, page=page)
 
 
 @plugin.route('/play/id/<video_id>')

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -349,6 +349,22 @@ msgctxt "#30423"
 msgid "[B]No transmission[/B]"
 msgstr ""
 
+msgctxt "#30424"
+msgid "[B]New search...[/B]"
+msgstr ""
+
+msgctxt "#30425"
+msgid "Perform a new search on VRT NU content"
+msgstr ""
+
+msgctxt "#30426"
+msgid "[B]Clear search history[/B]"
+msgstr ""
+
+msgctxt "#30427"
+msgid "Clear the search history"
+msgstr ""
+
 
 ### SETTINGS
 msgctxt "#30800"

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -253,6 +253,22 @@ msgctxt "#30423"
 msgid "[B]No transmission[/B]"
 msgstr "[B]Geen uitzending[/B]"
 
+msgctxt "#30424"
+msgid "[B]New search...[/B]"
+msgstr "[B]Nieuwe zoekopdracht...[/B]"
+
+msgctxt "#30425"
+msgid "Perform a new search on VRT NU content"
+msgstr "Geef een nieuwe zoekopdracht in"
+
+msgctxt "#30426"
+msgid "[B]Clear search history[/B]"
+msgstr "[B]Verwijder oude zoekopdrachten[/B]"
+
+msgctxt "#30427"
+msgid "Clear the search history"
+msgstr "Verwijder alle oude zoekopdrachten"
+
 
 ### SETTINGS
 msgctxt "#30800"

--- a/resources/lib/kodiwrapper.py
+++ b/resources/lib/kodiwrapper.py
@@ -179,7 +179,7 @@ class KodiWrapper:
             is_folder = bool(not title_item.is_playable and title_item.path)
             is_playable = bool(title_item.is_playable and title_item.path)
 
-            list_item = xbmcgui.ListItem(label=title_item.title, thumbnailImage=title_item.art_dict.get('thumb'))
+            list_item = xbmcgui.ListItem(label=title_item.title)
             list_item.setProperty(key='IsPlayable', value='true' if is_playable else 'false')
 
             # FIXME: The setIsFolder is new in Kodi18, so we cannot use it just yet.

--- a/resources/lib/search.py
+++ b/resources/lib/search.py
@@ -1,0 +1,116 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2019, Dag Wieers (@dagwieers) <dag@wieers.com>
+# GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+''' Implementation of Search class '''
+
+from __future__ import absolute_import, division, unicode_literals
+import json
+from resources.lib import favorites, vrtapihelper
+from resources.lib.helperobjects import TitleItem
+from resources.lib.statichelper import realpage
+
+
+class Search:
+    ''' Search and cache search queries '''
+
+    def __init__(self, _kodi):
+        ''' Initialize searchtes, relies on XBMC vfs '''
+        self._kodi = _kodi
+        self._favorites = favorites.Favorites(_kodi)
+        self._apihelper = vrtapihelper.VRTApiHelper(_kodi, self._favorites)
+
+        self._search_history = _kodi.get_userdata_path() + 'search_history.json'
+
+    def search_menu(self):
+        ''' Main search menu '''
+        menu_items = [
+            TitleItem(
+                title=self._kodi.localize(30424),  # New search...
+                path=self._kodi.url_for('search_query'),
+                art_dict=dict(thumb='DefaultAddonsSearch.png', fanart='DefaultAddonsSearch.png'),
+                info_dict=dict(plot=self._kodi.localize(30425)),
+                is_playable=False,
+            )
+        ]
+
+        try:
+            with self._kodi.open_file(self._search_history, 'r') as f:
+                history = json.load(f)
+        except Exception:
+            history = []
+
+        for keywords in history:
+            menu_items.append(TitleItem(
+                title=keywords,
+                path=self._kodi.url_for('search_query', keywords=keywords),
+                art_dict=dict(thumb='DefaultAddonsSearch.png', fanart='DefaultAddonsSearch.png'),
+                is_playable=False,
+            ))
+
+        if history:
+            menu_items.append(TitleItem(
+                title=self._kodi.localize(30426),  # Clear search history
+                path=self._kodi.url_for('clear_search'),
+                info_dict=dict(plot=self._kodi.localize(30427)),
+                art_dict=dict(thumb='icons/infodialogs/uninstall.png', fanart='icons/infodialogs/uninstall.png'),
+                is_playable=False,
+            ))
+
+        self._kodi.show_listing(menu_items)
+
+    def search(self, keywords=None, page=None):
+        ''' The VRT NU add-on Search functionality and results '''
+        if keywords is None:
+            keywords = self._kodi.get_search_string()
+
+        if not keywords:
+            self._kodi.end_of_directory()
+            return
+
+        page = realpage(page)
+
+        self.add(keywords)
+        search_items, sort, ascending, content = self._apihelper.get_search_items(keywords, page=page)
+        if not search_items:
+            self._kodi.show_ok_dialog(heading=self._kodi.localize(30098), message=self._kodi.localize(30099).format(keywords=keywords))
+            self._kodi.end_of_directory()
+            return
+
+        # Add 'More...' entry at the end
+        if len(search_items) == 50:
+            search_items.append(TitleItem(
+                title=self._kodi.localize(30300),
+                path=self._kodi.url_for('search', keywords=keywords, page=page + 1),
+                art_dict=dict(thumb='DefaultAddonSearch.png', fanart='DefaultAddonSearch.png'),
+                info_dict=dict(),
+            ))
+
+        self._kodi.container_update(replace=True)
+
+        self._favorites.get_favorites(ttl=60 * 60)
+        self._kodi.show_listing(search_items, sort=sort, ascending=ascending, content=content, cache=False)
+
+    def clear(self):
+        ''' Clear the search history '''
+        with self._kodi.open_file(self._search_history, 'w') as f:
+            json.dump([], f)
+        self._kodi.end_of_directory()
+
+    def add(self, keywords):
+        ''' Add new keywords to search history '''
+        from collections import OrderedDict
+        try:
+            with self._kodi.open_file(self._search_history, 'r') as f:
+                history = json.load(f)
+        except Exception:
+            history = []
+
+        history.insert(0, keywords)
+
+        # Remove duplicates while preserving order
+        history = list(OrderedDict((element, None) for element in history))
+
+        with self._kodi.open_file(self._search_history, 'w') as f:
+            json.dump(history, f)

--- a/resources/lib/tvguide.py
+++ b/resources/lib/tvguide.py
@@ -90,7 +90,7 @@ class TVGuide:
             cache_file = 'schedule.%s.json' % date
             date_items.append(TitleItem(
                 title=title,
-                path=self._kodi.url_for('tv_guide', date=date),
+                path=self._kodi.url_for('tvguide', date=date),
                 art_dict=dict(thumb='DefaultYear.png', fanart='DefaultYear.png'),
                 info_dict=dict(plot=self._kodi.localize_datelong(day)),
                 context_menu=[(self._kodi.localize(30413), 'RunPlugin(%s)' % self._kodi.url_for('delete_cache', cache_file=cache_file))],
@@ -113,7 +113,7 @@ class TVGuide:
             plot = '%s\n%s' % (self._kodi.localize(30301).format(**channel), datelong)
             channel_items.append(TitleItem(
                 title=channel.get('label'),
-                path=self._kodi.url_for('tv_guide', date=date, channel=channel.get('name')),
+                path=self._kodi.url_for('tvguide', date=date, channel=channel.get('name')),
                 art_dict=dict(thumb=thumb, fanart=fanart),
                 info_dict=dict(plot=plot, studio=channel.get('studio')),
             ))

--- a/resources/lib/vrtapihelper.py
+++ b/resources/lib/vrtapihelper.py
@@ -452,7 +452,7 @@ class VRTApiHelper:
             ))
         return season_items, sort, ascending, 'seasons'
 
-    def search(self, search_string, page=0):
+    def get_search_items(self, keywords, page=0):
         ''' Search VRT NU content for a given string '''
         import json
 
@@ -461,7 +461,7 @@ class VRTApiHelper:
             'from': ((page - 1) * 50) + 1,
             'i': 'video',
             'size': 50,
-            'q': search_string,
+            'q': keywords,
             'highlight': 'true',
         }
         search_url = self._VRTNU_SEARCH_URL + '?' + urlencode(params)

--- a/resources/lib/vrtplayer.py
+++ b/resources/lib/vrtplayer.py
@@ -64,7 +64,7 @@ class VRTPlayer:
                       art_dict=dict(thumb='DefaultCountry.png', fanart='DefaultCountry.png'),
                       info_dict=dict(plot=self._kodi.localize(30025))),
             TitleItem(title=self._kodi.localize(30026),  # TV guide
-                      path=self._kodi.url_for('tv_guide'),
+                      path=self._kodi.url_for('tvguide'),
                       art_dict=dict(thumb='DefaultAddonTvInfo.png', fanart='DefaultAddonTvInfo.png'),
                       info_dict=dict(plot=self._kodi.localize(30027))),
             TitleItem(title=self._kodi.localize(30028),  # Search
@@ -213,36 +213,6 @@ class VRTPlayer:
             ))
 
         self._kodi.show_listing(episode_items, sort=sort, ascending=ascending, content=content)
-
-    def search(self, search_string=None, page=None):
-        ''' The VRT NU add-on Search functionality and results '''
-        self._favorites.get_favorites(ttl=60 * 60)
-        page = realpage(page)
-
-        if search_string is None:
-            search_string = self._kodi.get_search_string()
-
-        if not search_string:
-            self._kodi.end_of_directory()
-            return
-
-        search_items, sort, ascending, content = self._apihelper.search(search_string, page=page)
-        if not search_items:
-            self._kodi.show_ok_dialog(heading=self._kodi.localize(30098), message=self._kodi.localize(30099).format(keywords=search_string))
-            self._kodi.end_of_directory()
-            return
-
-        # Add 'More...' entry at the end
-        if len(search_items) == 50:
-            search_items.append(TitleItem(
-                title=self._kodi.localize(30300),
-                path=self._kodi.url_for('search', search_string=search_string, page=page + 1),
-                art_dict=dict(thumb='DefaultAddonSearch.png', fanart='DefaultAddonSearch.png'),
-                info_dict=dict(),
-            ))
-
-        self._kodi.container_update(replace=True)
-        self._kodi.show_listing(search_items, sort=sort, ascending=ascending, content=content, cache=False)
 
     def play_latest_episode(self, program):
         ''' A hidden feature in the VRT NU add-on to play the latest episode of a program '''

--- a/test/routingtests.py
+++ b/test/routingtests.py
@@ -93,20 +93,20 @@ class TestRouter(unittest.TestCase):
     # TV guide menu: '/tvguide/<date>/<channel>'
     def test_tvguide_date_menu(self):
         plugin.run(['plugin://plugin.video.vrt.nu/tvguide', '0', ''])
-        self.assertEqual(plugin.url_for(addon.tv_guide), 'plugin://plugin.video.vrt.nu/tvguide')
+        self.assertEqual(plugin.url_for(addon.tvguide), 'plugin://plugin.video.vrt.nu/tvguide')
         plugin.run(['plugin://plugin.video.vrt.nu/tvguide/today', '0', ''])
-        self.assertEqual(plugin.url_for(addon.tv_guide, date='today'), 'plugin://plugin.video.vrt.nu/tvguide/today')
+        self.assertEqual(plugin.url_for(addon.tvguide, date='today'), 'plugin://plugin.video.vrt.nu/tvguide/today')
         plugin.run(['plugin://plugin.video.vrt.nu/tvguide/today/canvas', '0', ''])
-        self.assertEqual(plugin.url_for(addon.tv_guide, date='today', channel='canvas'), 'plugin://plugin.video.vrt.nu/tvguide/today/canvas')
+        self.assertEqual(plugin.url_for(addon.tvguide, date='today', channel='canvas'), 'plugin://plugin.video.vrt.nu/tvguide/today/canvas')
 
-    # Search VRT NU menu: '/search/<search_string>/<page>'
+    # Search VRT NU menu: '/search/query/<keywords>/<page>'
     def test_search_menu(self):
-        plugin.run(['plugin://plugin.video.vrt.nu/search', '0', ''])
-        self.assertEqual(plugin.url_for(addon.search), 'plugin://plugin.video.vrt.nu/search')
-        plugin.run(['plugin://plugin.video.vrt.nu/search/dag', '0', ''])
-        self.assertEqual(plugin.url_for(addon.search, search_string='dag'), 'plugin://plugin.video.vrt.nu/search/dag')
-        plugin.run(['plugin://plugin.video.vrt.nu/search/dag/2', '0', ''])
-        self.assertEqual(plugin.url_for(addon.search, search_string='dag', page=2), 'plugin://plugin.video.vrt.nu/search/dag/2')
+        plugin.run(['plugin://plugin.video.vrt.nu/search/query', '0', ''])
+        self.assertEqual(plugin.url_for(addon.search_query), 'plugin://plugin.video.vrt.nu/search/query')
+        plugin.run(['plugin://plugin.video.vrt.nu/search/query/dag', '0', ''])
+        self.assertEqual(plugin.url_for(addon.search_query, keywords='dag'), 'plugin://plugin.video.vrt.nu/search/query/dag')
+        plugin.run(['plugin://plugin.video.vrt.nu/search/query/dag/2', '0', ''])
+        self.assertEqual(plugin.url_for(addon.search_query, keywords='dag', page=2), 'plugin://plugin.video.vrt.nu/search/query/dag/2')
 
     # Follow method: '/follow/<program>/<title>'
     def test_follow_route(self):

--- a/test/searchtests.py
+++ b/test/searchtests.py
@@ -24,7 +24,7 @@ class TestSearch(unittest.TestCase):
 
     def test_search_journaal(self):
         ''' Test for journaal '''
-        search_items, sort, ascending, content = self._apihelper.search('journaal', page=1)
+        search_items, sort, ascending, content = self._apihelper.get_search_items('journaal', page=1)
 
         # Test we get a non-empty search result
         self.assertEqual(len(search_items), 50)
@@ -34,7 +34,7 @@ class TestSearch(unittest.TestCase):
 
     def test_search_journaal_page2(self):
         ''' Test for journaal '''
-        search_items, sort, ascending, content = self._apihelper.search('journaal', page=2)
+        search_items, sort, ascending, content = self._apihelper.get_search_items('journaal', page=2)
 
         # Test we get a non-empty search result
         self.assertEqual(len(search_items), 50)
@@ -44,7 +44,7 @@ class TestSearch(unittest.TestCase):
 
     def test_search_journaal_page3(self):
         ''' Test for journaal '''
-        search_items, sort, ascending, content = self._apihelper.search('journaal', page=3)
+        search_items, sort, ascending, content = self._apihelper.get_search_items('journaal', page=3)
 
         # Test we get a non-empty search result
         self.assertEqual(len(search_items), 50)
@@ -54,7 +54,7 @@ class TestSearch(unittest.TestCase):
 
     def test_search_weer(self):
         ''' Test for journaal '''
-        search_items, sort, ascending, content = self._apihelper.search('weer', page=1)
+        search_items, sort, ascending, content = self._apihelper.get_search_items('weer', page=1)
 
         # Test we get a non-empty search result
         self.assertEqual(len(search_items), 50)


### PR DESCRIPTION
This PR includes:
- Moving all search-related stuff into search.py
- Add a search-menu with previous search queries
- Store search history into userdata/search_history.json
- Add entry to clear complete search history

This fixes #301.