### PR TITLE
Handle a TypeError when download gets interrupted

### DIFF
--- a/resources/lib/kodiwrapper.py
+++ b/resources/lib/kodiwrapper.py
@@ -527,7 +527,7 @@ class KodiWrapper:
                 try:
                     # return json.load(f, encoding='utf-8')
                     return json.load(f)
-                except ValueError:
+                except (ValueError, TypeError):
                     return None
 
         return None


### PR DESCRIPTION
This happened for me when pressing back at the wrong time.

I have seen other cases where pressing back resulted in exiting the addon and ending up in some generic video Kodi menu. It's always related to unfortunate timing and I never can reproduce it if I try.

This case was different because there was an actual Exception and error-notification.