### PR TITLE
Remove Widevine installation (API and settings)

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -608,11 +608,7 @@ msgid "InputStream Adaptive settings..."
 msgstr ""
 
 msgctxt "#30921"
-msgid "InputStream Helper settings..."
-msgstr ""
-
-msgctxt "#30923"
-msgid "Install Widevine CDM... [COLOR gray][I](for protected content)[/I][/COLOR]"
+msgid "InputStream Helper settings... [COLOR gray][I](for protected content)[/I][/COLOR]"
 msgstr ""
 
 msgctxt "#30925"
@@ -687,22 +683,6 @@ msgstr ""
 
 msgctxt "#30966"
 msgid "Using a SOCKS proxy requires the PySocks library (script.module.pysocks) installed."
-msgstr ""
-
-msgctxt "#30971"
-msgid "Install Widevine using 'InputStream Helper' add-on"
-msgstr ""
-
-msgctxt "#30972"
-msgid "Installing Widevine libraries using the 'InputStream Helper' add-on is done at your own risk and the VRT NU add-on is not responsible for any results. Nor is it guaranteed that Widevine will be (re)installed correctly."
-msgstr ""
-
-msgctxt "#30973"
-msgid "Installation of Widevine failed!"
-msgstr ""
-
-msgctxt "#30974"
-msgid "Installation of Widevine completed!"
 msgstr ""
 
 msgctxt "#30975"

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -500,12 +500,8 @@ msgid "InputStream Adaptive settings..."
 msgstr "InputStream Adaptive instellingen..."
 
 msgctxt "#30921"
-msgid "InputStream Helper settings..."
-msgstr "InputStream Helper instellingen..."
-
-msgctxt "#30923"
-msgid "Install Widevine CDM... [COLOR gray][I](for protected content)[/I][/COLOR]"
-msgstr "Installeer Widevine CDM... [COLOR gray][I](voor beveiligde video's)[/I][/COLOR]"
+msgid "InputStream Helper settings... [COLOR gray][I](for protected content)[/I][/COLOR]"
+msgstr "InputStream Helper instellingen...[COLOR gray][I](voor beveiligde video's)[/I][/COLOR]"
 
 msgctxt "#30925"
 msgid "Logging"
@@ -580,22 +576,6 @@ msgstr "Dit programma kan niet afgespeeld worden. Het wordt geblokkeerd op jouw 
 msgctxt "#30966"
 msgid "Using a SOCKS proxy requires the PySocks library (script.module.pysocks) installed."
 msgstr "Het gebruik van SOCKS proxies vereist dat de PySocks library (script.module.pysocks) geïnstalleerd is."
-
-msgctxt "#30971"
-msgid "Install Widevine using 'InputStream Helper' add-on"
-msgstr "Installeer Widevine met de 'InputStream Helper' add-on"
-
-msgctxt "#30972"
-msgid "Installing Widevine libraries using the 'InputStream Helper' add-on is done at your own risk and the VRT NU add-on is not responsible for any results. Nor is it guaranteed that Widevine will be (re)installed correctly."
-msgstr "Het installeren van de Widevine bestanden met de 'InputStream Helper' add-on is op eigen risico en de VRT NU add-on is niet verantwoordelijk voor enig resultaat. Ook wordt het niet gegarandeerd dat Widevine succesvol kan worden geinstalleerd."
-
-msgctxt "#30973"
-msgid "Installation of Widevine failed!"
-msgstr "Widevine installatie mislukt!"
-
-msgctxt "#30974"
-msgid "Installation of Widevine completed!"
-msgstr "Widevine installatie gelukt"
 
 msgctxt "#30975"
 msgid "Failed to get favorites token from VRT NU"

--- a/resources/lib/addon.py
+++ b/resources/lib/addon.py
@@ -38,12 +38,6 @@ def delete_tokens():
     TokenResolver(kodi).delete_tokens()
 
 
-@plugin.route('/widevine/install')
-def install_widevine():
-    ''' The API interface to install Widevine '''
-    kodi.install_widevine()
-
-
 @plugin.route('/follow/<program>/<title>')
 def follow(program, title):
     ''' The API interface to follow a program used by the context menu '''

--- a/resources/lib/kodiwrapper.py
+++ b/resources/lib/kodiwrapper.py
@@ -130,22 +130,6 @@ class KodiWrapper:
         ''' Wrapper for routing.url_for() to lookup by name '''
         return self.plugin.url_for(self.addon[name], *args, **kwargs)
 
-    def install_widevine(self):
-        ''' Install Widevine using inputstreamhelper '''
-        ok = self.show_yesno_dialog(heading=self.localize(30971), message=self.localize(30972))
-        if not ok:
-            return
-        try:
-            from inputstreamhelper import Helper
-            is_helper = Helper('mpd', drm='com.widevine.alpha')
-            if is_helper.check_inputstream():
-                self.show_notification(heading=self.localize(30971), message=self.localize(30974), icon='info', time=5000)
-            else:
-                self.show_notification(heading=self.localize(30971), message=self.localize(30973), icon='error', time=5000)
-        except Exception:
-            self.show_notification(heading=self.localize(30971), message=self.localize(30973), icon='error', time=5000)
-        self.end_of_directory()
-
     def show_listing(self, list_items, category=None, sort='unsorted', ascending=True, content=None, cache=None):
         ''' Show a virtual directory in Kodi '''
         from xbmcgui import ListItem

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -51,7 +51,6 @@
         <setting label="30917" help="30918" type="bool" id="useinputstreamadaptive" default="true" visible="System.HasAddon(inputstream.adaptive)"/>
         <setting label="30919" help="30920" type="action" id="adaptive_settings" option="close" action="Addon.OpenSettings(inputstream.adaptive)" visible="System.HasAddon(inputstream.adaptive) + [String.StartsWith(System.BuildVersion,18) | String.StartsWith(System.BuildVersion,19)]" enable="eq(-1,true)" subsetting="true"/>
         <setting label="30921" help="30922" type="action" id="ishelper_install" option="close" action="Addon.OpenSettings(script.module.inputstreamhelper)" enable="eq(-2,true)" subsetting="true"/>
-        <setting label="30923" help="30924" type="action" id="widevine_install" option="close" action="RunPlugin(plugin://plugin.video.vrt.nu/widevine/install)" visible="System.HasAddon(inputstream.adaptive) + [String.StartsWith(System.BuildVersion,18) | String.StartsWith(System.BuildVersion,19)]" enable="eq(-3,true)" subsetting="true"/>
         <setting label="30925" type="lsep"/> <!-- Logging -->
         <setting label="30927" help="30928" type="select" id="max_log_level" values="Quiet|Info|Verbose|Debug" default="Info"/>
     </category>


### PR DESCRIPTION
Since inputstreamhelper will now be used for manual (re)installation of
Widevine, the existing reference to the inputstreamhelper settings is
sufficient for users to Troubleshoot their Widevine setup.