### PR TITLE
Use programUrl instead of targetUrl

### DIFF
--- a/resources/lib/apihelper.py
+++ b/resources/lib/apihelper.py
@@ -213,7 +213,7 @@ class ApiHelper:
         oneoff_programs = [statichelper.url_to_program(episode.get('programUrl')) for episode in oneoffs]
 
         for tvshow in tvshows:
-            program = statichelper.url_to_program(tvshow.get('targetUrl'))
+            program = statichelper.url_to_program(tvshow.get('programUrl'))
 
             if use_favorites and program not in favorite_programs:
                 continue

--- a/resources/lib/metadata.py
+++ b/resources/lib/metadata.py
@@ -233,7 +233,7 @@ class Metadata:
         # VRT NU Suggest API
         if api_data.get('type') == 'program':
             plot = statichelper.unescape(api_data.get('description', '???'))
-            permalink = statichelper.shorten_link(api_data.get('targetUrl'))
+            permalink = statichelper.shorten_link(api_data.get('programUrl'))
             if self._showpermalink and permalink:
                 plot = '%s\n\n[COLOR yellow]%s[/COLOR]' % (plot, permalink)
             return plot


### PR DESCRIPTION
Not sure why we are using targetUrl in the suggest API while we have a
programUrl (that does not have .relevant).

There probably is a good reason, but at least this gives the opportunity
to discuss it :-)