### PR TITLE
Fixed proxy.py version for Python 2.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ codecov
 git+git://github.com/emilsvennesson/script.module.inputstreamhelper.git@master#egg=inputstreamhelper
 kodi-addon-checker
 polib
-proxy.py
+proxy.py==0.3
 python-dateutil
 pylint
 git+git://github.com/dagwieers/kodi-plugin-routing.git@setup#egg=routing


### PR DESCRIPTION
The just released 1.0.0 no longer supports Python 2.7.