### PR TITLE
Add a disclaimer when the plugin is installed/updated

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -231,6 +231,13 @@ def play_by_air_date(channel, start_date, end_date=None):
     vrtplayer.VRTPlayer(kodi).play_episode_by_air_date(channel, start_date, end_date)
 
 
+@plugin.route('/show/disclaimer')
+def show_disclaimer():
+    ''' Show the disclaimer '''
+    from resources.lib import vrtplayer
+    vrtplayer.VRTPlayer(kodi).show_disclaimer()
+
+
 if __name__ == '__main__':
     kodi.log_access(to_unicode(sys.argv[0]))
     plugin.run(sys.argv)

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -607,6 +607,14 @@ msgctxt "#30921"
 msgid "Log level"
 msgstr ""
 
+msgctxt "#30930"
+msgid "About"
+msgstr ""
+
+msgctxt "#30931"
+msgid "Show disclaimer..."
+msgstr ""
+
 
 ### MESSAGES
 msgctxt "#30951"
@@ -719,4 +727,8 @@ msgstr ""
 
 msgctxt "#30986"
 msgid "No on demand stream available for %s."
+msgstr ""
+
+msgctxt "#30987"
+msgid "The VRT NU add-on is provided 'as is' without any warranty of any kind, and is not endorsed by VRT.\n\nBy using the VRT NU Kodi add-on you agree to VRT NU terms of use and VRT's privacy policy.\n\nThe authors and contributors to this plugin are not responsible for the use of this add-on.\n\nFor more information, read: [COLOR yellow]vrt.be/nl/info/gebruiksvoorwaarden/[/COLOR]"
 msgstr ""

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -499,6 +499,14 @@ msgctxt "#30921"
 msgid "Log level"
 msgstr "Log level"
 
+msgctxt "#30930"
+msgid "Over"
+msgstr ""
+
+msgctxt "#30931"
+msgid "Toon disclaimer..."
+msgstr ""
+
 
 ### MESSAGES
 msgctxt "#30951"
@@ -612,3 +620,7 @@ msgstr "VRT tokens werden verwijderd."
 msgctxt "#30986"
 msgid "No on demand stream available for %s."
 msgstr "Geen on demand stream beschikbaar voor %s"
+
+msgctxt "#30987"
+msgid "Deze VRT NU add-on wordt aangeboden 'as is', zonder enige garantie, en wordt niet ondersteund door de VRT.\n\nDoor de VRT NU Kodi add-on te gebruiken ga je akkoord met de VRT NU gebruikersvoorwaarden en VRT's privacybeleid.\n\nDe auteurs en bijdragers tot deze add-on zijn niet verantwoordelijke voor het gebruik van deze add-on.\n\nVoor meer informatie, lees: [COLOR yellow]vrt.be/nl/info/gebruiksvoorwaarden/[/COLOR]"
+msgstr ""

--- a/resources/lib/kodiwrapper.py
+++ b/resources/lib/kodiwrapper.py
@@ -248,9 +248,15 @@ class KodiWrapper:
         import xbmcgui
         if not heading:
             heading = self._addon.getAddonInfo('name')
-        dialog = xbmcgui.Dialog()
-        ok = dialog.ok(heading=heading, line1=message)
+        ok = xbmcgui.Dialog().ok(heading=heading, line1=message)
         return ok
+
+    def show_text_dialog(self, heading='', message='', usemono=False):
+        ''' Show Kodi's Text dialog '''
+        import xbmcgui
+        if not heading:
+            heading = self._addon.getAddonInfo('name')
+        xbmcgui.Dialog().textviewer(heading=heading, text=message, usemono=usemono)
 
     def show_notification(self, heading='', message='', icon='info', time=4000):
         ''' Show a Kodi notification '''

--- a/resources/lib/vrtplayer.py
+++ b/resources/lib/vrtplayer.py
@@ -79,8 +79,10 @@ class VRTPlayer:
         settings_version = self._kodi.get_setting('version', '')
         if settings_version == '' and self._kodi.has_credentials():  # New major version, favourites and what-was-watched will break
             self._kodi.show_ok_dialog(self._kodi.localize(30978), self._kodi.localize(30979))
+
         addon_version = self._kodi.get_addon_info('version')
         if settings_version != addon_version:
+            self.show_disclaimer()
             self._kodi.set_setting('version', addon_version)
 
     def show_favorites_menu_items(self):
@@ -223,6 +225,10 @@ class VRTPlayer:
             ))
 
         self._kodi.show_listing(episode_items, sort=sort, ascending=ascending, content=content)
+
+    def show_disclaimer(self):
+        ''' Show a disclaimer about VRT NU terms of use '''
+        self._kodi.show_text_dialog('Disclaimer', self._kodi.localize(30987))
 
     def play_latest_episode(self, program):
         ''' A hidden feature in the VRT NU add-on to play the latest episode of a program '''

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -55,4 +55,7 @@
         <setting label="30919" type="lsep"/> <!-- Logging -->
         <setting label="30921" help="30922" type="select" id="max_log_level" values="Quiet|Info|Verbose|Debug" default="Info"/>
     </category>
+    <category label="30930"> <!-- About -->
+        <setting label="30931" help="30932" type="action" id="show_disclaimer" action="RunPlugin(plugin://plugin.video.vrt.nu/show/disclaimer)"/>
+    </category>
 </settings>

--- a/test/xbmcgui.py
+++ b/test/xbmcgui.py
@@ -5,6 +5,7 @@
 ''' This file implements the Kodi xbmcgui module, either using stubs or alternative functionality '''
 
 from __future__ import absolute_import, division, print_function, unicode_literals
+from xbmcextra import kodi_to_ansi
 
 
 class Dialog:
@@ -12,11 +13,15 @@ class Dialog:
 
     def notification(self, heading='', message='', icon='', time=''):
         ''' A working implementation for the xbmcgui Dialog class notification() method '''
-        print('[37;100mNOTIFICATION:[35;0m [%s] [35;0m%s[0m' % (heading, message))
+        print('[37;100mNOTIFICATION:[35;0m [%s] [35;0m%s[0m' % (kodi_to_ansi(heading), kodi_to_ansi(message)))
 
     def ok(self, heading='', line1=''):
         ''' A stub implementation for the xbmcgui Dialog class ok() method '''
-        return
+        print('[37;100mOK:[35;0m [%s]\n[35;0m%s[0m' % (kodi_to_ansi(heading), kodi_to_ansi(line1)))
+
+    def textviewer(self, heading='', text='', usemono=False):
+        ''' A stub implementation for the xbmcgui Dialog class textviewer() method '''
+        print('[37;100mTEXT:[35;0m [%s]\n[35;0m%s[0m' % (kodi_to_ansi(heading), kodi_to_ansi(text)))
 
     def yesno(self, heading='', line1=''):
         ''' A stub implementation for the xbmcgui Dialog class yesno() method '''


### PR DESCRIPTION
This PR includes:
- A disclaimer for the end-user, so he is aware of the terms of use
- Implement a xbmcgui dialog textviewer
- Add the disclaimer to an About section in the settings