### PR TITLE
Add Radio 1 live TV stream

### DIFF
--- a/resources/lib/__init__.py
+++ b/resources/lib/__init__.py
@@ -79,6 +79,7 @@ CHANNELS = [
         name='radio1',
         label='Radio 1',
         studio='Radio 1',
+        live_stream_id='vualto_events3_geo',
     ),
     dict(
         id='24',

--- a/test/test_apihelper.py
+++ b/test/test_apihelper.py
@@ -24,7 +24,7 @@ class ApiHelperTests(unittest.TestCase):
 
     def test_get_api_data_single_season(self):
         title_items, sort, ascending, content = self._apihelper.get_episode_items(program='het-journaal')
-        self.assertTrue(120 <= len(title_items) <= 140, 'We got %s items instead.' % len(title_items))
+        self.assertTrue(110 <= len(title_items) <= 140, 'We got %s items instead.' % len(title_items))
         self.assertEqual(sort, 'dateadded')
         self.assertFalse(ascending)
         self.assertEqual(content, 'episodes')


### PR DESCRIPTION
It appears the Radio 1 live TV stream is behind **vualto_events3_geo**

This fixes #359 