### PR TITLE
provide user a message when api url is too long

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -697,6 +697,10 @@ msgctxt "#30966"
 msgid "Using a SOCKS proxy requires the PySocks library (script.module.pysocks) installed."
 msgstr ""
 
+msgctxt "#30967"
+msgid "Could not retrieve this program list. VRT Search API url is too long. Unfollowing some favorited programs will reduce url length and may fix this problem."
+msgstr ""
+
 msgctxt "#30971"
 msgid "Install Widevine using 'InputStream Helper' add-on"
 msgstr ""

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -686,6 +686,10 @@ msgctxt "#30966"
 msgid "Using a SOCKS proxy requires the PySocks library (script.module.pysocks) installed."
 msgstr "Het gebruik van SOCKS proxies vereist dat de PySocks library (script.module.pysocks) geïnstalleerd is."
 
+msgctxt "#30967"
+msgid "Could not retrieve this program list. VRT Search API url is too long. Unfollowing some favorited programs will reduce url length and may fix this problem."
+msgstr "Deze programmalijst kan niet opgehaald worden. VRT Search API url is te lang. Enkele favoriete programma's vergeten zal de lengte van de URL verminderen en dit probleem mogelijk oplossen."
+
 msgctxt "#30971"
 msgid "Install Widevine using 'InputStream Helper' add-on"
 msgstr "Installeer Widevine met de 'InputStream Helper' add-on"

--- a/test/test_apihelper.py
+++ b/test/test_apihelper.py
@@ -83,6 +83,12 @@ class ApiHelperTests(unittest.TestCase):
         self.assertFalse(ascending)
         self.assertEqual(content, 'episodes')
 
+    def test_get_tvshows(self):
+        ''' Test get tvshows '''
+        category = 'humor'
+        tvshow_items = self._apihelper.get_tvshows(category=category)
+        self.assertTrue(tvshow_items)
+
     def test_list_tvshows(self):
         ''' Test items, sort and order '''
         category = 'nieuws-en-actua'

--- a/test/test_favorites.py
+++ b/test/test_favorites.py
@@ -7,6 +7,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import os
 import unittest
+from random import shuffle
 from addon import kodi
 from apihelper import ApiHelper
 from favorites import Favorites
@@ -41,6 +42,35 @@ class TestFavorites(unittest.TestCase):
         self.assertEqual(sort, 'dateadded')
         self.assertFalse(ascending)
         self.assertEqual(content, 'episodes')
+
+    @unittest.SkipTest
+    def test_unfollow_all(self):
+        programs = self._apihelper.get_tvshows()
+        for program_item in programs:
+            program_title = program_item.get('title')
+            program = program_item.get('programName')
+            if self._favorites.is_favorite(program):
+                # Unfollow
+                self._favorites.unfollow(program=program, title=program_title)
+                self.assertFalse(self._favorites.is_favorite(program))
+
+    @unittest.SkipTest
+    def test_follow_number(self):
+        number = 118
+        programs = self._apihelper.get_tvshows()
+        shuffle(programs)
+        print('VRT NU has %d programs available' % len(programs))
+        for program_item in programs[:number]:
+            program_title = program_item.get('title')
+            program = program_item.get('programName')
+
+            # Follow
+            self._favorites.follow(program=program, title=program_title)
+            self.assertTrue(self._favorites.is_favorite(program))
+
+            # Unfollow
+            # self._favorites.unfollow(program=program, title=program_title)
+            # self.assertFalse(self._favorites.is_favorite(program))
 
     def test_follow_unfollow(self):
         programs = [


### PR DESCRIPTION
One little step forward in trying to fix https://github.com/pietje666/plugin.video.vrt.nu/issues/399
This pull request includes:
- remove urlencode to support longer api urls
- provide user a message when api url is too long
- add unit tests to easily follow/unfollow hundreds of programs