### PR TITLE
Rename My favorites menu items

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -119,7 +119,7 @@ msgid "Alphabetically sorted list of My TV programs"
 msgstr ""
 
 msgctxt "#30042"
-msgid "My movies"
+msgid "Movies"
 msgstr ""
 
 msgctxt "#30043"
@@ -127,7 +127,7 @@ msgid "All movies available on VRT NU"
 msgstr ""
 
 msgctxt "#30044"
-msgid "My documentaries"
+msgid "Documentaries"
 msgstr ""
 
 msgctxt "#30045"
@@ -135,7 +135,7 @@ msgid "All [I]one-off[/I] documentaries on VRT NU"
 msgstr ""
 
 msgctxt "#30046"
-msgid "My most recent"
+msgid "Most recent"
 msgstr ""
 
 msgctxt "#30047"
@@ -143,7 +143,7 @@ msgid "Recently published episodes of My TV programs"
 msgstr ""
 
 msgctxt "#30048"
-msgid "My soon offline"
+msgid "Soon offline"
 msgstr ""
 
 msgctxt "#30049"
@@ -151,7 +151,7 @@ msgid "My episodes that will soon be offline"
 msgstr ""
 
 msgctxt "#30050"
-msgid "My watch later"
+msgid "Watch later"
 msgstr ""
 
 msgctxt "#30051"
@@ -395,7 +395,7 @@ msgid "Unfollow {title}"
 msgstr ""
 
 msgctxt "#30413"
-msgid "Refresh"
+msgid "Refresh menu"
 msgstr ""
 
 msgctxt "#30415"
@@ -450,6 +450,10 @@ msgctxt "#30427"
 msgid "Clear the search history"
 msgstr ""
 
+msgctxt "#30428"
+msgid "My"
+msgstr ""
+
 
 ### SETTINGS
 msgctxt "#30800"
@@ -497,11 +501,11 @@ msgid "Manage My favorites..."
 msgstr ""
 
 msgctxt "#30827"
-msgid "Add My movies"
+msgid "Add Movies subsection"
 msgstr ""
 
 msgctxt "#30829"
-msgid "Add My documentaries"
+msgid "Add Documentaries subsection"
 msgstr ""
 
 msgctxt "#30831"

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -120,40 +120,40 @@ msgid "Alphabetically sorted list of My TV programs"
 msgstr "Alle tv-programma's die je volgt in alfabetische volgorde"
 
 msgctxt "#30042"
-msgid "My movies"
-msgstr "Mijn films"
+msgid "Movies"
+msgstr "Films"
 
 msgctxt "#30043"
 msgid "All movies available on VRT NU"
 msgstr "Alle films beschikbaar op VRT NU"
 
 msgctxt "#30044"
-msgid "My documentaries"
-msgstr "Mijn documentaires"
+msgid "Documentaries"
+msgstr "Documentaires"
 
 msgctxt "#30045"
 msgid "All [I]one-off[/I] documentaries on VRT NU"
 msgstr "Alle [I]one-off[/I] documentaires op VRT NU"
 
 msgctxt "#30046"
-msgid "My most recent"
-msgstr "Mijn meest recent"
+msgid "Most recent"
+msgstr "Meest recent"
 
 msgctxt "#30047"
 msgid "Recently published episodes of My TV programs"
 msgstr "Recent gepubliceerde afleveringen van tv-programma's die je volgt"
 
 msgctxt "#30048"
-msgid "My soon offline"
-msgstr "Mijn binnenkort offline"
+msgid "Soon offline"
+msgstr "Binnenkort offline"
 
 msgctxt "#30049"
 msgid "My episodes that will soon be offline"
 msgstr "Mijn afleveringen die binnenkort verdwijnen"
 
 msgctxt "#30050"
-msgid "My watch later"
-msgstr "Mijn later bekijken"
+msgid "Watch later"
+msgstr "Later bekijken"
 
 msgctxt "#30051"
 msgid "The videos you like to watch later"
@@ -161,7 +161,7 @@ msgstr "Mijn afleveringen die ik later wil bekijken"
 
 msgctxt "#30052"
 msgid "Continue watching"
-msgstr "Programma's verder kijken"
+msgstr "Verder kijken"
 
 msgctxt "#30053"
 msgid "Continue watching the videos you started earlier"
@@ -396,8 +396,8 @@ msgid "Unfollow {title}"
 msgstr "Vergeet {title}"
 
 msgctxt "#30413"
-msgid "Refresh"
-msgstr "Vernieuw"
+msgid "Refresh menu"
+msgstr "Vernieuw menu"
 
 msgctxt "#30415"
 msgid "No followed programs found"
@@ -451,6 +451,10 @@ msgctxt "#30427"
 msgid "Clear the search history"
 msgstr "Verwijder alle oude zoekopdrachten"
 
+msgctxt "#30428"
+msgid "My"
+msgstr "Mijn"
+
 
 ### SETTINGS
 msgctxt "#30800"
@@ -498,12 +502,12 @@ msgid "Manage My favorites..."
 msgstr "Beheer Mijn favorieten..."
 
 msgctxt "#30827"
-msgid "Add My movies"
-msgstr "Toon Mijn films"
+msgid "Add Movies subsection"
+msgstr "Toon Films rubriek"
 
 msgctxt "#30829"
-msgid "Add My documentaries"
-msgstr "Toon Mijn documentaires"
+msgid "Add Documentaries subsection"
+msgstr "Toon Documentaires rubriek"
 
 msgctxt "#30831"
 msgid "Show one-off videos in between program folders"

--- a/resources/lib/kodiwrapper.py
+++ b/resources/lib/kodiwrapper.py
@@ -157,6 +157,9 @@ class KodiWrapper:
         if category:
             if not content:
                 category_label = 'VRT NU / '
+            from addon import plugin
+            if plugin.path.startswith('/favorites/'):
+                category_label += self.localize(30428) + ' / '  # My
             if isinstance(category, int):
                 category_label += self.localize(category)
             else:

--- a/resources/lib/tokenresolver.py
+++ b/resources/lib/tokenresolver.py
@@ -101,7 +101,7 @@ class TokenResolver:
             now = datetime.now(dateutil.tz.tzlocal())
             exp = dateutil.parser.parse(token.get('expirationDate'))
             if exp > now:
-                self._kodi.log("Got cached token '{path}'", 'Verbose', path=path)
+                self._kodi.log("Got cached token '{path}'", 'Debug', path=path)
                 cached_token = token.get(token_name)
             else:
                 self._kodi.log("Cached token '{path}' deleted", 'Verbose', path=path)

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -57,6 +57,6 @@
         <setting label="30921" help="30922" type="action" id="ishelper_info" action="RunScript(script.module.inputstreamhelper, info)" enable="eq(-2,true)"/>
         <setting label="30923" help="30924" type="action" id="ishelper_settings" option="close" action="Addon.OpenSettings(script.module.inputstreamhelper)" enable="eq(-3,true)" subsetting="true"/>
         <setting label="30925" type="lsep"/> <!-- Logging -->
-        <setting label="30927" help="30928" type="select" id="max_log_level" values="Quiet|Info|Verbose|Debug" default="Info"/>
+        <setting label="30927" help="30928" type="select" id="max_log_level" values="Quiet|Info|Verbose|Debug" default="Quiet"/>
     </category>
 </settings>

--- a/test/userdata/global_settings.json
+++ b/test/userdata/global_settings.json
@@ -1,4 +1,5 @@
 {
+    "debug.showloginfo": true,
     "locale.language": "resource.language.nl_nl",
     "network.bandwidth": "0",
     "network.usehttpproxy": false,

--- a/test/xbmc.py
+++ b/test/xbmc.py
@@ -147,13 +147,15 @@ def getRegion(key):
 def log(msg, level):
     ''' A reimplementation of the xbmc log() function '''
     if level in ('Error', 'Fatal'):
-        print('\033[31;1m%s: \033[32;0m%s\033[0;39m' % (level, to_unicode(msg)))
+        print('\033[31;1m%s: \033[32;0m%s\033[39;0m' % (level, to_unicode(msg)))
         if level == 'Fatal':
             raise Exception(msg)
     elif level in ('Warning', 'Notice'):
-        print('\033[33;1m%s: \033[32;0m%s\033[0;39m' % (level, to_unicode(msg)))
+        print('\033[33;1m%s: \033[32;0m%s\033[39;0m' % (level, to_unicode(msg)))
+    elif level == 'Debug':
+        print('\033[32;1m%s: \033[30;1m%s\033[39;0m' % (level, to_unicode(msg)))
     else:
-        print('\033[32;1m%s: \033[32;0m%s\033[0;39m' % (level, to_unicode(msg)))
+        print('\033[32;1m%s: \033[32;0m%s\033[39;0m' % (level, to_unicode(msg)))
 
 
 def setContent(self, content):


### PR DESCRIPTION
This PR includes:
- Rename menu items in 'My favorites' menu
- Add My breadcrumbs support
- Add 'Go to program' context menu in 'Watch Later' and 'Continue watching' listings
- Change order of context items (Follow, Watch Later, Go to program, Refresh)
- Enable debug logging in global_settings.json
- Change log levels for Verbose and Debug
- Change default log level to Quiet
- Do not set resumetime in the first and last 60 seconds
- Show debug messages in (dark) gray