### PR TITLE
Use new high-res fanart by default

### DIFF
--- a/Build-Zip.ps1
+++ b/Build-Zip.ps1
@@ -4,7 +4,7 @@ Set-StrictMode -Version 5.0
 
 $include_files = @( 'addon.xml', 'LICENSE', 'README.md' )
 $include_paths = @( 'resources/' )
-$exclude_files = @( '*.new', '*.orig', '*.pyc' )
+$exclude_files = @( '*.new', '*.orig', '*.pyc', '*.pyo' )
 
 # Get addon metadata
 [xml]$XmlDocument = Get-Content -LiteralPath 'addon.xml'

--- a/resources/lib/addon.py
+++ b/resources/lib/addon.py
@@ -162,10 +162,11 @@ def featured(feature=None):
 
 
 @plugin.route('/tvguide')
+@plugin.route('/tvguide/date')
 @plugin.route('/tvguide/date/<date>')
 @plugin.route('/tvguide/date/<date>/<channel>')
 def tvguide(date=None, channel=None):
-    ''' The TV guide menu and listings '''
+    ''' The TV guide menu and listings by date '''
     from tvguide import TVGuide
     TVGuide(kodi).show_tvguide(date=date, channel=channel)
 
@@ -174,9 +175,9 @@ def tvguide(date=None, channel=None):
 @plugin.route('/tvguide/channel/<channel>')
 @plugin.route('/tvguide/channel/<channel>/<date>')
 def tvguide_channel(channel=None, date=None):
-    ''' The TV guide menu and listings '''
+    ''' The TV guide menu and listings by channel '''
     from tvguide import TVGuide
-    TVGuide(kodi).show_tvguide(channel=channel)
+    TVGuide(kodi).show_tvguide(channel=channel, date=date)
 
 
 @plugin.route('/search')

--- a/resources/lib/apihelper.py
+++ b/resources/lib/apihelper.py
@@ -475,20 +475,19 @@ class ApiHelper:
                 continue
 
             context_menu = []
+            art_dict = dict()
 
             # Try to use the white icons for thumbnails (used for icons as well)
             if self._kodi.get_cond_visibility('System.HasAddon(resource.images.studios.white)') == 1:
-                thumb = 'resource://resource.images.studios.white/{studio}.png'.format(**channel)
+                art_dict['thumb'] = 'resource://resource.images.studios.white/{studio}.png'.format(**channel)
             else:
-                thumb = 'DefaultTags.png'
+                art_dict['thumb'] = 'DefaultTags.png'
 
             # Try to use the coloured icons for fanart
             if self._kodi.get_cond_visibility('System.HasAddon(resource.images.studios.coloured)') == 1:
-                fanart = 'resource://resource.images.studios.coloured/{studio}.png'.format(**channel)
+                art_dict['fanart'] = 'resource://resource.images.studios.coloured/{studio}.png'.format(**channel)
             elif self._kodi.get_cond_visibility('System.HasAddon(resource.images.studios.white)') == 1:
-                fanart = 'resource://resource.images.studios.white/{studio}.png'.format(**channel)
-            else:
-                fanart = 'DefaultTags.png'
+                art_dict['fanart'] = 'resource://resource.images.studios.white/{studio}.png'.format(**channel)
 
             if not live:
                 path = self._kodi.url_for('channels', channel=channel.get('name'))
@@ -509,7 +508,7 @@ class ApiHelper:
                 is_playable = True
                 if channel.get('name') in ['een', 'canvas', 'ketnet']:
                     if self._showfanart:
-                        fanart = self.get_live_screenshot(channel.get('name', fanart))
+                        art_dict['fanart'] = self.get_live_screenshot(channel.get('name', art_dict.get('fanart')))
                     plot = '%s\n\n%s' % (self._kodi.localize(30102, **channel), _tvguide.live_description(channel.get('name')))
                 else:
                     plot = self._kodi.localize(30102, **channel)
@@ -524,7 +523,7 @@ class ApiHelper:
             channel_items.append(TitleItem(
                 title=label,
                 path=path,
-                art_dict=dict(thumb=thumb, fanart=fanart),
+                art_dict=art_dict,
                 info_dict=info_dict,
                 stream_dict=stream_dict,
                 context_menu=context_menu,
@@ -546,20 +545,19 @@ class ApiHelper:
                 continue
 
             context_menu = []
+            art_dict = dict()
 
             # Try to use the white icons for thumbnails (used for icons as well)
             if self._kodi.get_cond_visibility('System.HasAddon(resource.images.studios.white)') == 1:
-                thumb = 'resource://resource.images.studios.white/{studio}.png'.format(**channel)
+                art_dict['thumb'] = 'resource://resource.images.studios.white/{studio}.png'.format(**channel)
             else:
-                thumb = 'DefaultTags.png'
+                art_dict['thumb'] = 'DefaultTags.png'
 
             # Try to use the coloured icons for fanart
             if self._kodi.get_cond_visibility('System.HasAddon(resource.images.studios.coloured)') == 1:
-                fanart = 'resource://resource.images.studios.coloured/{studio}.png'.format(**channel)
+                art_dict['fanart'] = 'resource://resource.images.studios.coloured/{studio}.png'.format(**channel)
             elif self._kodi.get_cond_visibility('System.HasAddon(resource.images.studios.white)') == 1:
-                fanart = 'resource://resource.images.studios.white/{studio}.png'.format(**channel)
-            else:
-                fanart = 'DefaultTags.png'
+                art_dict['fanart'] = 'resource://resource.images.studios.white/{studio}.png'.format(**channel)
 
             if channel.get('youtube'):
                 path = channel.get('youtube')
@@ -578,7 +576,7 @@ class ApiHelper:
             youtube_items.append(TitleItem(
                 title=label,
                 path=path,
-                art_dict=dict(thumb=thumb, fanart=fanart),
+                art_dict=art_dict,
                 info_dict=info_dict,
                 context_menu=context_menu,
                 is_playable=False,
@@ -596,7 +594,7 @@ class ApiHelper:
             featured_items.append(TitleItem(
                 title=featured_name,
                 path=self._kodi.url_for('featured', feature=feature.get('id')),
-                art_dict=dict(thumb='DefaultCountry.png', fanart='DefaultCountry.png'),
+                art_dict=dict(thumb='DefaultCountry.png'),
                 info_dict=dict(plot='[B]%s[/B]' % featured_name, studio='VRT'),
             ))
         return featured_items
@@ -636,7 +634,7 @@ class ApiHelper:
             category_items.append(TitleItem(
                 title=category_name,
                 path=self._kodi.url_for('categories', category=category.get('id')),
-                art_dict=dict(thumb=thumbnail, icon='DefaultGenre.png', fanart=thumbnail),
+                art_dict=dict(thumb=thumbnail, icon='DefaultGenre.png'),
                 info_dict=dict(plot='[B]%s[/B]' % category_name, studio='VRT'),
             ))
         return category_items

--- a/resources/lib/kodiwrapper.py
+++ b/resources/lib/kodiwrapper.py
@@ -119,6 +119,7 @@ class KodiWrapper:
             self._url = self.plugin.base_url
         self._addon = Addon()
         self._addon_id = to_unicode(self._addon.getAddonInfo('id'))
+        self._addon_fanart = to_unicode(self._addon.getAddonInfo('fanart'))
         self._max_log_level = log_levels.get(self.get_setting('max_log_level', 'Debug'), 3)
         self._usemenucaching = self.get_setting('usemenucaching', 'true') == 'true'
         self._cache_path = self.get_userdata_path() + 'cache/'
@@ -193,6 +194,7 @@ class KodiWrapper:
             # list_item.setIsFolder(is_folder)
 
             if title_item.art_dict:
+                list_item.setArt(dict(fanart=self._addon_fanart))
                 list_item.setArt(title_item.art_dict)
 
             if title_item.info_dict:

--- a/resources/lib/metadata.py
+++ b/resources/lib/metadata.py
@@ -367,80 +367,50 @@ class Metadata:
 
     def get_art(self, api_data, season=False):
         ''' Get art dict from single item json api data '''
+        art_dict = dict()
 
         # VRT NU Search API
         if api_data.get('type') == 'episode':
             if season:
                 if self._showfanart:
-                    fanart = statichelper.add_https_method(api_data.get('programImageUrl', 'DefaultSets.png'))
-                    thumb = statichelper.add_https_method(api_data.get('videoThumbnailUrl', fanart)) if season != 'allseasons' else fanart
+                    art_dict['fanart'] = statichelper.add_https_method(api_data.get('programImageUrl', 'DefaultSets.png'))
+                    if season != 'allseasons':
+                        art_dict['thumb'] = statichelper.add_https_method(api_data.get('videoThumbnailUrl', art_dict.get('fanart')))
+                    else:
+                        art_dict['thumb'] = art_dict.get('fanart')
                 else:
-                    thumb = 'DefaultSets.png'
-                    fanart = 'DefaultSets.png'
+                    art_dict['thumb'] = 'DefaultSets.png'
             else:
                 if self._showfanart:
-                    thumb = statichelper.add_https_method(api_data.get('videoThumbnailUrl', 'DefaultAddonVideo.png'))
-                    fanart = statichelper.add_https_method(api_data.get('programImageUrl', thumb))
+                    art_dict['thumb'] = statichelper.add_https_method(api_data.get('videoThumbnailUrl', 'DefaultAddonVideo.png'))
+                    art_dict['fanart'] = statichelper.add_https_method(api_data.get('programImageUrl', art_dict.get('thumb')))
                 else:
-                    thumb = 'DefaultAddonVideo.png'
-                    fanart = 'DefaultAddonVideo.png'
+                    art_dict['thumb'] = 'DefaultAddonVideo.png'
 
-            art = dict(
-                thumb=thumb,
-                poster='',
-                banner=fanart,
-                fanart=fanart,
-                clearart='',
-                clearlogo='',
-                landscape='',
-                icon='DefaultAddonVideo.png'
-            )
-            return art
+            return art_dict
 
         # VRT NU Suggest API
         if api_data.get('type') == 'program':
             if self._showfanart:
-                thumb = statichelper.add_https_method(api_data.get('thumbnail', 'DefaultAddonVideo.png'))
-                fanart = thumb
+                art_dict['thumb'] = statichelper.add_https_method(api_data.get('thumbnail', 'DefaultAddonVideo.png'))
+                art_dict['fanart'] = art_dict.get('thumb')
             else:
-                thumb = 'DefaultAddonVideo.png'
-                fanart = 'DefaultAddonVideo.png'
+                art_dict['thumb'] = 'DefaultAddonVideo.png'
 
-            art = dict(
-                thumb=thumb,
-                poster='',
-                banner=fanart,
-                fanart=fanart,
-                clearart='',
-                clearlogo='',
-                landscape='',
-                icon='DefaultAddonVideo.png'
-            )
-            return art
+            return art_dict
 
         # VRT NU Schedule API
         if api_data.get('vrt.whatson-id'):
             if self._showfanart:
-                thumb = api_data.get('image', 'DefaultAddonVideo.png')
-                fanart = thumb
+                art_dict['thumb'] = api_data.get('image', 'DefaultAddonVideo.png')
+                art_dict['fanart'] = art_dict.get('thumb')
             else:
-                thumb = 'DefaultAddonVideo.png'
-                fanart = 'DefaultAddonVideo.png'
+                art_dict['thumb'] = 'DefaultAddonVideo.png'
 
-            art = dict(
-                thumb=thumb,
-                poster='',
-                banner=fanart,
-                fanart=fanart,
-                clearart='',
-                clearlogo='',
-                landscape='',
-                icon='DefaultAddonVideo.png'
-            )
-            return art
+            return art_dict
 
         # Not Found
-        return dict()
+        return art_dict
 
     def get_info_labels(self, api_data, season=False, date=None, channel=None):
         ''' Get infoLabels dict from single item json api data '''

--- a/resources/lib/search.py
+++ b/resources/lib/search.py
@@ -25,7 +25,7 @@ class Search:
             TitleItem(
                 title=self._kodi.localize(30424),  # New search...
                 path=self._kodi.url_for('search_query'),
-                art_dict=dict(thumb='DefaultAddonsSearch.png', fanart='DefaultAddonsSearch.png'),
+                art_dict=dict(thumb='DefaultAddonsSearch.png'),
                 info_dict=dict(plot=self._kodi.localize(30425)),
                 is_playable=False,
             )
@@ -41,7 +41,7 @@ class Search:
             menu_items.append(TitleItem(
                 title=keywords,
                 path=self._kodi.url_for('search_query', keywords=keywords),
-                art_dict=dict(thumb='DefaultAddonsSearch.png', fanart='DefaultAddonsSearch.png'),
+                art_dict=dict(thumb='DefaultAddonsSearch.png'),
                 is_playable=False,
                 context_menu=[(self._kodi.localize(30030), 'RunPlugin(%s)' % self._kodi.url_for('remove_search', keywords=keywords))]
             ))
@@ -51,7 +51,7 @@ class Search:
                 title=self._kodi.localize(30426),  # Clear search history
                 path=self._kodi.url_for('clear_search'),
                 info_dict=dict(plot=self._kodi.localize(30427)),
-                art_dict=dict(thumb='icons/infodialogs/uninstall.png', fanart='icons/infodialogs/uninstall.png'),
+                art_dict=dict(thumb='icons/infodialogs/uninstall.png'),
                 is_playable=False,
             ))
 
@@ -83,7 +83,7 @@ class Search:
             search_items.append(TitleItem(
                 title=self._kodi.localize(30300),
                 path=self._kodi.url_for('search_query', keywords=keywords, page=page + 1),
-                art_dict=dict(thumb='DefaultAddonSearch.png', fanart='DefaultAddonSearch.png'),
+                art_dict=dict(thumb='DefaultAddonSearch.png'),
                 info_dict=dict(),
             ))
 

--- a/resources/lib/tvguide.py
+++ b/resources/lib/tvguide.py
@@ -103,7 +103,7 @@ class TVGuide:
             date_items.append(TitleItem(
                 title=title,
                 path=path,
-                art_dict=dict(thumb='DefaultYear.png', fanart='DefaultYear.png'),
+                art_dict=dict(thumb='DefaultYear.png'),
                 info_dict=dict(plot=self._kodi.localize_datelong(day)),
                 context_menu=[(self._kodi.localize(30413), 'RunPlugin(%s)' % self._kodi.url_for('delete_cache', cache_file=cache_file))],
             ))
@@ -126,8 +126,19 @@ class TVGuide:
             if channel and channel != chan.get('name'):
                 continue
 
-            fanart = 'resource://resource.images.studios.coloured/%(studio)s.png' % chan
-            thumb = 'resource://resource.images.studios.white/%(studio)s.png' % chan
+            art_dict = {}
+
+            # Try to use the white icons for thumbnails (used for icons as well)
+            if self._kodi.get_cond_visibility('System.HasAddon(resource.images.studios.white)') == 1:
+                art_dict['thumb'] = 'resource://resource.images.studios.white/{studio}.png'.format(**chan)
+            else:
+                art_dict['thumb'] = 'DefaultTags.png'
+
+            # Try to use the coloured icons for fanart
+            if self._kodi.get_cond_visibility('System.HasAddon(resource.images.studios.coloured)') == 1:
+                art_dict['fanart'] = 'resource://resource.images.studios.coloured/{studio}.png'.format(**chan)
+            elif self._kodi.get_cond_visibility('System.HasAddon(resource.images.studios.white)') == 1:
+                art_dict['fanart'] = 'resource://resource.images.studios.white/{studio}.png'.format(**chan)
 
             if date:
                 title = chan.get('label')
@@ -141,7 +152,7 @@ class TVGuide:
             channel_items.append(TitleItem(
                 title=title,
                 path=path,
-                art_dict=dict(thumb=thumb, fanart=fanart),
+                art_dict=art_dict,
                 info_dict=dict(plot=plot, studio=chan.get('studio')),
             ))
         return channel_items

--- a/resources/lib/vrtplayer.py
+++ b/resources/lib/vrtplayer.py
@@ -27,47 +27,46 @@ class VRTPlayer:
             main_items.append(TitleItem(
                 title=self._kodi.localize(30010),  # My programs
                 path=self._kodi.url_for('favorites_menu'),
-                art_dict=dict(thumb='icons/settings/profiles.png', fanart='icons/settings/profiles.png'),
+                art_dict=dict(thumb='icons/settings/profiles.png'),
                 info_dict=dict(plot=self._kodi.localize(30011))
             ))
 
         main_items.extend([
             TitleItem(title=self._kodi.localize(30012),  # A-Z listing
                       path=self._kodi.url_for('programs'),
-                      art_dict=dict(thumb='DefaultMovieTitle.png', fanart='DefaultMovieTitle.png'),
+                      art_dict=dict(thumb='DefaultMovieTitle.png'),
                       info_dict=dict(plot=self._kodi.localize(30013))),
             TitleItem(title=self._kodi.localize(30014),  # Categories
                       path=self._kodi.url_for('categories'),
-                      art_dict=dict(thumb='DefaultGenre.png', fanart='DefaultGenre.png'),
+                      art_dict=dict(thumb='DefaultGenre.png'),
                       info_dict=dict(plot=self._kodi.localize(30015))),
             TitleItem(title=self._kodi.localize(30016),  # Channels
                       path=self._kodi.url_for('channels'),
-                      art_dict=dict(thumb='DefaultTags.png', fanart='DefaultTags.png'),
+                      art_dict=dict(thumb='DefaultTags.png'),
                       info_dict=dict(plot=self._kodi.localize(30017))),
             TitleItem(title=self._kodi.localize(30018),  # Live TV
                       path=self._kodi.url_for('livetv'),
-                      # art_dict=dict(thumb='DefaultAddonPVRClient.png', fanart='DefaultAddonPVRClient.png'),
-                      art_dict=dict(thumb='DefaultTVShows.png', fanart='DefaultTVShows.png'),
+                      art_dict=dict(thumb='DefaultTVShows.png'),
                       info_dict=dict(plot=self._kodi.localize(30019))),
             TitleItem(title=self._kodi.localize(30020),  # Recent items
                       path=self._kodi.url_for('recent'),
-                      art_dict=dict(thumb='DefaultRecentlyAddedEpisodes.png', fanart='DefaultRecentlyAddedEpisodes.png'),
+                      art_dict=dict(thumb='DefaultRecentlyAddedEpisodes.png'),
                       info_dict=dict(plot=self._kodi.localize(30021))),
             TitleItem(title=self._kodi.localize(30022),  # Soon offline
                       path=self._kodi.url_for('offline'),
-                      art_dict=dict(thumb='DefaultYear.png', fanart='DefaultYear.png'),
+                      art_dict=dict(thumb='DefaultYear.png'),
                       info_dict=dict(plot=self._kodi.localize(30023))),
             TitleItem(title=self._kodi.localize(30024),  # Featured content
                       path=self._kodi.url_for('featured'),
-                      art_dict=dict(thumb='DefaultCountry.png', fanart='DefaultCountry.png'),
+                      art_dict=dict(thumb='DefaultCountry.png'),
                       info_dict=dict(plot=self._kodi.localize(30025))),
             TitleItem(title=self._kodi.localize(30026),  # TV guide
                       path=self._kodi.url_for('tvguide'),
-                      art_dict=dict(thumb='DefaultAddonTvInfo.png', fanart='DefaultAddonTvInfo.png'),
+                      art_dict=dict(thumb='DefaultAddonTvInfo.png'),
                       info_dict=dict(plot=self._kodi.localize(30027))),
             TitleItem(title=self._kodi.localize(30028),  # Search
                       path=self._kodi.url_for('search'),
-                      art_dict=dict(thumb='DefaultAddonsSearch.png', fanart='DefaultAddonsSearch.png'),
+                      art_dict=dict(thumb='DefaultAddonsSearch.png'),
                       info_dict=dict(plot=self._kodi.localize(30029))),
         ])
         self._kodi.show_listing(main_items)
@@ -110,15 +109,15 @@ class VRTPlayer:
         favorites_items = [
             TitleItem(title=self._kodi.localize(30040),  # My A-Z listing
                       path=self._kodi.url_for('favorites_programs'),
-                      art_dict=dict(thumb='DefaultMovieTitle.png', fanart='DefaultMovieTitle.png'),
+                      art_dict=dict(thumb='DefaultMovieTitle.png'),
                       info_dict=dict(plot=self._kodi.localize(30041))),
             TitleItem(title=self._kodi.localize(30046),  # My recent items
                       path=self._kodi.url_for('favorites_recent'),
-                      art_dict=dict(thumb='DefaultRecentlyAddedEpisodes.png', fanart='DefaultRecentlyAddedEpisodes.png'),
+                      art_dict=dict(thumb='DefaultRecentlyAddedEpisodes.png'),
                       info_dict=dict(plot=self._kodi.localize(30047))),
             TitleItem(title=self._kodi.localize(30048),  # My soon offline
                       path=self._kodi.url_for('favorites_offline'),
-                      art_dict=dict(thumb='DefaultYear.png', fanart='DefaultYear.png'),
+                      art_dict=dict(thumb='DefaultYear.png'),
                       info_dict=dict(plot=self._kodi.localize(30049))),
         ]
 
@@ -126,7 +125,7 @@ class VRTPlayer:
             favorites_items.append(
                 TitleItem(title=self._kodi.localize(30042),  # My movies
                           path=self._kodi.url_for('categories', category='films'),
-                          art_dict=dict(thumb='DefaultAddonVideo.png', fanart='DefaultAddonVideo.png'),
+                          art_dict=dict(thumb='DefaultAddonVideo.png'),
                           info_dict=dict(plot=self._kodi.localize(30043))),
             )
 
@@ -134,7 +133,7 @@ class VRTPlayer:
             favorites_items.append(
                 TitleItem(title=self._kodi.localize(30044),  # My documentaries
                           path=self._kodi.url_for('favorites_docu'),
-                          art_dict=dict(thumb='DefaultMovies.png', fanart='DefaultMovies.png'),
+                          art_dict=dict(thumb='DefaultMovies.png'),
                           info_dict=dict(plot=self._kodi.localize(30045))),
             )
 
@@ -220,7 +219,7 @@ class VRTPlayer:
             episode_items.append(TitleItem(
                 title=self._kodi.localize(30300),
                 path=self._kodi.url_for(recent, page=page + 1),
-                art_dict=dict(thumb='DefaultRecentlyAddedEpisodes.png', fanart='DefaultRecentlyAddedEpisodes.png'),
+                art_dict=dict(thumb='DefaultRecentlyAddedEpisodes.png'),
                 info_dict=dict(),
             ))
 
@@ -244,7 +243,7 @@ class VRTPlayer:
             episode_items.append(TitleItem(
                 title=self._kodi.localize(30300),
                 path=self._kodi.url_for(offline, page=page + 1),
-                art_dict=dict(thumb='DefaultYear.png', fanart='DefaultYear.png'),
+                art_dict=dict(thumb='DefaultYear.png'),
                 info_dict=dict(),
             ))
 

--- a/test/test_kodi.py
+++ b/test/test_kodi.py
@@ -21,15 +21,12 @@ class KodiTests(unittest.TestCase):
     def test_localize(self):
         msg = self._kodi.localize(30958)
         self.assertEqual(msg, "There is a problem with this VRT NU {protocol} stream. Try again with {component} {state} or try to play this program from the VRT NU website. Please report this problem at https://www.vrt.be/vrtnu/help/")  # noqa
-        print(msg)
 
         msg = self._kodi.localize(30958, component='Widevine DRM', state='enabled')
         self.assertEqual(msg, "There is a problem with this VRT NU {protocol} stream. Try again with Widevine DRM enabled or try to play this program from the VRT NU website. Please report this problem at https://www.vrt.be/vrtnu/help/")  # noqa
-        print(msg)
 
         msg = self._kodi.localize(30958, protocol='MPEG-DASH', component='Widevine DRM', state='enabled')
         self.assertEqual(msg, "There is a problem with this VRT NU MPEG-DASH stream. Try again with Widevine DRM enabled or try to play this program from the VRT NU website. Please report this problem at https://www.vrt.be/vrtnu/help/")  # noqa
-        print(msg)
 
 
 if __name__ == '__main__':

--- a/test/test_routing.py
+++ b/test/test_routing.py
@@ -98,7 +98,7 @@ class TestRouter(unittest.TestCase):
     # TV guide menu: '/tvguide/<date>/<channel>'
     def test_tvguide_date_menu(self):
         plugin.run(['plugin://plugin.video.vrt.nu/tvguide', '0', ''])
-        self.assertEqual(plugin.url_for(addon.tvguide), 'plugin://plugin.video.vrt.nu/tvguide')
+        self.assertEqual(plugin.url_for(addon.tvguide), 'plugin://plugin.video.vrt.nu/tvguide/date')
         plugin.run(['plugin://plugin.video.vrt.nu/tvguide/date/today', '0', ''])
         self.assertEqual(plugin.url_for(addon.tvguide, date='today'), 'plugin://plugin.video.vrt.nu/tvguide/date/today')
         plugin.run(['plugin://plugin.video.vrt.nu/tvguide/date/today/canvas', '0', ''])


### PR DESCRIPTION
This PR includes:
- Use the new high-res fanart instead of low-res icons
- Exclude .pyo files in Build-Zip
- Small changes to /tvguide rating
- Remove (debug) prints from test_kodi localize() tests