### PR TITLE
implement Unicode Sandwich

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import, division, unicode_literals
 import sys
 import routing
 from resources.lib import kodiwrapper
+from resources.lib.statichelper import to_unicode
 
 plugin = routing.Plugin()
 kodi = kodiwrapper.KodiWrapper(globals())
@@ -215,5 +216,6 @@ def play_last(program):
 
 
 if __name__ == '__main__':
-    kodi.log_access(sys.argv[0])
-    plugin.run(sys.argv)
+    argv = [to_unicode(arg) for arg in sys.argv]
+    kodi.log_access(argv[0])
+    plugin.run(argv)

--- a/resources/lib/favorites.py
+++ b/resources/lib/favorites.py
@@ -9,10 +9,9 @@ from __future__ import absolute_import, division, unicode_literals
 from resources.lib import statichelper, tokenresolver
 
 try:  # Python 3
-    from urllib.parse import unquote
     from urllib.request import build_opener, install_opener, ProxyHandler, Request, urlopen
 except ImportError:  # Python 2
-    from urllib2 import build_opener, install_opener, ProxyHandler, Request, unquote, urlopen
+    from urllib2 import build_opener, install_opener, ProxyHandler, Request, urlopen
 
 
 class Favorites:
@@ -103,14 +102,14 @@ class Favorites:
         ''' Follow your favorite program '''
         ok = self.set_favorite(program, title, True)
         if ok:
-            self._kodi.show_notification(message=self._kodi.localize(30411) + ' ' + unquote(title))
+            self._kodi.show_notification(message=self._kodi.localize(30411) + ' ' + title)
             self._kodi.container_refresh()
 
     def unfollow(self, program, title):
         ''' Unfollow your favorite program '''
         ok = self.set_favorite(program, title, False)
         if ok:
-            self._kodi.show_notification(message=self._kodi.localize(30412) + ' ' + unquote(title))
+            self._kodi.show_notification(message=self._kodi.localize(30412) + ' ' + title)
             self._kodi.container_refresh()
 
     def uuid(self, program):

--- a/resources/lib/kodiwrapper.py
+++ b/resources/lib/kodiwrapper.py
@@ -7,6 +7,8 @@
 from __future__ import absolute_import, division, unicode_literals
 from contextlib import contextmanager
 
+from resources.lib.statichelper import to_unicode, from_unicode
+
 import xbmc
 import xbmcplugin
 import xbmcaddon
@@ -111,7 +113,7 @@ class KodiWrapper:
             self._handle = self.plugin.handle
             self._url = self.plugin.base_url
         self._addon = xbmcaddon.Addon()
-        self._addon_id = self._addon.getAddonInfo('id')
+        self._addon_id = to_unicode(self._addon.getAddonInfo('id'))
         self._max_log_level = log_levels.get(self.get_setting('max_log_level', 'Debug'), 3)
         self._usemenucaching = self.get_setting('usemenucaching', 'true') == 'true'
         self._cache_path = self.get_userdata_path() + 'cache/'
@@ -581,14 +583,16 @@ class KodiWrapper:
     def log_access(self, url, query_string=None, log_level='Verbose'):
         ''' Log addon access '''
         if log_levels.get(log_level, 0) <= self._max_log_level:
-            message = url + ('?' + query_string if query_string else '')
-            xbmc.log(msg='[%s] Access: %s' % (self._addon_id, unquote(message)), level=xbmc.LOGNOTICE)
+            message = '[%s] Access: %s' % (self._addon_id, url + ('?' + query_string if query_string else ''))
+            xbmc.log(msg=from_unicode(message), level=xbmc.LOGNOTICE)
 
     def log_notice(self, message, log_level='Info'):
         ''' Log info messages to Kodi '''
         if log_levels.get(log_level, 0) <= self._max_log_level:
-            xbmc.log(msg='[%s] %s' % (self._addon_id, message), level=xbmc.LOGNOTICE)
+            message = '[%s] %s' % (self._addon_id, message)
+            xbmc.log(msg=from_unicode(message), level=xbmc.LOGNOTICE)
 
     def log_error(self, message, log_level='Info'):
         ''' Log error messages to Kodi '''
-        xbmc.log(msg='[%s] %s' % (self._addon_id, message), level=xbmc.LOGERROR)
+        message = '[%s] %s' % (self._addon_id, message)
+        xbmc.log(msg=from_unicode(message), level=xbmc.LOGERROR)

--- a/resources/lib/statichelper.py
+++ b/resources/lib/statichelper.py
@@ -70,6 +70,19 @@ def url_to_program(url):
     return program
 
 
+def to_unicode(text, encoding='utf-8'):
+    ''' Force text to unicode '''
+    return text.decode(encoding) if isinstance(text, bytes) else text
+
+
+def from_unicode(text, encoding='utf-8'):
+    ''' Force unicode to text '''
+    import sys
+    if sys.version_info.major == 2 and isinstance(text, unicode):  # pylint: disable=undefined-variable
+        return text.encode(encoding)
+    return text
+
+
 def shorten_link(url):
     ''' Create a link that is as short as possible '''
     if url is None:

--- a/resources/lib/vrtapihelper.py
+++ b/resources/lib/vrtapihelper.py
@@ -9,11 +9,11 @@ from resources.lib import CHANNELS, CATEGORIES, metadatacreator, statichelper
 from resources.lib.helperobjects import TitleItem
 
 try:  # Python 3
-    from urllib.parse import urlencode, quote, unquote
+    from urllib.parse import urlencode, unquote
     from urllib.request import build_opener, install_opener, ProxyHandler, urlopen
 except ImportError:  # Python 2
     from urllib import urlencode
-    from urllib2 import build_opener, install_opener, ProxyHandler, urlopen, quote, unquote
+    from urllib2 import build_opener, install_opener, ProxyHandler, urlopen, unquote
 
 
 class VRTApiHelper:
@@ -127,7 +127,7 @@ class VRTApiHelper:
         else:
             thumbnail = 'DefaultAddonVideo.png'
         if self._favorites.is_activated():
-            program_title = quote(tvshow.get('title').encode('utf-8'), safe=':/'.encode('utf-8'))
+            program_title = tvshow.get('title')
             if self._favorites.is_favorite(program):
                 context_menu = [(self._kodi.localize(30412), 'RunPlugin(%s)' % self._kodi.url_for('unfollow', program=program, title=program_title))]
                 label += ' [COLOR yellow]°[/COLOR]'
@@ -357,7 +357,7 @@ class VRTApiHelper:
 
         label, sort, ascending = self._make_label(episode, titletype, options=display_options)
         if self._favorites.is_activated():
-            program_title = quote(episode.get('program').encode('utf-8'), safe=':/'.encode('utf-8'))
+            program_title = episode.get('program')
             if self._favorites.is_favorite(program):
                 context_menu = [(self._kodi.localize(30412), 'RunPlugin(%s)' % self._kodi.url_for('unfollow', program=program, title=program_title))]
                 label += ' [COLOR yellow]°[/COLOR]'

--- a/test/favoritestests.py
+++ b/test/favoritestests.py
@@ -27,7 +27,7 @@ class TestFavorites(unittest.TestCase):
         programs = [
             {'program_title': 'Winteruur', 'program': 'winteruur'},
             {'program_title': 'De Campus Cup', 'program': 'de-campus-cup'},
-            {'program_title': 'De Afspraak op vrijdag', 'program': 'de-afspraak-op-vrijdag'}
+            {'program_title': 'Terug naar Siberië', 'program': 'terug-naar-siberie'}
         ]
         for program_item in programs:
             program_title = program_item.get('program_title')

--- a/test/xbmc.py
+++ b/test/xbmc.py
@@ -33,7 +33,10 @@ try:
         GLOBAL_SETTINGS = json.load(f)
 except Exception as e:
     print("Error using 'test/userdata/addon_settings.json' : %s" % e, file=sys.stderr)
-    GLOBAL_SETTINGS = {}
+    GLOBAL_SETTINGS = {
+        'locale.language': 'resource.language.en_gb',
+        'network.bandwidth': 0,
+    }
 
 
 class Keyboard:

--- a/test/xbmcaddon.py
+++ b/test/xbmcaddon.py
@@ -89,5 +89,9 @@ class Addon:
         return ADDON_SETTINGS.get(key, '')
 
     @staticmethod
+    def openSettings():
+        ''' A stub implementation for the xbmcaddon Addon class openSettings() method '''
+
+    @staticmethod
     def setSetting(key, value):
         ''' A stub implementation for the xbmcaddon Addon class setSetting() method '''


### PR DESCRIPTION
This includes:
- always use unicode strings inside the add-on
- only decode/encode  when necessary for input and output on the outer edges of the add-on
 - fixes problems with special characters, for instance follow/unfollow Terug naar Siberië