### PR TITLE
Rename 'My programs' to 'My favorites'

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -17,7 +17,7 @@ msgstr ""
 
 ### MAIN MENU
 msgctxt "#30010"
-msgid "My programs"
+msgid "My favorites"
 msgstr ""
 
 msgctxt "#30011"
@@ -111,7 +111,7 @@ msgstr ""
 
 ### FAVORITES
 msgctxt "#30040"
-msgid "My favourite programs"
+msgid "My favorite programs"
 msgstr ""
 
 msgctxt "#30041"
@@ -432,11 +432,11 @@ msgid "Features"
 msgstr ""
 
 msgctxt "#30823"
-msgid "Enable My programs"
+msgid "Enable My favorites"
 msgstr ""
 
 msgctxt "#30824"
-msgid "When enabled, the user can follow their favourite programs and list these separately. In this case the VRT NU add-on will download and update a list of your followed programs on the VRT NU website."
+msgid "When enabled, the user can follow their favorite programs and list these separately. In this case the VRT NU add-on will download and update a list of your followed programs on the VRT NU website."
 msgstr ""
 
 msgctxt "#30825"
@@ -718,7 +718,7 @@ msgid "Welcome to VRT NU add-on v2.0.0"
 msgstr ""
 
 msgctxt "#30979"
-msgid "Because of important internal changes, existing Kodi favourites and watched history from VRT NU no longer work.\n[B]Please recreate all your VRT NU favourites.[/B]"
+msgid "Because of important internal changes, existing Kodi favourites and watched history from VRT NU no longer work.\n[B]Please recreate all your VRT NU favorites.[/B]"
 msgstr ""
 
 msgctxt "#30981"

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -18,8 +18,8 @@ msgstr ""
 
 ### MAIN MENU
 msgctxt "#30010"
-msgid "My programs"
-msgstr "Mijn programma's"
+msgid "My favorites"
+msgstr "Mijn favorieten"
 
 msgctxt "#30011"
 msgid "Browse only the programs you follow"
@@ -112,7 +112,7 @@ msgstr "Zoekresultaten"
 
 ### FAVORITES
 msgctxt "#30040"
-msgid "My favourite programs"
+msgid "My favorite programs"
 msgstr "Mijn favoriete programma's"
 
 msgctxt "#30041"
@@ -328,11 +328,11 @@ msgid "Features"
 msgstr "Functionaliteit"
 
 msgctxt "#30823"
-msgid "Enable My programs"
-msgstr "Toon Mijn programma's"
+msgid "Enable My favorites"
+msgstr "Toon Mijn favorieten"
 
 msgctxt "#30824"
-msgid "When enabled, the user can follow their favourite programs and list these separately. In this case the VRT NU add-on will download and update a list of your followed programs on the VRT NU website."
+msgid "When enabled, the user can follow their favorite programs and list these separately. In this case the VRT NU add-on will download and update a list of your followed programs on the VRT NU website."
 msgstr "Indien actief kan de gebruiker zijn favoriete programma's volgen en apart aanroepen. Dit zorgt er wel voor dat de VRT NU add-on een lijst van favoriete programma's download en aanpast op de VRT NU website."
 
 msgctxt "#30825"
@@ -610,7 +610,7 @@ msgid "Welcome to VRT NU add-on v2.0.0"
 msgstr "Welkom bij VRT NU add-on v2.0.0"
 
 msgctxt "#30979"
-msgid "Because of important internal changes, existing Kodi favourites and watched history from VRT NU no longer work.\n[B]Please recreate all your VRT NU favourites.[/B]"
+msgid "Because of important internal changes, existing Kodi favourites and watched history from VRT NU no longer work.\n[B]Please recreate all your VRT NU favorites.[/B]"
 msgstr "Wegens belangrijke interne wijzigingen werken bestaande Kodi-favorieten en kijkgeschiedenis van VRT NU niet meer.\n[B]Gelieve al uw VRT NU-favorieten opnieuw aan te maken.[/B]"
 
 msgctxt "#30981"

--- a/resources/lib/addon.py
+++ b/resources/lib/addon.py
@@ -60,7 +60,7 @@ def unfollow(program, title):
 
 @plugin.route('/favorites')
 def favorites_menu():
-    ''' The favorites My program menu '''
+    ''' The My favorites menu '''
     from vrtplayer import VRTPlayer
     VRTPlayer(kodi).show_favorites_menu()
 

--- a/resources/lib/vrtplayer.py
+++ b/resources/lib/vrtplayer.py
@@ -22,12 +22,12 @@ class VRTPlayer:
         self._favorites.get_favorites(ttl=60 * 60)
         main_items = []
 
-        # Only add 'My programs' when it has been activated
+        # Only add 'My favorites' when it has been activated
         if self._favorites.is_activated():
             main_items.append(TitleItem(
-                title=self._kodi.localize(30010),  # My programs
+                title=self._kodi.localize(30010),  # My favorites
                 path=self._kodi.url_for('favorites_menu'),
-                art_dict=dict(thumb='icons/settings/profiles.png'),
+                art_dict=dict(thumb='DefaultFavourites.png'),
                 info_dict=dict(plot=self._kodi.localize(30011))
             ))
 
@@ -75,7 +75,7 @@ class VRTPlayer:
     def _version_check(self):
         first_run, settings_version, addon_version = self._first_run()
         if first_run:
-            # 2.0.0 version: changed plugin:// url interface: show warning that favourites and what-was-watched will break
+            # 2.0.0 version: changed plugin:// url interface: show warning that Kodi favourites and what-was-watched will break
             if settings_version == '' and self._kodi.credentials_filled_in():
                 self._kodi.show_ok_dialog(self._kodi.localize(30978), self._kodi.localize(30979))
             if addon_version == '2.2.1':
@@ -140,7 +140,7 @@ class VRTPlayer:
                           info_dict=dict(plot=self._kodi.localize(30045))),
             )
 
-        self._kodi.show_listing(favorites_items, category=30010)  # My programs
+        self._kodi.show_listing(favorites_items, category=30010)  # My favorites
 
         # Show dialog when no favorites were found
         if not self._favorites.titles():
@@ -154,7 +154,7 @@ class VRTPlayer:
 
     def show_tvshow_menu(self, use_favorites=False):
         ''' The VRT NU add-on 'A-Z' listing menu '''
-        # My programs menus may need more up-to-date favorites
+        # My favorites menus may need more up-to-date favorites
         self._favorites.get_favorites(ttl=5 * 60 if use_favorites else 60 * 60)
         tvshow_items = self._apihelper.list_tvshows(use_favorites=use_favorites)
         self._kodi.show_listing(tvshow_items, category=30012, sort='label', content='tvshows')
@@ -208,7 +208,7 @@ class VRTPlayer:
         ''' The VRT NU add-on 'Most recent' and 'My most recent' listing menu '''
         from statichelper import realpage
 
-        # My programs menus may need more up-to-date favorites
+        # My favorites menus may need more up-to-date favorites
         self._favorites.get_favorites(ttl=5 * 60 if use_favorites else 60 * 60)
         page = realpage(page)
         episode_items, sort, ascending, content = self._apihelper.list_episodes(page=page, use_favorites=use_favorites, variety='recent')
@@ -232,7 +232,7 @@ class VRTPlayer:
         ''' The VRT NU add-on 'Soon offline' and 'My soon offline' listing menu '''
         from statichelper import realpage
 
-        # My programs menus may need more up-to-date favorites
+        # My favorites menus may need more up-to-date favorites
         self._favorites.get_favorites(ttl=5 * 60 if use_favorites else 60 * 60)
         page = realpage(page)
         episode_items, sort, ascending, content = self._apihelper.list_episodes(page=page, use_favorites=use_favorites, variety='offline')


### PR DESCRIPTION
Since the VRT NU app now also list "Favorieten" we want to make our
naming consisent to the VRT NU app.