### PR TITLE
more unicode fixes

### DIFF
--- a/resources/lib/addon.py
+++ b/resources/lib/addon.py
@@ -11,7 +11,7 @@ except ImportError:  # Python 2
     from urllib import unquote_plus
 
 from kodiwrapper import KodiWrapper
-from statichelper import to_unicode
+from statichelper import from_unicode, to_unicode
 
 plugin = Plugin()
 kodi = KodiWrapper(globals())
@@ -42,7 +42,7 @@ def delete_tokens():
 def follow(program, title):
     ''' The API interface to follow a program used by the context menu '''
     from favorites import Favorites
-    Favorites(kodi).follow(program=program, title=to_unicode(unquote_plus(title)))
+    Favorites(kodi).follow(program=program, title=to_unicode(unquote_plus(from_unicode(title))))
 
 
 @plugin.route('/unfollow/<program>/<title>')
@@ -50,7 +50,7 @@ def unfollow(program, title):
     ''' The API interface to unfollow a program used by the context menu '''
     move_down = bool(plugin.args.get('move_down'))
     from favorites import Favorites
-    Favorites(kodi).unfollow(program=program, title=to_unicode(unquote_plus(title)), move_down=move_down)
+    Favorites(kodi).unfollow(program=program, title=to_unicode(unquote_plus(from_unicode(title))), move_down=move_down)
 
 
 @plugin.route('/favorites')
@@ -244,5 +244,5 @@ def play_by_air_date(channel, start_date, end_date=None):
 
 def run(argv):
     ''' Addon entry point from wrapper '''
-    kodi.log_access(to_unicode(argv[0]))
+    kodi.log_access(argv[0])
     plugin.run(argv)

--- a/resources/lib/apihelper.py
+++ b/resources/lib/apihelper.py
@@ -6,9 +6,10 @@ from __future__ import absolute_import, division, unicode_literals
 
 try:  # Python 3
     from urllib.error import HTTPError
-    from urllib.parse import unquote
+    from urllib.parse import quote_plus, unquote
     from urllib.request import build_opener, install_opener, ProxyHandler, Request, urlopen
 except ImportError:  # Python 2
+    from urllib import quote_plus
     from urllib2 import build_opener, install_opener, ProxyHandler, Request, HTTPError, unquote, urlopen
 
 import statichelper
@@ -417,7 +418,7 @@ class ApiHelper:
 
         if keywords:
             season = 'allseasons'
-            params['q'] = keywords
+            params['q'] = quote_plus(statichelper.from_unicode(keywords))
             params['highlight'] = 'true'
 
         if whatson_id:

--- a/resources/lib/kodiwrapper.py
+++ b/resources/lib/kodiwrapper.py
@@ -265,7 +265,7 @@ class KodiWrapper:
         keyboard = xbmc.Keyboard('', self.localize(30097))
         keyboard.doModal()
         if keyboard.isConfirmed():
-            search_string = keyboard.getText()
+            search_string = to_unicode(keyboard.getText())
         return search_string
 
     def show_ok_dialog(self, heading='', message=''):

--- a/resources/lib/metadata.py
+++ b/resources/lib/metadata.py
@@ -76,7 +76,7 @@ class Metadata:
                 follow_enabled = bool(api_data.get('url'))
 
             if follow_enabled:
-                program_title = quote_plus(statichelper.from_unicode(program_title))  # We need to ensure forward slashes are quoted
+                program_title = statichelper.to_unicode(quote_plus(statichelper.from_unicode(program_title)))  # We need to ensure forward slashes are quoted
                 if self._favorites.is_favorite(program):
                     extras = dict()
                     # If we are in a favorites menu, move cursor down before removing a favorite

--- a/test/test_search.py
+++ b/test/test_search.py
@@ -52,6 +52,16 @@ class TestSearch(unittest.TestCase):
         self.assertFalse(ascending)
         self.assertEqual(content, 'episodes')
 
+    def test_search_unicode(self):
+        ''' Test for unicode '''
+        search_items, sort, ascending, content = self._apihelper.list_search('René', page=1)
+
+        # Test we get a non-empty search result
+        self.assertGreater(len(search_items), 2)
+        self.assertEqual(sort, 'dateadded')
+        self.assertFalse(ascending)
+        self.assertEqual(content, 'episodes')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/xbmc.py
+++ b/test/xbmc.py
@@ -12,6 +12,7 @@ import os
 import json
 import time
 from xbmcextra import global_settings, import_language
+from statichelper import to_unicode
 
 LOGDEBUG = 'Debug'
 LOGERROR = 'Error'
@@ -124,7 +125,7 @@ def getRegion(key):
 
 def log(msg, level):
     ''' A reimplementation of the xbmc log() function '''
-    print('[32;1m%s: [32;0m%s[0m' % (level, msg))
+    print('[32;1m%s: [32;0m%s[0m' % (level, to_unicode(msg)))
 
 
 def setContent(self, content):


### PR DESCRIPTION
This pull request includes:
- support for script.module.routing 0.2.2 (`unicode_literals` was added) returning unicode strings now
- make sure we always convert to/from unicode when using unquote_plus which doesn't support unicode (fixed issue with the (un)follow notification dialog of "Het koninkrijk van René Heyvaert"
- support unicode keywords in Search function
- add 'René' unicode search test