### PR TITLE
Simplify the availability of videos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,10 @@ msbuild.wrn
 # Packages
 *.zip
 
+# Logs
+kodi-addon-checker-report.log
+kodi-addon-checker.log
+
 # Credentials
 test/userdata/addon_settings.json
 test/userdata/cache/

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ python:
 sudo: false
 
 env:
-  CODECOV_TOKEN: 828d7a36-56bb-4e9b-97aa-d9cc6736b7ad
   PYTHONPATH: resources/lib:test
 
 install:

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -294,15 +294,27 @@ msgid "[COLOR red]Geo-blocked[/COLOR]\n"
 msgstr ""
 
 msgctxt "#30202"
-msgid "[COLOR blue]Available until {date}[/COLOR]\n"
+msgid "[COLOR blue][B]{years} more years[/B] available[/COLOR]\n"
 msgstr ""
 
 msgctxt "#30203"
-msgid "[COLOR gray]({days} days left)[/COLOR]\n"
+msgid "[COLOR blue][B]{months} more months[/B] available[/COLOR]\n"
 msgstr ""
 
 msgctxt "#30204"
-msgid "[COLOR gray]({hours} hours left)[/COLOR]\n"
+msgid "[COLOR blue][B]{days} more days[/B] available[/COLOR]\n"
+msgstr ""
+
+msgctxt "#30205"
+msgid "[COLOR blue][B]1 more day[/B] available[/COLOR]\n"
+msgstr ""
+
+msgctxt "#30206"
+msgid "[COLOR blue][B]{hours} more hours[/B] available[/COLOR]\n"
+msgstr ""
+
+msgctxt "#30207"
+msgid "[COLOR blue][B]1 more hour[/B] available[/COLOR]\n"
 msgstr ""
 
 msgctxt "#30300"

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -198,16 +198,28 @@ msgid "[COLOR red]Geo-blocked[/COLOR]\n"
 msgstr "[COLOR red]Geo-geblokkeerd[/COLOR]\n"
 
 msgctxt "#30202"
-msgid "[COLOR blue]Available until {date}[/COLOR]\n"
-msgstr "[COLOR blue]Beschikbaar tot {date}[/COLOR]\n"
+msgid "[COLOR blue][B]{years} more years[/B] available[/COLOR]\n"
+msgstr "[COLOR blue]Nog [B]{years} jaren[/B] beschikbaar[/COLOR]\n"
 
 msgctxt "#30203"
-msgid "[COLOR gray]({days} days left)[/COLOR]\n"
-msgstr "[COLOR gray](nog {days} dagen)[/COLOR]\n"
+msgid "[COLOR blue][B]{months} more months[/B] available[/COLOR]\n"
+msgstr "[COLOR blue]Nog [B]{months} maanden[/B] beschikbaar[/COLOR]\n"
 
 msgctxt "#30204"
-msgid "[COLOR gray]({hours} hours left)[/COLOR]\n"
-msgstr "[COLOR gray](nog {hours} uur)[/COLOR]\n"
+msgid "[COLOR blue][B]{days} more days[/B] available[/COLOR]\n"
+msgstr "[COLOR blue]Nog [B]{days} dagen[/B] beschikbaar[/COLOR]\n"
+
+msgctxt "#30205"
+msgid "[COLOR blue][B]1 more day[/B] available[/COLOR]\n"
+msgstr "[COLOR blue]Nog [B]1 dag[/B] Beschikbaar[/COLOR]\n"
+
+msgctxt "#30206"
+msgid "[COLOR blue][B]{hours} more hours[/B] available[/COLOR]\n"
+msgstr "[COLOR blue]Nog [B]{hours} uren[/B] beschikaar[/COLOR]\n"
+
+msgctxt "#30207"
+msgid "[COLOR blue][B]1 more hour[/B] available[/COLOR]\n"
+msgstr "[COLOR blue]Nog [B]1 uur[/B] beschikaar[/COLOR]\n"
 
 msgctxt "#30300"
 msgid "[B][COLOR yellow]More...[/COLOR][/B]"

--- a/resources/lib/metadata.py
+++ b/resources/lib/metadata.py
@@ -168,21 +168,31 @@ class Metadata:
 
             # Add additional metadata to plot
             plot_meta = ''
-            if api_data.get('allowedRegion') == 'BE':
-                # Show Geo-blocked
-                plot_meta += self._kodi.localize(30201)
-
             # Only display when a video disappears if it is within the next 3 months
             if api_data.get('assetOffTime'):
                 offtime = dateutil.parser.parse(api_data.get('assetOffTime'))
-            if offtime and (offtime - now).days < 93:
-                # Show date when episode is removed
-                plot_meta += self._kodi.localize(30202, date=self._kodi.localize_dateshort(offtime))
+
                 # Show the remaining days/hours the episode is still available
-                if (offtime - now).days > 0:
-                    plot_meta += self._kodi.localize(30203, days=(offtime - now).days)
-                else:
-                    plot_meta += self._kodi.localize(30204, hours=int((offtime - now).seconds / 3600))
+                if offtime:
+                    remaining = offtime - now
+                    if remaining.days / 365 > 5:
+                        pass  # If it is available for more than 5 years, do not show
+                    elif remaining.days / 365 > 2:
+                        plot_meta += self._kodi.localize(30202, years=int(remaining.days / 365))  # X years remaining
+                    elif remaining.days / 30.5 > 3:
+                        plot_meta += self._kodi.localize(30203, months=int(remaining.days / 30.5))  # X months remaining
+                    elif remaining.days > 1:
+                        plot_meta += self._kodi.localize(30204, days=remaining.days)  # X days to go
+                    elif remaining.days == 1:
+                        plot_meta += self._kodi.localize(30205)  # 1 day to go
+                    elif int(remaining.seconds / 3600) > 1:
+                        plot_meta += self._kodi.localize(30206, hours=int(remaining.seconds / 3600))  # X hours to go
+                    elif int(remaining.seconds / 3600) == 1:
+                        plot_meta += self._kodi.localize(30207)  # 1 hour to go
+
+            if api_data.get('allowedRegion') == 'BE':
+                # Show Geo-blocked
+                plot_meta += self._kodi.localize(30201)
 
             plot = '%s\n%s' % (plot_meta, plot)
 


### PR DESCRIPTION
This PR includes:
- Simply show the number of hours/days/months/years available
- Show it before showing **Geo-blocked**
- Ignore the add-on checker logs
- Remove unneeded Travis CODECOV_TOKEN