### PR TITLE
Move cursor down when ListItem is unfollowed/removed

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -9,7 +9,7 @@
         <!-- import addon="inputstream.adaptive" version="2.0.20" optional="true"/ -->
         <import addon="script.module.inputstreamhelper" version="0.3.5"/>
         <import addon="script.module.pysocks" version="1.6.8" optional="true"/>
-        <import addon="script.module.routing" version="0.2.0"/>
+        <import addon="script.module.routing" version="0.2.2"/>
         <import addon="xbmc.python" version="2.25.0"/>
     </requires>
     <extension point="xbmc.python.pluginsource" library="resources/lib/addon_plugin.py">

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -111,7 +111,7 @@ msgstr ""
 
 ### FAVORITES
 msgctxt "#30040"
-msgid "My favorite programs"
+msgid "My programs"
 msgstr ""
 
 msgctxt "#30041"

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -112,8 +112,8 @@ msgstr "Zoekresultaten"
 
 ### FAVORITES
 msgctxt "#30040"
-msgid "My favorite programs"
-msgstr "Mijn favoriete programma's"
+msgid "My programs"
+msgstr "Mijn programma's"
 
 msgctxt "#30041"
 msgid "Alphabetically sorted list of My TV programs"

--- a/resources/lib/addon.py
+++ b/resources/lib/addon.py
@@ -48,8 +48,9 @@ def follow(program, title):
 @plugin.route('/unfollow/<program>/<title>')
 def unfollow(program, title):
     ''' The API interface to unfollow a program used by the context menu '''
+    move_down = bool(plugin.args.get('move_down'))
     from favorites import Favorites
-    Favorites(kodi).unfollow(program=program, title=to_unicode(unquote_plus(title)))
+    Favorites(kodi).unfollow(program=program, title=to_unicode(unquote_plus(title)), move_down=move_down)
 
 
 @plugin.route('/favorites')

--- a/resources/lib/favorites.py
+++ b/resources/lib/favorites.py
@@ -106,11 +106,14 @@ class Favorites:
             self._kodi.show_notification(message=self._kodi.localize(30411) + ' ' + title)
             self._kodi.container_refresh()
 
-    def unfollow(self, program, title):
+    def unfollow(self, program, title, move_down=False):
         ''' Unfollow your favorite program '''
         ok = self.set_favorite(program, title, False)
         if ok:
             self._kodi.show_notification(message=self._kodi.localize(30412) + ' ' + title)
+            # If the current item is selected and we need to move down before removing
+            if move_down:
+                self._kodi.input_down()
             self._kodi.container_refresh()
 
     def uuid(self, program):

--- a/resources/lib/kodiwrapper.py
+++ b/resources/lib/kodiwrapper.py
@@ -603,6 +603,10 @@ class KodiWrapper:
             self.delete_file(self._cache_path + f)
         self.delete_file(self._cache_path + 'oneoff.json')
 
+    def input_down(self):
+        ''' Move the cursor down '''
+        xbmc.executeJSONRPC('{"jsonrpc": "2.0", "method": "Input.Down", "id": 1}')
+
     def container_refresh(self):
         ''' Refresh the current container '''
         self.log_notice('Execute: Container.Refresh', 'Debug')

--- a/resources/lib/metadata.py
+++ b/resources/lib/metadata.py
@@ -51,6 +51,7 @@ class Metadata:
 
     def get_context_menu(self, api_data, program, cache_file):
         ''' Get context menu '''
+        from addon import plugin
         favorite_marker = ''
         context_menu = []
         if self._favorites.is_activated():
@@ -77,10 +78,14 @@ class Metadata:
             if follow_enabled:
                 program_title = quote_plus(statichelper.from_unicode(program_title))  # We need to ensure forward slashes are quoted
                 if self._favorites.is_favorite(program):
+                    extras = dict()
+                    # If we are in a favorites menu, move cursor down before removing a favorite
+                    if plugin.path.startswith('/favorites'):
+                        extras = dict(move_down=True)
                     # Unfollow context menu
                     context_menu.append((
                         self._kodi.localize(30412) + follow_suffix,
-                        'RunPlugin(%s)' % self._kodi.url_for('unfollow', program=program, title=program_title)
+                        'RunPlugin(%s)' % self._kodi.url_for('unfollow', program=program, title=program_title, **extras)
                     ))
                     favorite_marker = '[COLOR yellow]ᵛ[/COLOR]'
                 else:
@@ -91,7 +96,7 @@ class Metadata:
                     ))
 
         # Go to program context menu
-        if cache_file and cache_file.startswith(('my-offline', 'my-recent', 'offline', 'recent')):
+        if plugin.path.startswith(('/favorites/offline', '/favorites/recent', '/offline', '/recent')):
             plugin_url = self._kodi.url_for('programs', program=program, season='allseasons')
             # NOTE: Because of a bug in ActivateWindow(), return does not work
             # context_menu.append((self._kodi.localize(30417), 'ActivateWindow(Videos,%s,return)' % plugin_url))

--- a/test/routing.py
+++ b/test/routing.py
@@ -47,10 +47,13 @@ class RoutingError(Exception):
     pass
 
 
-class Plugin(object):
+class Plugin:
     """
     :ivar handle: The plugin handle from kodi
     :type handle: int
+
+    :ivar path: The current path
+    :type path: byte string
 
     :ivar args: The parsed query string.
     :type args: dict of byte strings
@@ -58,8 +61,14 @@ class Plugin(object):
 
     def __init__(self, base_url=None):
         self._rules = {}  # function to list of rules
-        argv = sys.argv if len(sys.argv) > 1 else ['', '', '']
-        self.handle = int(argv[1]) if argv[1].isdigit() else -1
+        if sys.argv:
+            self.path = urlsplit(sys.argv[0]).path or '/'
+        else:
+            self.path = '/'
+        if len(sys.argv) > 1 and sys.argv[1].isdigit():
+            self.handle = int(sys.argv[1])
+        else:
+            self.handle = -1
         self.args = {}
         self.base_url = base_url
         if self.base_url is None:
@@ -74,7 +83,7 @@ class Plugin(object):
         if path.startswith(self.base_url):
             path = path.split(self.base_url, 1)[1]
 
-        for view_fun, rules in iter(self._rules.items()):
+        for view_fun, rules in iter(list(self._rules.items())):
             for rule in rules:
                 if rule.match(path) is not None:
                     return view_fun
@@ -113,17 +122,19 @@ class Plugin(object):
             self._rules[func] = []
         self._rules[func].append(rule)
 
-    def run(self, argv=sys.argv):
+    def run(self, argv=None):
+        if argv is None:
+            argv = sys.argv
+        self.path = urlsplit(argv[0]).path or '/'
         if len(argv) > 2:
             self.args = parse_qs(argv[2].lstrip('?'))
-        path = urlsplit(argv[0]).path or '/'
-        self._dispatch(path)
+        self._dispatch(self.path)
 
     def redirect(self, path):
         self._dispatch(path)
 
     def _dispatch(self, path):
-        for view_func, rules in iter(self._rules.items()):
+        for view_func, rules in iter(list(self._rules.items())):
             for rule in rules:
                 kwargs = rule.match(path)
                 if kwargs is not None:
@@ -133,7 +144,7 @@ class Plugin(object):
         raise RoutingError('No route to path "%s"' % path)
 
 
-class UrlRule(object):
+class UrlRule:
 
     def __init__(self, pattern):
         kw_pattern = r'<(?:[^:]+:)?([A-z]+)>'
@@ -151,6 +162,10 @@ class UrlRule(object):
         Check if path matches this rule. Returns a dictionary of the extracted
         arguments if match, otherwise None.
         """
+        # Strip trailing slashes
+        if len(path) > 1:
+            path = path.rstrip('/')
+
         # match = self._regex.search(urlsplit(path).path)
         match = self._regex.search(path)
         return match.groupdict() if match else None
@@ -168,8 +183,8 @@ class UrlRule(object):
 
         # We need to find the keys from kwargs that occur in our pattern.
         # Unknown keys are pushed to the query string.
-        url_kwargs = dict(((k, v) for k, v in kwargs.items() if k in self._keywords))
-        qs_kwargs = dict(((k, v) for k, v in kwargs.items() if k not in self._keywords))
+        url_kwargs = dict(((k, v) for k, v in list(kwargs.items()) if k in self._keywords))
+        qs_kwargs = dict(((k, v) for k, v in list(kwargs.items()) if k not in self._keywords))
 
         query = '?' + urlencode(qs_kwargs) if qs_kwargs else ''
         try:


### PR DESCRIPTION
This fixes an annoying issue where your cursor would jump to the start of
the list when you unfollow a program in the favorite listing, and so the
selected ListItem disappears from under the cursor.

This also implements a smarter way to know where we are within the
add-on at any time.

This requires tamland/kodi-plugin-routing#20