### PR TITLE
quit bad credentials loop if user doesn't want to change credentials

### DIFF
--- a/resources/lib/tokenresolver.py
+++ b/resources/lib/tokenresolver.py
@@ -151,7 +151,7 @@ class TokenResolver:
             if refresh:
                 return self._kodi.open_settings()
             self._kodi.open_settings()
-            if not self._credentials_changed() and not self._kodi.credentials_filled_in():
+            if not self._credentials_changed():
                 return None
             login_json = self._get_login_json()
 


### PR DESCRIPTION
After removing the password clearing functionality, we got an endless OK dialog/settings dialog loop when the user tries to start a VOD stream and can't provide good credentials.
With this pull request the user can exit the loop if he doesn't change the bad credentials.