### PR TITLE
Add an action to check your credentials from the add-on settings.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,7 @@ msbuild.wrn
 
 # Test caches
 *.pyc
+*.pyo
 .pytest_cache/
 .tox/
 

--- a/addon.py
+++ b/addon.py
@@ -35,6 +35,17 @@ def delete_tokens():
     tokenresolver.TokenResolver(kodi).delete_tokens()
 
 
+@plugin.route('/tokens/check-credentials')
+def check_credentials():
+    ''' Check if the credentials are correct '''
+    from resources.lib import tokenresolver
+    if tokenresolver.TokenResolver(kodi).check_credentials():
+        kodi.show_ok_dialog(message=kodi.localize(30980))
+    else:
+        kodi.show_ok_dialog(message=kodi.localize(30952))
+    kodi.open_settings()
+
+
 @plugin.route('/widevine/install')
 def install_widevine():
     ''' The API interface to install Widevine '''

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -391,6 +391,14 @@ msgctxt "#30806"
 msgid "Provide your VRT NU account password."
 msgstr ""
 
+msgctxt "#30807"
+msgid "Check credentials"
+msgstr ""
+
+msgctxt "#30808"
+msgid "Check if your VRT NU credentials are correct."
+msgstr ""
+
 msgctxt "#30820"
 msgid "Interface"
 msgstr ""
@@ -671,4 +679,8 @@ msgstr ""
 
 msgctxt "#30979"
 msgid "Because of important internal changes, existing Kodi favourites and watched history from VRT NU no longer work.\n[B]Please recreate all your VRT NU favourites.[/B]"
+msgstr ""
+
+msgctxt "#30980"
+msgid "Login successful!"
 msgstr ""

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -287,6 +287,14 @@ msgctxt "#30805"
 msgid "Password"
 msgstr "Wachtwoord"
 
+msgctxt "#30807"
+msgid "Check credentials"
+msgstr "Controleer inloggegevens"
+
+msgctxt "#30808"
+msgid "Check if your VRT NU credentials are correct."
+msgstr "Controleer of je VRT NU inloggegevens correct zijn."
+
 msgctxt "#30820"
 msgid "Interface"
 msgstr "Interface"
@@ -565,3 +573,6 @@ msgctxt "#30979"
 msgid "Because of important internal changes, existing Kodi favourites and watched history from VRT NU no longer work.\n[B]Please recreate all your VRT NU favourites.[/B]"
 msgstr "Wegens belangrijke interne wijzigingen werken bestaande Kodi-favorieten en kijkgeschiedenis van VRT NU niet meer.\n[B]Gelieve al uw VRT NU-favorieten opnieuw aan te maken.[/B]"
 
+msgctxt "#30980"
+msgid "Login successful!"
+msgstr "Inloggen gelukt!"

--- a/resources/lib/tokenresolver.py
+++ b/resources/lib/tokenresolver.py
@@ -80,6 +80,26 @@ class TokenResolver:
                 token = self._get_new_xvrttoken(token_variant)
         return token
 
+    def check_credentials(self):
+        ''' Check the credentials '''
+        cred = Credentials(self._kodi)
+        if not cred.are_filled_in():
+            return False
+
+        payload = dict(
+            loginID=cred.username,
+            password=cred.password,
+            sessionExpiration='-1',
+            APIKey=self._API_KEY,
+            targetEnv='jssdk',
+        )
+        data = urlencode(payload).encode('utf8')
+        self._kodi.log_notice('URL post: ' + unquote(self._LOGIN_URL), 'Verbose')
+        req = Request(self._LOGIN_URL, data=data)
+        logon_json = json.load(urlopen(req))
+
+        return logon_json.get('errorCode') == 0
+
     def _get_token_path(self, token_name, token_variant):
         ''' Create token path following predefined file naming rules '''
         prefix = token_variant + '_' if token_variant else ''

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -5,6 +5,7 @@
         <setting label="30801" type="lsep"/> <!-- VRT NU login -->
         <setting label="30803" help="30804" type="text" id="username"/>
         <setting label="30805" help="30806" type="text" id="password" option="hidden"/>
+        <setting label="30807" help="30808" type="action" id="check_credentials" option="close" action="RunPlugin(plugin://plugin.video.vrt.nu/tokens/check-credentials)" subsetting="true"  enable="!eq(-2,) + !eq(-1,)"/>
     </category>
     <category label="30820"> <!-- Interface -->
         <setting label="30821" type="lsep"/> <!-- Features -->


### PR DESCRIPTION
Fixes #351 

This adds a function to `tokenresolver.py` to just check the tokens. I couldn't reuse an existing function since they look in cache first. The credentials tab in the settings has an action now to run this function that checks the login credentials. A message is displayed indicating success or failure, and the settings dialog is shown again.

Note that I had to add `option="close"` to the settings since Kodi only saves the settings when the dialog is closed.

I also added `*.pyo` to the `.gitignore` file. Kodi creates these compiled files.