### PR TITLE
Improve testing using Travis credentials

### DIFF
--- a/resources/lib/apihelper.py
+++ b/resources/lib/apihelper.py
@@ -60,7 +60,7 @@ class ApiHelper:
         tvshows = self._kodi.get_cache(cache_file, ttl=60 * 60)  # Try the cache if it is fresh
         if not tvshows:
             import json
-            querystring = '&'.join('{}={}'.format(key, value) for key, value in params.items())
+            querystring = '&'.join('{}={}'.format(key, value) for key, value in list(params.items()))
             suggest_url = self._VRTNU_SUGGEST_URL + '?' + querystring
             self._kodi.log('URL get: {url}', 'Verbose', url=unquote(suggest_url))
             tvshows = json.load(urlopen(suggest_url))
@@ -425,7 +425,7 @@ class ApiHelper:
             params['facets[whatsonId]'] = whatson_id
 
         # Construct VRT NU Search API Url and get api data
-        querystring = '&'.join('{}={}'.format(key, value) for key, value in params.items())
+        querystring = '&'.join('{}={}'.format(key, value) for key, value in list(params.items()))
         search_url = self._VRTNU_SEARCH_URL + '?' + querystring
 
         import json

--- a/test/userdata/addon_settings.json
+++ b/test/userdata/addon_settings.json
@@ -2,8 +2,6 @@
     "inputstream.adaptive": {
         "DECRYPTERPATH": "special://home/cdm"
     }, 
-    "last_update": "1568504274.0", 
-    "password": "pt4PYWDU", 
     "plugin.video.vrt.nu": {
         "_comment": "do-not-add-username-and-password-here", 
         "canvas": "true", 
@@ -27,10 +25,12 @@
         "useinputstreamadaptive": "true", 
         "usemenucaching": "true", 
         "username": "", 
-        "version": "2.3.4", 
+        "version": "", 
         "vrtnws": "true", 
         "vrtnxt": "true"
     }, 
-    "username": "dag@wieers.com", 
-    "version": "2.3.4"
+    "script.module.inputstreamhelper": {
+        "last_update": "", 
+        "version": ""
+    }
 }

--- a/test/userdata/search_history.json
+++ b/test/userdata/search_history.json
@@ -1,1 +1,1 @@
-["winter", "dag", "unittest", "foobar"]
+["winter", "dag", "de", "foobar"]

--- a/test/xbmc.py
+++ b/test/xbmc.py
@@ -49,7 +49,7 @@ class Keyboard:
 
     def getText(self):
         ''' A stub implementation for the xbmc Keyboard class getText() method '''
-        return 'unittest'
+        return 'test'
 
 
 class Monitor:

--- a/test/xbmcaddon.py
+++ b/test/xbmcaddon.py
@@ -6,14 +6,11 @@
 # pylint: disable=invalid-name
 
 from __future__ import absolute_import, division, print_function, unicode_literals
-import json
 from xbmc import getLocalizedString
-from xbmcextra import addon_settings, global_settings, import_language, read_addon_xml
+from xbmcextra import ADDON_INFO, ADDON_ID, addon_settings, global_settings, import_language
 
 GLOBAL_SETTINGS = global_settings()
 ADDON_SETTINGS = addon_settings()
-ADDON_INFO = read_addon_xml('addon.xml')
-ADDON_ID = next(iter(ADDON_INFO.values())).get('id')
 PO = import_language(language=GLOBAL_SETTINGS.get('locale.language'))
 
 
@@ -27,8 +24,8 @@ class Addon:
     def getAddonInfo(self, key):
         ''' A working implementation for the xbmcaddon Addon class getAddonInfo() method '''
         stub_info = dict(id=self.id, name=self.id, version='2.3.4', type='kodi.inputstream', profile='special://userdata', path='special://userdata')
-        # Add stub_info values to ADD_INFO when missing (e.g. path and profile)
-        addon_info = dict(ADDON_INFO, **stub_info)
+        # Add stub_info values to ADDON_INFO when missing (e.g. path and profile)
+        addon_info = dict(stub_info, **ADDON_INFO)
         return addon_info.get(self.id, stub_info).get(key)
 
     @staticmethod
@@ -38,7 +35,7 @@ class Addon:
 
     def getSetting(self, key):
         ''' A working implementation for the xbmcaddon Addon class getSetting() method '''
-        return ADDON_SETTINGS.get(self.id, ADDON_SETTINGS).get(key, '')
+        return ADDON_SETTINGS.get(self.id, {}).get(key, '')
 
     @staticmethod
     def openSettings():
@@ -46,9 +43,9 @@ class Addon:
 
     def setSetting(self, key, value):
         ''' A stub implementation for the xbmcaddon Addon class setSetting() method '''
-        if ADDON_SETTINGS.get(self.id):
-            ADDON_SETTINGS[self.id][key] = value
-        else:
-            ADDON_SETTINGS[key] = value
-        with open('test/userdata/addon_settings.json', 'w') as fd:
-            json.dump(ADDON_SETTINGS, fd, sort_keys=True, indent=4)
+        if not ADDON_SETTINGS.get(self.id):
+            ADDON_SETTINGS[self.id] = dict()
+        ADDON_SETTINGS[self.id][key] = value
+        # NOTE: Disable actual writing as it is no longer needed for testing
+        # with open('test/userdata/addon_settings.json', 'w') as fd:
+        #     json.dump(filtered_settings, fd, sort_keys=True, indent=4)

--- a/test/xbmcextra.py
+++ b/test/xbmcextra.py
@@ -35,7 +35,7 @@ def uri_to_path(uri):
     ''' Shorten a plugin URI to just the path '''
     if uri is None:
         return None
-    return ' \033[33m→ \033[34m%s\033[39;0m' % uri.replace('plugin://plugin.video.vrt.nu', '')
+    return ' \033[33m→ \033[34m%s\033[39;0m' % uri.replace('plugin://' + ADDON_ID, '')
 
 
 def read_addon_xml(path):
@@ -110,20 +110,25 @@ def addon_settings():
         print("Error: Cannot use 'test/userdata/addon_settings.json' : %s" % e)
         settings = {}
 
-    # Read credentials from credentials.json
-    try:
+    # Read credentials from environment or credentials.json
+    if 'ADDON_USERNAME' in os.environ and 'ADDON_PASSWORD' in os.environ:
+        print('Using credentials from the environment variables ADDON_USERNAME and ADDON_PASSWORD')
+        settings[ADDON_ID]['username'] = os.environ.get('ADDON_USERNAME')
+        settings[ADDON_ID]['password'] = os.environ.get('ADDON_PASSWORD')
+    elif os.path.exists('test/userdata/credentials.json'):
+        print('Using credentials from test/userdata/credentials.json')
         with open('test/userdata/credentials.json') as f:
-            settings.update(json.load(f))
-    except (IOError, OSError) as e:
-        if 'VRTNU_USERNAME' in os.environ and 'VRTNU_PASSWORD' in os.environ:
-            print('Using credentials from the environment variables VRTNU_USERNAME and VRTNU_PASSWORD')
-            settings['plugin.video.vrt.nu']['username'] = os.environ.get('VRTNU_USERNAME')
-            settings['plugin.video.vrt.nu']['password'] = os.environ.get('VRTNU_PASSWORD')
-        else:
-            print("Error: Cannot use 'test/userdata/credentials.json' : %s" % e)
+            credentials = json.load(f)
+        settings[ADDON_ID].update(credentials)
+    else:
+        print("Error: Cannot use 'test/userdata/credentials.json'")
     return settings
 
 
 def import_language(language):
     ''' Process the language.po file '''
     return polib.pofile('resources/language/{language}/strings.po'.format(language=language))
+
+
+ADDON_INFO = read_addon_xml('addon.xml')
+ADDON_ID = next(iter(ADDON_INFO.values())).get('id')


### PR DESCRIPTION
We are now using `ADDON_USERNAME` and `ADDON_PASSWORD` for environment
variables and no longer write settings changes.

This used to be necessary for command line testing, but we now having
routing tests and settings survive tests.

This PR also includes suggestions from the addon checker.