### PR TITLE
Various resumepoint fixes

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -371,10 +371,18 @@ msgid "In 2 days"
 msgstr ""
 
 msgctxt "#30401"
-msgid "Add {title} to watch later"
+msgid "Watch later"
 msgstr ""
 
 msgctxt "#30402"
+msgid "Remove from watch later"
+msgstr ""
+
+msgctxt "#30403"
+msgid "Add {title} to watch later"
+msgstr ""
+
+msgctxt "#30404"
 msgid "Remove {title} from watch later"
 msgstr ""
 
@@ -501,30 +509,38 @@ msgid "Manage My favorites..."
 msgstr ""
 
 msgctxt "#30827"
-msgid "Add Movies subsection"
+msgid "Enable watching activity"
+msgstr ""
+
+msgctxt "#30828"
+msgid "This enables 'watch later' and 'continue watching' menus and syncs playback position between different devices using the same VRT NU account."
 msgstr ""
 
 msgctxt "#30829"
-msgid "Add Documentaries subsection"
+msgid "Add Movies subsection"
 msgstr ""
 
 msgctxt "#30831"
-msgid "Show one-off videos in between program folders"
+msgid "Add Documentaries subsection"
 msgstr ""
 
 msgctxt "#30833"
-msgid "Show fanart"
+msgid "Show one-off videos in between program folders"
 msgstr ""
 
 msgctxt "#30835"
-msgid "Show YouTube channel content"
+msgid "Show fanart"
 msgstr ""
 
 msgctxt "#30837"
+msgid "Show YouTube channel content"
+msgstr ""
+
+msgctxt "#30839"
 msgid "Show episode permalink in plot"
 msgstr ""
 
-msgctxt "#30838"
+msgctxt "#30840"
 msgid "When enabled, the video description will include a permanent link that points to this episode. This is useful for quickly opening an episode or movie on a mobile device."
 msgstr ""
 
@@ -637,59 +653,55 @@ msgid "Refresh favorites"
 msgstr ""
 
 msgctxt "#30907"
-msgid "Use menu caching"
-msgstr ""
-
-msgctxt "#30908"
-msgid "When enabled, menus are being cached so they work more quickly. Only in very specific use-cases this is problematic as new episodes may not appear when they are expected. You can also use [B]Refresh[/B] from the context-menu."
+msgid "Refresh watching activity"
 msgstr ""
 
 msgctxt "#30909"
-msgid "Use local HTTP caching"
+msgid "Use menu caching"
+msgstr ""
+
+msgctxt "#30910"
+msgid "When enabled, menus are being cached so they work more quickly. Only in very specific use-cases this is problematic as new episodes may not appear when they are expected. You can also use [B]Refresh[/B] from the context-menu."
 msgstr ""
 
 msgctxt "#30911"
-msgid "Invalidate local HTTP caches"
+msgid "Use local HTTP caching"
 msgstr ""
 
 msgctxt "#30913"
-msgid "Streaming"
+msgid "Invalidate local HTTP caches"
 msgstr ""
 
 msgctxt "#30915"
-msgid "Please install or enable InputStream Adaptive to use this setting"
+msgid "Streaming"
 msgstr ""
 
 msgctxt "#30917"
-msgid "Use InputStream Adaptive"
+msgid "Please install or enable InputStream Adaptive to use this setting"
 msgstr ""
 
 msgctxt "#30919"
-msgid "InputStream Adaptive settings..."
+msgid "Use InputStream Adaptive"
 msgstr ""
 
 msgctxt "#30921"
-msgid "InputStream Helper information"
+msgid "InputStream Adaptive settings..."
 msgstr ""
 
 msgctxt "#30923"
-msgid "InputStream Helper settings... [COLOR gray][I](for protected content)[/I][/COLOR]"
+msgid "InputStream Helper information"
 msgstr ""
 
 msgctxt "#30925"
-msgid "Logging"
+msgid "InputStream Helper settings... [COLOR gray][I](for protected content)[/I][/COLOR]"
 msgstr ""
 
 msgctxt "#30927"
-msgid "Log level"
+msgid "Logging"
 msgstr ""
 
 msgctxt "#30929"
-msgid "Enable watching activity"
-msgstr ""
-
-msgctxt "#30930"
-msgid "This enables 'watch later' and 'continue watching' menus and syncs playback position between different devices using the same VRT NU account."
+msgid "Log level"
 msgstr ""
 
 
@@ -770,6 +782,10 @@ msgctxt "#30976"
 msgid "Failed to (un)follow program '{program}' at VRT NU"
 msgstr ""
 
+msgctxt "#30977"
+msgid "Failed to update watch activity at VRT NU"
+msgstr ""
+
 msgctxt "#30978"
 msgid "Welcome to VRT NU add-on v2.0.0"
 msgstr ""
@@ -784,6 +800,10 @@ msgstr ""
 
 msgctxt "#30982"
 msgid "Successfully refreshed favorites."
+msgstr ""
+
+msgctxt "#30983"
+msgid "Successfully refreshed watching activity."
 msgstr ""
 
 msgctxt "#30985"

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -372,10 +372,18 @@ msgid "In 2 days"
 msgstr "Overmorgen"
 
 msgctxt "#30401"
+msgid "Watch later"
+msgstr "Later bekijken"
+
+msgctxt "#30402"
+msgid "Remove from watch later"
+msgstr "Niet later bekijken"
+
+msgctxt "#30403"
 msgid "Add {title} to watch later"
 msgstr "{title} later bekijken"
 
-msgctxt "#30402"
+msgctxt "#30404"
 msgid "Remove {title} from watch later"
 msgstr "{title} niet later bekijken"
 
@@ -502,30 +510,38 @@ msgid "Manage My favorites..."
 msgstr "Beheer Mijn favorieten..."
 
 msgctxt "#30827"
+msgid "Enable watching activity"
+msgstr "Toon kijkactiviteit"
+
+msgctxt "#30828"
+msgid "This enables 'watch later' and 'continue watching' menus and syncs playback position between different devices using the same VRT NU account."
+msgstr "Dit activeert 'kijk later' en 'verderkijken' menu's and synchroniseert de afspeelpositie tussen verschillende toestellen die hetzelfde VRT NU account gebruiken."
+
+msgctxt "#30829"
 msgid "Add Movies subsection"
 msgstr "Toon Films rubriek"
 
-msgctxt "#30829"
+msgctxt "#30831"
 msgid "Add Documentaries subsection"
 msgstr "Toon Documentaires rubriek"
 
-msgctxt "#30831"
+msgctxt "#30833"
 msgid "Show one-off videos in between program folders"
 msgstr "Toon one-off video's tussen tv-programmafolders"
 
-msgctxt "#30833"
+msgctxt "#30835"
 msgid "Show fanart"
 msgstr "Toon fanart"
 
-msgctxt "#30835"
+msgctxt "#30837"
 msgid "Show YouTube channel content"
 msgstr "Toon YouTube kanaal video's"
 
-msgctxt "#30837"
+msgctxt "#30839"
 msgid "Show episode permalink in plot"
 msgstr "Toon aflevering permalink in beschrijving"
 
-msgctxt "#30838"
+msgctxt "#30840"
 msgid "When enabled, the video description will include a permanent link that points to this episode. This is useful for quickly opening an episode or movie on a mobile device."
 msgstr "Indien actief zal de beschrijving van iedere video een permanent link bevatten die je rechtstreeks naar de VRT NU website brengt. Dit is handig om snel een aflevering of film to openen op een mobiel toestel."
 
@@ -638,60 +654,56 @@ msgid "Refresh favorites"
 msgstr "Ververs favoriete programma's"
 
 msgctxt "#30907"
+msgid "Refresh watching activity"
+msgstr "Ververs kijkactiviteit"
+
+msgctxt "#30909"
 msgid "Use menu caching"
 msgstr "Gebruik menu caching"
 
-msgctxt "#30908"
+msgctxt "#30910"
 msgid "When enabled, menus are being cached so they work more quickly. Only in very specific use-cases this is problematic as new episodes may not appear when they are expected. You can also use [B]Refresh[/B] from the context-menu."
 msgstr "Indien geactiveerd worden Kodi menus gecached zodat ze sneller werken. Enkel in heel uitzonderlijke gevallen is het interessanter noodzakelijk om altijd nieuwe episodes te zijn als ze uitkomen. Je kan ook [B]Ververs[/B] gebruiken vanuit het context-menu."
 
-msgctxt "#30909"
+msgctxt "#30911"
 msgid "Use local HTTP caching"
 msgstr "Gebruik lokale HTTP caching"
 
-msgctxt "#30911"
+msgctxt "#30913"
 msgid "Invalidate local HTTP caches"
 msgstr "Maak lokale HTTP caches ongeldig"
 
-msgctxt "#30913"
+msgctxt "#30915"
 msgid "Streaming"
 msgstr "Streaming"
 
-msgctxt "#30915"
+msgctxt "#30917"
 msgid "Please install or enable InputStream Adaptive to use this setting"
 msgstr "Installeer of schakel InputStream Adaptive in voor deze instelling"
 
-msgctxt "#30917"
+msgctxt "#30919"
 msgid "Use InputStream Adaptive"
 msgstr "Gebruik InputStream Adaptive"
 
-msgctxt "#30919"
+msgctxt "#30921"
 msgid "InputStream Adaptive settings..."
 msgstr "InputStream Adaptive instellingen..."
 
-msgctxt "#30921"
+msgctxt "#30923"
 msgid "InputStream Helper information"
 msgstr "InputStream Helper informatie"
 
-msgctxt "#30923"
+msgctxt "#30925"
 msgid "InputStream Helper settings... [COLOR gray][I](for protected content)[/I][/COLOR]"
 msgstr "InputStream Helper instellingen...[COLOR gray][I](voor beveiligde video's)[/I][/COLOR]"
 
-msgctxt "#30925"
+msgctxt "#30927"
 msgid "Logging"
 msgstr "Logboek"
 
-msgctxt "#30927"
+msgctxt "#30929"
 msgid "Log level"
 msgstr "Log niveau"
-
-msgctxt "#30929"
-msgid "Enable watching activity"
-msgstr "Toon kijkactiviteit"
-
-msgctxt "#30930"
-msgid "This enables 'watch later' and 'continue watching' menus and syncs playback position between different devices using the same VRT NU account."
-msgstr "Dit activeert 'kijk later' en 'verderkijken' menu's and synchroniseert de afspeelpositie tussen verschillende toestellen die hetzelfde VRT NU account gebruiken."
 
 
 ### MESSAGES
@@ -771,6 +783,10 @@ msgctxt "#30976"
 msgid "Failed to (un)follow program '{program}' at VRT NU"
 msgstr "Het programma '{program}' op VRT NU volgen of vergeten is mislukt"
 
+msgctxt "#30977"
+msgid "Failed to update watch activity at VRT NU"
+msgstr "Updaten van kijkactiviteit bij VRT NU is mislukt"
+
 msgctxt "#30978"
 msgid "Welcome to VRT NU add-on v2.0.0"
 msgstr "Welkom bij VRT NU add-on v2.0.0"
@@ -786,6 +802,10 @@ msgstr "Caches werden ongeldig gemaakt."
 msgctxt "#30982"
 msgid "Successfully refreshed favorites."
 msgstr "Favoriete programmma's werden verversd."
+
+msgctxt "#30983"
+msgid "Successfully refreshed watching activity."
+msgstr "Kijkactiviteit werd verversd."
 
 msgctxt "#30985"
 msgid "Successfully cleared VRT tokens."

--- a/resources/lib/addon.py
+++ b/resources/lib/addon.py
@@ -27,7 +27,7 @@ def main_menu():
 
 @plugin.route('/cache/delete')
 @plugin.route('/cache/delete/<cache_file>')
-def delete_cache(cache_file=None):
+def delete_cache(cache_file='*.json'):
     ''' The API interface to delete caches '''
     kodi.refresh_caches(cache_file=cache_file)
 
@@ -105,32 +105,41 @@ def favorites_offline(page=1):
     VRTPlayer(kodi).show_offline_menu(page=page, use_favorites=True)
 
 
-@plugin.route('/favorites/watchlater')
-def favorites_watchlater():
-    ''' The resumepoints watchlater listing '''
-    from vrtplayer import VRTPlayer
-    VRTPlayer(kodi).show_watchlater_menu(page=1, use_favorites=True)
-
-
-@plugin.route('/favorites/continue')
-def favorites_continue():
-    ''' The resumepoints continue listing '''
-    from vrtplayer import VRTPlayer
-    VRTPlayer(kodi).show_continue_menu(page=1, use_favorites=True)
-
-
 @plugin.route('/favorites/refresh')
 def favorites_refresh():
     ''' The API interface to refresh the favorites cache '''
     from favorites import Favorites
-    Favorites(kodi).refresh_favorites()
+    Favorites(kodi).refresh(ttl=0)
+    kodi.show_notification(message=kodi.localize(30982))
 
 
 @plugin.route('/favorites/manage')
 def favorites_manage():
     ''' The API interface to manage your favorites '''
     from favorites import Favorites
-    Favorites(kodi).manage_favorites()
+    Favorites(kodi).manage()
+
+
+@plugin.route('/resumepoints/continue')
+def resumepoints_continue():
+    ''' The resumepoints continue listing '''
+    from vrtplayer import VRTPlayer
+    VRTPlayer(kodi).show_continue_menu(page=1)
+
+
+@plugin.route('/resumepoints/refresh')
+def resumepoints_refresh():
+    ''' The API interface to refresh the resumepoints cache '''
+    from resumepoints import ResumePoints
+    ResumePoints(kodi).refresh(ttl=0)
+    kodi.show_notification(message=kodi.localize(30983))
+
+
+@plugin.route('/resumepoints/watchlater')
+def resumepoints_watchlater():
+    ''' The resumepoints watchlater listing '''
+    from vrtplayer import VRTPlayer
+    VRTPlayer(kodi).show_watchlater_menu(page=1)
 
 
 @plugin.route('/programs')

--- a/resources/lib/favorites.py
+++ b/resources/lib/favorites.py
@@ -27,7 +27,7 @@ class Favorites:
         ''' Is favorites activated in the menu and do we have credentials ? '''
         return self._kodi.get_setting('usefavorites') == 'true' and self._kodi.credentials_filled_in()
 
-    def get_favorites(self, ttl=None):
+    def refresh(self, ttl=None):
         ''' Get a cached copy or a newer favorites from VRT, or fall back to a cached file '''
         if not self.is_activated():
             return
@@ -54,10 +54,10 @@ class Favorites:
         if favorites_json:
             self._favorites = favorites_json
 
-    def set_favorite(self, program, title, value=True):
+    def update(self, program, title, value=True):
         ''' Set a program as favorite, and update local copy '''
 
-        self.get_favorites(ttl=60 * 60)
+        self.refresh(ttl=60)
         if value is self.is_favorite(program):
             # Already followed/unfollowed, nothing to do
             return True
@@ -90,7 +90,7 @@ class Favorites:
         # NOTE: Updates to favorites take a longer time to take effect, so we keep our own cache and use it
         self._favorites[program_uuid] = dict(value=payload)
         self._kodi.update_cache('favorites.json', self._favorites)
-        self.invalidate_caches()
+        # self.invalidate_caches()
         return True
 
     def is_favorite(self, program):
@@ -103,14 +103,14 @@ class Favorites:
 
     def follow(self, program, title):
         ''' Follow your favorite program '''
-        succeeded = self.set_favorite(program, title, True)
+        succeeded = self.update(program, title, True)
         if succeeded:
             self._kodi.show_notification(message=self._kodi.localize(30411, title=title))
             self._kodi.container_refresh()
 
     def unfollow(self, program, title, move_down=False):
         ''' Unfollow your favorite program '''
-        succeeded = self.set_favorite(program, title, False)
+        succeeded = self.update(program, title, False)
         if succeeded:
             self._kodi.show_notification(message=self._kodi.localize(30412, title=title))
             # If the current item is selected and we need to move down before removing
@@ -134,20 +134,12 @@ class Favorites:
 
     def invalidate_caches(self):
         ''' Invalidate caches that rely on favorites '''
-        # NOTE: Do not invalidate favorites cache as we manage it ourselves
-        # self._kodi.invalidate_caches('favorites.json')
-        self._kodi.invalidate_caches('my-offline-*.json')
-        self._kodi.invalidate_caches('my-recent-*.json')
+        self._kodi.invalidate_caches('favorites.json', 'my-offline-*.json', 'my-recent-*.json')
 
-    def refresh_favorites(self):
-        ''' External API call to refresh favorites, used in Troubleshooting section '''
-        self.get_favorites(ttl=0)
-        self._kodi.show_notification(message=self._kodi.localize(30982))
-
-    def manage_favorites(self):
+    def manage(self):
         ''' Allow the user to unselect favorites to be removed from the listing '''
         from statichelper import url_to_program
-        self.get_favorites(ttl=0)
+        self.refresh(ttl=0)
         if not self._favorites:
             self._kodi.show_ok_dialog(heading=self._kodi.localize(30418), message=self._kodi.localize(30419))  # No favorites found
             return

--- a/resources/lib/kodiwrapper.py
+++ b/resources/lib/kodiwrapper.py
@@ -158,7 +158,7 @@ class KodiWrapper:
             if not content:
                 category_label = 'VRT NU / '
             from addon import plugin
-            if plugin.path.startswith('/favorites/'):
+            if plugin.path.startswith(('/favorites/', '/resumepoints/')):
                 category_label += self.localize(30428) + ' / '  # My
             if isinstance(category, int):
                 category_label += self.localize(category)
@@ -622,21 +622,23 @@ class KodiWrapper:
 
     def refresh_caches(self, cache_file=None):
         ''' Invalidate the needed caches and refresh container '''
-        self.invalidate_caches(expr=cache_file)
+        files = ['favorites.json', 'oneoff.json', 'resume_points.json']
+        if cache_file and cache_file not in files:
+            files.append(cache_file)
+        self.invalidate_caches(*files)
         self.container_refresh()
         self.show_notification(message=self.localize(30981))
 
-    def invalidate_caches(self, expr=None):
+    def invalidate_caches(self, *caches):
         ''' Invalidate multiple cache files '''
         import fnmatch
         _, files = self.listdir(self._cache_path)
-        if expr:
-            files = fnmatch.filter(files, expr)
-        for filename in files:
+        # Invalidate caches related to menu list refreshes
+        removes = set()
+        for expr in caches:
+            removes.update(fnmatch.filter(files, expr))
+        for filename in removes:
             self.delete_file(self._cache_path + filename)
-        self.delete_file(self._cache_path + 'favorites.json')
-        self.delete_file(self._cache_path + 'oneoff.json')
-        self.delete_file(self._cache_path + 'resume_points.json')
 
     @staticmethod
     def input_down():

--- a/resources/lib/playerinfo.py
+++ b/resources/lib/playerinfo.py
@@ -17,20 +17,22 @@ class PlayerInfo(Player):
         self._tracker = None
         self._last_pos = 0
         self._total = None
+        self._stop = False
         Player.__init__(self)
-        while not self._monitor.abortRequested():
-            if self._monitor.waitForAbort(10):
+        while not self._monitor.abortRequested() and not self._stop:
+            if self._monitor.waitForAbort(5):
                 break
 
     def onAVStarted(self):  # pylint: disable=invalid-name
         ''' called when Kodi has a video or audiostream '''
         self._total = self.getTotalTime()
-        self._tracker = Thread(target=self.stream_position)
+        self._tracker = Thread(target=self.stream_position, name='VRTNUThread')
         self._tracker.start()
 
     def onPlayBackStopped(self):  # pylint: disable=invalid-name
         ''' called when user stops Kodi playing a file '''
         self._info((self._last_pos, self._total))
+        self._stop = True
 
     def onAVChange(self):  # pylint: disable=invalid-name
         ''' called when Kodi has a video, audio or subtitle stream. Also happens when the stream changes. '''
@@ -38,9 +40,11 @@ class PlayerInfo(Player):
     def onPlayBackEnded(self):  # pylint: disable=invalid-name
         ''' called when Kodi stops playing a file '''
         self._info((self._total, self._total))
+        self._stop = True
 
     def onPlayBackError(self):  # pylint: disable=invalid-name
         ''' called when playback stops due to an error '''
+        self._info((self._total, self._total))
 
     def onPlayBackPaused(self):  # pylint: disable=invalid-name
         ''' called when user pauses a playing file '''
@@ -53,4 +57,4 @@ class PlayerInfo(Player):
         ''' get latest stream position while playing '''
         while self.isPlaying():
             self._last_pos = self.getTime()
-            sleep(100)
+            sleep(500)

--- a/resources/lib/resumepoints.py
+++ b/resources/lib/resumepoints.py
@@ -6,9 +6,10 @@
 from __future__ import absolute_import, division, unicode_literals
 
 try:  # Python 3
+    from urllib.error import HTTPError
     from urllib.request import build_opener, install_opener, ProxyHandler, Request, urlopen
 except ImportError:  # Python 2
-    from urllib2 import build_opener, install_opener, ProxyHandler, Request, urlopen
+    from urllib2 import build_opener, install_opener, ProxyHandler, Request, HTTPError, urlopen
 
 
 class ResumePoints:
@@ -26,10 +27,10 @@ class ResumePoints:
         ''' Is resumepoints activated in the menu and do we have credentials ? '''
         return self._kodi.get_setting('useresumepoints') == 'true' and self._kodi.credentials_filled_in()
 
-    def get_resumepoints(self, ttl=None):
+    def refresh(self, ttl=None):
         ''' Get a cached copy or a newer resumepoints from VRT, or fall back to a cached file '''
         if not self.is_activated():
-            return None
+            return
         resumepoints_json = self._kodi.get_cache('resume_points.json', ttl)
         if not resumepoints_json:
             from tokenresolver import TokenResolver
@@ -52,19 +53,24 @@ class ResumePoints:
                     self._kodi.update_cache('resume_points.json', resumepoints_json)
         if resumepoints_json:
             self._resumepoints = resumepoints_json
-        return self._resumepoints
 
-    def set_resumepoint(self, uuid, title, url, watch_later=None, position=0, total=100):
+    def update(self, uuid, title, url, watch_later=None, position=None, total=None):
         ''' Set program resumepoint or watchLater status and update local copy '''
+        removes = []
+        self.refresh(ttl=0)
 
-        # Load current resumepoints
-        self.get_resumepoints(ttl=60 * 60)
+        # The video has no assetPath, so we cannot update resumepoints
+        if uuid is None:
+            return True
 
-        if watch_later is not None and not position and watch_later is self.is_watchlater(uuid):
+        if position is not None and position >= total - 30:
+            watch_later = False
+
+        if watch_later is not None and position is None and total is None and watch_later is self.is_watchlater(uuid):
             # watchLater status is not changed, nothing to do
             return True
 
-        if watch_later is None and position == self.get_position(uuid):
+        if watch_later is None and position == self.get_position(uuid) and total == self.get_total(uuid):
             # resumepoint is not changed, nothing to do
             return True
 
@@ -86,55 +92,58 @@ class ResumePoints:
             # Update existing resumepoint values
             payload = self._resumepoints[uuid]['value']
             payload['url'] = url
-            payload['position'] = position
-            payload['total'] = total
         else:
             # Create new resumepoint values
-            payload = dict(position=position, total=total, url=url)
+            payload = dict(position=0, total=100, url=url, watchLater=False)
+
+        if position is not None:
+            payload['position'] = position
+
+        if total is not None:
+            payload['total'] = total
+
+        if position is not None or total is not None:
+            removes.append('continue-*.json')
 
         if watch_later is not None:
             # Add watchLater status to payload
             payload['watchLater'] = watch_later
-
-            # Updating watchLater status, invalidate watchlater menu cache
-            self._kodi.invalidate_caches('watchlater-*.json')
+            removes.append('watchlater-*.json')
 
         import json
         data = json.dumps(payload).encode()
         self._kodi.log('URL post: https://video-user-data.vrt.be/resume_points/{uuid}', 'Verbose', uuid=uuid)
-        req = Request('https://video-user-data.vrt.be/resume_points/%s' % uuid, data=data, headers=headers)
-        result = urlopen(req)
-        if result.getcode() != 200:
-            self._kodi.log_error("Failed to (un)watch episode' at VRT NU")
-            self._kodi.show_notification(message=self._kodi.localize(30976))
+        self._kodi.log('URL post data:: {data}', 'Verbose', data=data)
+        try:
+            req = Request('https://video-user-data.vrt.be/resume_points/%s' % uuid, data=data, headers=headers)
+            urlopen(req)
+        except HTTPError as exc:
+            self._kodi.log_error('Failed to (un)watch episode at VRT NU (%s)' % exc)
+            self._kodi.show_notification(message=self._kodi.localize(30977))
             return False
 
         # NOTE: Updates to resumepoints take a longer time to take effect, so we keep our own cache and use it
         self._resumepoints[uuid] = dict(value=payload)
         self._kodi.update_cache('resume_points.json', self._resumepoints)
-        self._kodi.container_refresh()
+        self._kodi.invalidate_caches(*removes)
         return True
 
     def is_watchlater(self, uuid):
         ''' Is a program set to watch later ? '''
-        value = False
-        entry = self._resumepoints.get(uuid)
-        if entry:
-            value = entry.get('value', {}).get('watchLater')
-        return value is True
+        return self._resumepoints.get(uuid, {}).get('value', {}).get('watchLater') is True
 
     def watchlater(self, uuid, title, url):
         ''' Watch an episode later '''
-        succeeded = self.set_resumepoint(uuid=uuid, title=title, url=url, watch_later=True)
+        succeeded = self.update(uuid=uuid, title=title, url=url, watch_later=True)
         if succeeded:
-            self._kodi.show_notification(message=self._kodi.localize(30401, title=title))
+            self._kodi.show_notification(message=self._kodi.localize(30403, title=title))
             self._kodi.container_refresh()
 
     def unwatchlater(self, uuid, title, url, move_down=False):
         ''' Unwatch an episode later '''
-        succeeded = self.set_resumepoint(uuid=uuid, title=title, url=url, watch_later=False)
+        succeeded = self.update(uuid=uuid, title=title, url=url, watch_later=False)
         if succeeded:
-            self._kodi.show_notification(message=self._kodi.localize(30402, title=title))
+            self._kodi.show_notification(message=self._kodi.localize(30404, title=title))
             # If the current item is selected and we need to move down before removing
             if move_down:
                 self._kodi.input_down()
@@ -142,50 +151,36 @@ class ResumePoints:
 
     def get_position(self, uuid):
         ''' Return the stored position of a video '''
-        position = 0
-        entry = self._resumepoints.get(uuid)
-        if entry:
-            position = entry.get('value', {}).get('position', 0)
-        return position
+        return self._resumepoints.get(uuid, {}).get('value', {}).get('position', 0)
+
+    def get_total(self, uuid):
+        ''' Return the stored total length of a video '''
+        return self._resumepoints.get(uuid, {}).get('value', {}).get('total', 100)
+
+    def get_url(self, uuid, url_type='medium'):
+        ''' Return the stored url a video '''
+        from statichelper import reformat_url
+        return reformat_url(self._resumepoints.get(uuid, {}).get('value', {}).get('url'), url_type)
 
     @staticmethod
     def assetpath_to_uuid(assetpath):
         ''' Convert an assetpath (e.g. /content/dam/vrt/2019/08/14/woodstock-depot_WP00157456)
             to a resumepoint uuid (e.g. contentdamvrt20190814woodstockdepotwp00157456) '''
+        # The video has no assetPath, so we return None instead
+        if assetpath is None:
+            return None
         return assetpath.translate({ord(char): None for char in '/-_'}).lower()
 
-    def watchlater_uuids(self):
-        ''' Return all watchlater uuids '''
-        return [key for key, value in list(self._resumepoints.items()) if value.get('value').get('watchLater') is True]
+    def watchlater_urls(self):
+        ''' Return all watchlater urls '''
+        return [self.get_url(uuid) for uuid in self._resumepoints if self.is_watchlater(uuid)]
 
-    def resumepoints_uuids(self):
-        ''' Return all resumepoints uuids and their resume point '''
-        return {key: value.get('value').get('position') for key, value in list(self._resumepoints.items()) if value.get('value').get('position', 0) != 0}
+    def resumepoints_urls(self):
+        ''' Return all urls that have not been finished watching '''
+        seconds_margin = 30  # Margin in seconds
+        return [self.get_url(uuid) for uuid in self._resumepoints if seconds_margin < self.get_position(uuid) < (self.get_total(uuid) - seconds_margin)]
 
-    def refresh_resumepoints(self):
-        ''' External API call to refresh resumepoints, used in Troubleshooting section '''
-        self.get_resumepoints(ttl=0)
-        self._kodi.show_notification(message=self._kodi.localize(30982))
-
-    def manage_watchlater(self):
-        ''' Allow the user to unselect watchlater to be removed from the listing '''
-        self.get_resumepoints(ttl=0)
-        if not self._resumepoints:
-            self._kodi.show_ok_dialog(heading=self._kodi.localize(30418), message=self._kodi.localize(30419))  # No watchlater list found
-            return
-
-#        def by_title(item):
-#            ''' Sort by title '''
-#            return item.get('value').get('title')
-#
-#        items = [dict(program=url_to_program(value.get('value').get('programUrl')),
-#                      title=unquote(value.get('value').get('title')),
-#                      enabled=value.get('value').get('watchLater')) for value in list(sorted(self._resumepoints.values(), key=by_title))]
-#        titles = [item['title'] for item in items]
-#        preselect = [idx for idx in range(0, len(items) - 1) if items[idx]['enabled']]
-#        selected = self._kodi.show_multiselect(self._kodi.localize(30420), options=titles, preselect=preselect)  # Please select/unselect to follow/unfollow
-#        if selected is not None:
-#            for idx in set(preselect).difference(set(selected)):
-#                self.unwatch(program=items[idx]['program'], title=items[idx]['title'])
-#            for idx in set(selected).difference(set(preselect)):
-#                self.watch(program=items[idx]['program'], title=items[idx]['title'])
+    def invalidate_caches(self):
+        ''' Invalidate caches that rely on favorites '''
+        # Delete resumepoints-related caches
+        self._kodi.invalidate_caches('continue-*.json', 'resume_points.json', 'watchlater-*.json')

--- a/resources/lib/search.py
+++ b/resources/lib/search.py
@@ -98,7 +98,7 @@ class Search:
                 info_dict=dict(),
             ))
 
-        self._favorites.get_favorites(ttl=60 * 60)
+        self._favorites.refresh(ttl=60 * 60)
         self._kodi.show_listing(search_items, category=30032, sort=sort, ascending=ascending, content=content, cache=False)
 
     def clear(self):

--- a/resources/lib/service.py
+++ b/resources/lib/service.py
@@ -25,12 +25,7 @@ class VrtMonitor(Monitor):
         ''' Handler for changes to settings '''
         _kodi = KodiWrapper(None)
         _kodi.log('Settings changed')
-
-        _kodi.invalidate_caches('favorites.json')
-        _kodi.invalidate_caches('offline-*.json')
-        _kodi.invalidate_caches('recent-*.json')
-        _kodi.invalidate_caches('resume_points.json')
-        _kodi.invalidate_caches('watchlater-*.json')
-
         TokenResolver(_kodi).refresh_login()
+
+        _kodi.invalidate_caches('continue-*.json', 'favorites.json', 'my-offline-*.json', 'my-recent-*.json', 'resume_points.json', 'watchlater-*.json')
         _kodi.container_refresh()

--- a/resources/lib/statichelper.py
+++ b/resources/lib/statichelper.py
@@ -33,6 +33,35 @@ def convert_html_to_kodilabel(text):
     return unescape(text).strip()
 
 
+def reformat_url(url, url_type):
+    ''' Convert a url '''
+    # Clean URLs with a hash in it
+    pos = url.find('#')
+    if pos >= 0:
+        url = url[:pos]
+    # long url
+    if url_type == 'long':
+        if url.startswith('/vrtnu/a-z'):
+            return 'https://www.vrt.be' + url
+        if url.startswith('//www.vrt.be'):
+            return 'https:' + url
+        return url
+    # medium url
+    if url_type == 'medium':
+        if url.startswith('https:'):
+            return url.replace('https:', '')
+        if url.startswith('/vrtnu/a-z'):
+            return '//www.vrt.be' + url
+        return url
+    # short url
+    if url_type == 'short':
+        if url.startswith('https://www.vrt.be'):
+            return url.replace('https://www.vrt.be', '')
+        if url.startswith('//www.vrt.be'):
+            return url.replace('//www.vrt.be', '')
+    return url
+
+
 def program_to_url(program, url_type):
     ''' Convert a program url component (e.g. de-campus-cup) to a short programUrl (e.g. /vrtnu/a-z/de-campus-cup/)
         or to a long programUrl (e.g. //www.vrt.be/vrtnu/a-z/de-campus-cup/)
@@ -43,8 +72,10 @@ def program_to_url(program, url_type):
         if url_type == 'short':
             url = '/vrtnu/a-z/' + program + '/'
         # long programUrl
-        elif url_type == 'long':
+        elif url_type == 'medium':
             url = '//www.vrt.be/vrtnu/a-z/' + program + '/'
+        elif url_type == 'long':
+            url = 'https://www.vrt.be/vrtnu/a-z/' + program + '/'
     return url
 
 
@@ -73,6 +104,9 @@ def url_to_episode(url):
     ''' Convert a targetUrl (e.g. //www.vrt.be/vrtnu/a-z/buck/1/buck-s1a32/)
         to a short episode url (/vrtnu/a-z/buck/1/buck-s1a32/)
     '''
+    if url.startswith('https://www.vrt.be/vrtnu/a-z/'):
+        # very long episode url
+        return url.replace('https://www.vrt.be/vrtnu/a-z/', '/vrtnu/a-z/')
     if url.startswith('//www.vrt.be/vrtnu/a-z/'):
         # long episode url
         return url.replace('//www.vrt.be/vrtnu/a-z/', '/vrtnu/a-z/')

--- a/resources/lib/tokenresolver.py
+++ b/resources/lib/tokenresolver.py
@@ -341,13 +341,8 @@ class TokenResolver:
         # Delete token cache
         self.delete_tokens()
 
-        # Delete favorites
-        self._kodi.invalidate_caches('favorites.json')
-        self._kodi.invalidate_caches('my-offline-*.json')
-        self._kodi.invalidate_caches('my-recent-*.json')
-
-        # Delete resume_points
-        self._kodi.invalidate_caches('resume_points.json')
+        # Delete user-related caches
+        self._kodi.invalidate_caches('continue-*.json', 'favorites.json', 'my-offline-*.json', 'my-recent-*.json', 'resume_points.json', 'watchlater-*.json')
 
     def logged_in(self):
         ''' Whether there is an active login '''

--- a/resources/lib/tvguide.py
+++ b/resources/lib/tvguide.py
@@ -151,7 +151,7 @@ class TVGuide:
         epg = self.parse(date, now)
         epg_url = epg.strftime(self.VRT_TVGUIDE)
 
-        self._favorites.get_favorites(ttl=60 * 60)
+        self._favorites.refresh(ttl=60 * 60)
 
         cache_file = 'schedule.%s.json' % date
         if date in ('today', 'yesterday', 'tomorrow'):

--- a/resources/lib/vrtplayer.py
+++ b/resources/lib/vrtplayer.py
@@ -8,7 +8,6 @@ from favorites import Favorites
 from helperobjects import TitleItem
 from resumepoints import ResumePoints
 from statichelper import find_entry, url_to_episode
-from playerinfo import PlayerInfo
 
 
 class VRTPlayer:
@@ -23,7 +22,7 @@ class VRTPlayer:
 
     def show_main_menu(self):
         ''' The VRT NU add-on main menu '''
-        self._favorites.get_favorites(ttl=60 * 60)
+        # self._favorites.refresh(ttl=60 * 60)
         main_items = []
 
         # Only add 'My favorites' when it has been activated
@@ -112,8 +111,7 @@ class VRTPlayer:
 
     def show_favorites_menu(self):
         ''' The VRT NU addon 'My Programs' menu '''
-        self._favorites.get_favorites(ttl=60 * 60)
-        self._resumepoints.get_resumepoints(ttl=60 * 60)
+        self._favorites.refresh(ttl=60 * 60)
         favorites_items = [
             TitleItem(title=self._kodi.localize(30040),  # My A-Z listing
                       path=self._kodi.url_for('favorites_programs'),
@@ -133,13 +131,13 @@ class VRTPlayer:
         if self._resumepoints.is_activated():
             favorites_items.append(TitleItem(
                 title=self._kodi.localize(30050),  # My watch later
-                path=self._kodi.url_for('favorites_watchlater'),
+                path=self._kodi.url_for('resumepoints_watchlater'),
                 art_dict=dict(thumb='DefaultVideoPlaylists.png'),
                 info_dict=dict(plot=self._kodi.localize(30051)),
             ))
             favorites_items.append(TitleItem(
                 title=self._kodi.localize(30052),  # Continue Watching
-                path=self._kodi.url_for('favorites_continue'),
+                path=self._kodi.url_for('resumepoints_continue'),
                 art_dict=dict(thumb='DefaultInProgressShows.png'),
                 info_dict=dict(plot=self._kodi.localize(30053)),
             ))
@@ -168,24 +166,24 @@ class VRTPlayer:
 
     def show_favorites_docu_menu(self):
         ''' The VRT NU add-on 'My documentaries' listing menu '''
-        self._favorites.get_favorites(ttl=60 * 60)
-        self._resumepoints.get_resumepoints(ttl=60 * 60)
+        self._favorites.refresh(ttl=60 * 60)
+        self._resumepoints.refresh(ttl=60 * 60)
         episode_items, sort, ascending, content = self._apihelper.list_episodes(category='docu', season='allseasons', programtype='oneoff')
         self._kodi.show_listing(episode_items, category=30044, sort=sort, ascending=ascending, content=content)
 
     def show_tvshow_menu(self, use_favorites=False):
         ''' The VRT NU add-on 'A-Z' listing menu '''
         # My favorites menus may need more up-to-date favorites
-        self._favorites.get_favorites(ttl=5 * 60 if use_favorites else 60 * 60)
-        self._resumepoints.get_resumepoints(ttl=5 * 60 if use_favorites else 60 * 60)
+        self._favorites.refresh(ttl=5 * 60 if use_favorites else 60 * 60)
+        self._resumepoints.refresh(ttl=5 * 60 if use_favorites else 60 * 60)
         tvshow_items = self._apihelper.list_tvshows(use_favorites=use_favorites)
         self._kodi.show_listing(tvshow_items, category=30012, sort='label', content='tvshows')
 
     def show_category_menu(self, category=None):
         ''' The VRT NU add-on 'Categories' listing menu '''
         if category:
-            self._favorites.get_favorites(ttl=60 * 60)
-            self._resumepoints.get_resumepoints(60 * 60)
+            self._favorites.refresh(ttl=60 * 60)
+            self._resumepoints.refresh(ttl=60 * 60)
             tvshow_items = self._apihelper.list_tvshows(category=category)
             from data import CATEGORIES
             category_msgctxt = find_entry(CATEGORIES, 'id', category).get('msgctxt')
@@ -198,8 +196,8 @@ class VRTPlayer:
         ''' The VRT NU add-on 'Channels' listing menu '''
         if channel:
             from tvguide import TVGuide
-            self._favorites.get_favorites(ttl=60 * 60)
-            self._resumepoints.get_resumepoints(60 * 60)
+            self._favorites.refresh(ttl=60 * 60)
+            self._resumepoints.refresh(ttl=60 * 60)
             channel_items = self._apihelper.list_channels(channels=[channel])  # Live TV
             channel_items.extend(TVGuide(self._kodi).get_channel_items(channel=channel))  # TV guide
             channel_items.extend(self._apihelper.list_youtube(channels=[channel]))  # YouTube
@@ -214,8 +212,8 @@ class VRTPlayer:
     def show_featured_menu(self, feature=None):
         ''' The VRT NU add-on 'Featured content' listing menu '''
         if feature:
-            self._favorites.get_favorites(ttl=60 * 60)
-            self._resumepoints.get_resumepoints(60 * 60)
+            self._favorites.refresh(ttl=60 * 60)
+            self._resumepoints.refresh(ttl=60 * 60)
             tvshow_items = self._apihelper.list_tvshows(feature=feature)
             from data import FEATURED
             feature_msgctxt = find_entry(FEATURED, 'id', feature).get('msgctxt')
@@ -231,8 +229,8 @@ class VRTPlayer:
 
     def show_episodes_menu(self, program, season=None):
         ''' The VRT NU add-on episodes listing menu '''
-        self._favorites.get_favorites(ttl=60 * 60)
-        self._resumepoints.get_resumepoints(60 * 60)
+        self._favorites.refresh(ttl=60 * 60)
+        self._resumepoints.refresh(ttl=60 * 60)
         episode_items, sort, ascending, content = self._apihelper.list_episodes(program=program, season=season)
         # FIXME: Translate program in Program Title
         self._kodi.show_listing(episode_items, category=program.title(), sort=sort, ascending=ascending, content=content)
@@ -242,8 +240,8 @@ class VRTPlayer:
         from statichelper import realpage
 
         # My favorites menus may need more up-to-date favorites
-        self._favorites.get_favorites(ttl=5 * 60 if use_favorites else 60 * 60)
-        self._resumepoints.get_resumepoints(60 * 60)
+        self._favorites.refresh(ttl=5 * 60 if use_favorites else 60 * 60)
+        self._resumepoints.refresh(ttl=5 * 60 if use_favorites else 60 * 60)
         page = realpage(page)
         episode_items, sort, ascending, content = self._apihelper.list_episodes(page=page, use_favorites=use_favorites, variety='recent')
 
@@ -267,8 +265,8 @@ class VRTPlayer:
         from statichelper import realpage
 
         # My favorites menus may need more up-to-date favorites
-        self._favorites.get_favorites(ttl=5 * 60 if use_favorites else 60 * 60)
-        self._resumepoints.get_resumepoints(ttl=5 * 60 if use_favorites else 60 * 60)
+        self._favorites.refresh(ttl=5 * 60 if use_favorites else 60 * 60)
+        self._resumepoints.refresh(ttl=5 * 60 if use_favorites else 60 * 60)
         page = realpage(page)
         episode_items, sort, ascending, content = self._apihelper.list_episodes(page=page, use_favorites=use_favorites, variety='offline')
 
@@ -287,27 +285,27 @@ class VRTPlayer:
 
         self._kodi.show_listing(episode_items, category=30022, sort=sort, ascending=ascending, content=content, cache=False)
 
-    def show_watchlater_menu(self, page=0, use_favorites=False):
+    def show_watchlater_menu(self, page=0):
         ''' The VRT NU add-on 'My watch later' listing menu '''
         from statichelper import realpage
 
         # My watch later menu may need more up-to-date favorites
-        self._favorites.get_favorites(ttl=5 * 60 if use_favorites else 60 * 60)
-        self._resumepoints.get_resumepoints(ttl=5 * 60)
+        self._favorites.refresh(ttl=5 * 60)
+        self._resumepoints.refresh(ttl=5 * 60)
         page = realpage(page)
         episode_items, sort, ascending, content = self._apihelper.list_episodes(page=page, variety='watchlater')
-        self._kodi.show_listing(episode_items, category=30022, sort=sort, ascending=ascending, content=content, cache=False)
+        self._kodi.show_listing(episode_items, category=30050, sort=sort, ascending=ascending, content=content, cache=False)
 
-    def show_continue_menu(self, page=0, use_favorites=False):
+    def show_continue_menu(self, page=0):
         ''' The VRT NU add-on 'Continue waching' listing menu '''
         from statichelper import realpage
 
         # Continue watching menu may need more up-to-date favorites
-        self._favorites.get_favorites(ttl=5 * 60 if use_favorites else 60 * 60)
-        self._resumepoints.get_resumepoints(ttl=5 * 60)
+        self._favorites.refresh(ttl=5 * 60)
+        self._resumepoints.refresh(ttl=5 * 60)
         page = realpage(page)
         episode_items, sort, ascending, content = self._apihelper.list_episodes(page=page, variety='continue')
-        self._kodi.show_listing(episode_items, category=30022, sort=sort, ascending=ascending, content=content, cache=False)
+        self._kodi.show_listing(episode_items, category=30052, sort=sort, ascending=ascending, content=content, cache=False)
 
     def play_latest_episode(self, program):
         ''' A hidden feature in the VRT NU add-on to play the latest episode of a program '''
@@ -343,6 +341,7 @@ class VRTPlayer:
         if stream is not None:
             self._kodi.play(stream, video.get('listitem'))
         if self._resumepoints.is_activated():
+            from playerinfo import PlayerInfo
             # Get timestamps from player
             PlayerInfo(position=lambda position: self.push_position(position, video))
 
@@ -360,4 +359,5 @@ class VRTPlayer:
         url = url_to_episode(episode.get('url', ''))
 
         # Push resumepoint to VRT NU
-        self._resumepoints.set_resumepoint(uuid=uuid, title=title, url=url, watch_later=None, position=position[0], total=position[1])
+        self._resumepoints.update(uuid=uuid, title=title, url=url, position=position[0], total=position[1])
+        self._kodi.container_refresh()

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -10,16 +10,16 @@
     <category label="30820"> <!-- Interface -->
         <setting label="30821" type="lsep"/> <!-- Features -->
         <setting label="30823" help="30824" type="bool" id="usefavorites" default="true"/>
-        <setting label="30929" help="30930" type="bool" id="useresumepoints" default="true" enable="eq(-1,true)" subsetting="true"/>
-        <setting label="30825" help="30826" type="action" id="manage_favorites" action="RunPlugin(plugin://plugin.video.vrt.nu/favorites/manage)" enable="eq(-2,true)" subsetting="true"/>
-        <setting label="30827" help="30828" type="bool" id="addmymovies" default="true" enable="eq(-3,true)" subsetting="true"/>
-        <setting label="30829" help="30830" type="bool" id="addmydocu" default="true" enable="eq(-4,true)" subsetting="true"/>
+        <setting label="30825" help="30826" type="action" id="manage_favorites" action="RunPlugin(plugin://plugin.video.vrt.nu/favorites/manage)" enable="eq(-1,true)" subsetting="true"/>
+        <setting label="30827" help="30828" type="bool" id="useresumepoints" default="true" enable="eq(-2,true)" subsetting="true"/>
+        <setting label="30829" help="30830" type="bool" id="addmymovies" default="true" enable="eq(-3,true)" subsetting="true"/>
+        <setting label="30831" help="30832" type="bool" id="addmydocu" default="true" enable="eq(-4,true)" subsetting="true"/>
 
         <setting type="sep"/>
-        <setting label="30831" help="30832" type="bool" id="showoneoff" default="true"/>
-        <setting label="30833" help="30834" type="bool" id="showfanart" default="true"/>
-        <setting label="30835" help="30836" type="bool" id="showyoutube" default="true" enable="System.HasAddon(plugin.video.youtube)"/>
-        <setting label="30837" help="30838" type="bool" id="showpermalink" default="false"/>
+        <setting label="30833" help="30834" type="bool" id="showoneoff" default="true"/>
+        <setting label="30835" help="30836" type="bool" id="showfanart" default="true"/>
+        <setting label="30837" help="30838" type="bool" id="showyoutube" default="true" enable="System.HasAddon(plugin.video.youtube)"/>
+        <setting label="30839" help="30840" type="bool" id="showpermalink" default="false"/>
     </category>
     <category label="30860"> <!-- Playback -->
         <setting label="30861" type="lsep"/>
@@ -47,16 +47,17 @@
         <setting label="30901" type="lsep"/> <!-- Cache -->
         <setting label="30903" help="30904" type="action" id="delete_tokens" action="RunPlugin(plugin://plugin.video.vrt.nu/tokens/delete)"/>
         <setting label="30905" help="30906" type="action" id="refresh_favorites" action="RunPlugin(plugin://plugin.video.vrt.nu/favorites/refresh)"/>
-        <setting label="30907" help="30908" type="bool" id="usemenucaching" default="true"/>
-        <setting label="30909" help="30910" type="bool" id="usehttpcaching" default="true"/>
-        <setting label="30911" help="30912" type="action" id="invalidate_caches" action="RunPlugin(plugin://plugin.video.vrt.nu/cache/delete)" enable="eq(-1,true)" subsetting="true"/>
-        <setting label="30913" type="lsep"/> <!-- InputStream Adaptive -->
-        <setting label="30915" type="action" visible="!System.HasAddon(inputstream.adaptive)" enable="false"/>
-        <setting label="30917" help="30918" type="bool" id="useinputstreamadaptive" default="true" visible="System.HasAddon(inputstream.adaptive)"/>
-        <setting label="30919" help="30920" type="action" id="adaptive_settings" option="close" action="Addon.OpenSettings(inputstream.adaptive)" visible="System.HasAddon(inputstream.adaptive) + [String.StartsWith(System.BuildVersion,18) | String.StartsWith(System.BuildVersion,19)]" enable="eq(-1,true)" subsetting="true"/>
-        <setting label="30921" help="30922" type="action" id="ishelper_info" action="RunScript(script.module.inputstreamhelper, info)" enable="eq(-2,true)"/>
-        <setting label="30923" help="30924" type="action" id="ishelper_settings" option="close" action="Addon.OpenSettings(script.module.inputstreamhelper)" enable="eq(-3,true)" subsetting="true"/>
-        <setting label="30925" type="lsep"/> <!-- Logging -->
-        <setting label="30927" help="30928" type="select" id="max_log_level" values="Quiet|Info|Verbose|Debug" default="Quiet"/>
+        <setting label="30907" help="30908" type="action" id="refresh_resumepoints" action="RunPlugin(plugin://plugin.video.vrt.nu/resumepoints/refresh)"/>
+        <setting label="30909" help="30910" type="bool" id="usemenucaching" default="true"/>
+        <setting label="30911" help="30912" type="bool" id="usehttpcaching" default="true"/>
+        <setting label="30913" help="30914" type="action" id="invalidate_caches" action="RunPlugin(plugin://plugin.video.vrt.nu/cache/delete)" enable="eq(-1,true)" subsetting="true"/>
+        <setting label="30915" type="lsep"/> <!-- InputStream Adaptive -->
+        <setting label="30917" type="action" visible="!System.HasAddon(inputstream.adaptive)" enable="false"/>
+        <setting label="30919" help="30920" type="bool" id="useinputstreamadaptive" default="true" visible="System.HasAddon(inputstream.adaptive)"/>
+        <setting label="30921" help="30922" type="action" id="adaptive_settings" option="close" action="Addon.OpenSettings(inputstream.adaptive)" visible="System.HasAddon(inputstream.adaptive) + [String.StartsWith(System.BuildVersion,18) | String.StartsWith(System.BuildVersion,19)]" enable="eq(-1,true)" subsetting="true"/>
+        <setting label="30923" help="30924" type="action" id="ishelper_info" action="RunScript(script.module.inputstreamhelper, info)" enable="eq(-2,true)"/>
+        <setting label="30925" help="30926" type="action" id="ishelper_settings" option="close" action="Addon.OpenSettings(script.module.inputstreamhelper)" enable="eq(-3,true)" subsetting="true"/>
+        <setting label="30927" type="lsep"/> <!-- Logging -->
+        <setting label="30929" help="30930" type="select" id="max_log_level" values="Quiet|Info|Verbose|Debug" default="Quiet"/>
     </category>
 </settings>

--- a/test/test_resumepoints.py
+++ b/test/test_resumepoints.py
@@ -26,19 +26,36 @@ class TestResumePoints(unittest.TestCase):
     _resumepoints = ResumePoints(kodi)
     _apihelper = ApiHelper(kodi, _favorites, _resumepoints)
 
-    # Update resume_points.json
-    _resumepoints.get_resumepoints(ttl=0)
+    @unittest.skipUnless(xbmcaddon.ADDON_SETTINGS.get('plugin.video.vrt.nu').get('username'), 'Skipping as VRT username is missing.')
+    @unittest.skipUnless(xbmcaddon.ADDON_SETTINGS.get('plugin.video.vrt.nu').get('password'), 'Skipping as VRT password is missing.')
+    def test_get_watchlater_episodes(self):
+        ''' Test items, sort and order '''
+        episode_items, sort, ascending, content = self._apihelper.list_episodes(page=1, variety='watchlater')
+        self.assertTrue(episode_items)
+        self.assertEqual(sort, 'dateadded')
+        self.assertFalse(ascending)
+        self.assertEqual(content, 'episodes')
+
+    @unittest.skipUnless(xbmcaddon.ADDON_SETTINGS.get('plugin.video.vrt.nu').get('username'), 'Skipping as VRT username is missing.')
+    @unittest.skipUnless(xbmcaddon.ADDON_SETTINGS.get('plugin.video.vrt.nu').get('password'), 'Skipping as VRT password is missing.')
+    def test_get_continue_episodes(self):
+        ''' Test items, sort and order '''
+        episode_items, sort, ascending, content = self._apihelper.list_episodes(page=1, variety='continue')
+        self.assertTrue(episode_items)
+        self.assertEqual(sort, 'dateadded')
+        self.assertFalse(ascending)
+        self.assertEqual(content, 'episodes')
 
     @unittest.skipUnless(xbmcaddon.ADDON_SETTINGS.get('plugin.video.vrt.nu').get('username'), 'Skipping as VRT username is missing.')
     @unittest.skipUnless(xbmcaddon.ADDON_SETTINGS.get('plugin.video.vrt.nu').get('password'), 'Skipping as VRT password is missing.')
     def test_update_watchlist(self):
-        self._resumepoints.get_resumepoints(ttl=0)
+        self._resumepoints.refresh(ttl=0)
         assetuuid, first_entry = next(iter(self._resumepoints._resumepoints.items()))  # pylint: disable=protected-access
         print('%s = %s' % (assetuuid, first_entry))
         url = first_entry.get('value').get('url')
         self._resumepoints.watchlater(uuid=assetuuid, title='Foo bar', url=url)
         self._resumepoints.unwatchlater(uuid=assetuuid, title='Foo bar', url=url)
-        self._resumepoints.get_resumepoints(ttl=0)
+        self._resumepoints.refresh(ttl=0)
         assetuuid, first_entry = next(iter(self._resumepoints._resumepoints.items()))  # pylint: disable=protected-access
         print('%s = %s' % (assetuuid, first_entry))
 

--- a/test/test_routing.py
+++ b/test/test_routing.py
@@ -35,6 +35,8 @@ class TestRouter(unittest.TestCase):
         plugin.run(['plugin://plugin.video.vrt.nu/favorites/recent/2', '0', ''])
         self.assertEqual(plugin.url_for(addon.favorites_recent, page=2), 'plugin://plugin.video.vrt.nu/favorites/recent/2')
         plugin.run(['plugin://plugin.video.vrt.nu/favorites/offline', '0', ''])
+        plugin.run(['plugin://plugin.video.vrt.nu/resumepoints/watchlater', '0', ''])
+        plugin.run(['plugin://plugin.video.vrt.nu/resumepoints/continue', '0', ''])
         plugin.run(['plugin://plugin.video.vrt.nu/favorites/docu', '0', ''])
 
     # A-Z menu: '/programs'
@@ -46,8 +48,8 @@ class TestRouter(unittest.TestCase):
     def test_episodes_menu(self):
         plugin.run(['plugin://plugin.video.vrt.nu/programs/thuis', '0', ''])
         self.assertEqual(plugin.url_for(addon.programs, program='thuis'), 'plugin://plugin.video.vrt.nu/programs/thuis')
-        plugin.run(['plugin://plugin.video.vrt.nu/programs/de-campus-cup', '0', ''])
-        self.assertEqual(plugin.url_for(addon.programs, program='de-campus-cup'), 'plugin://plugin.video.vrt.nu/programs/de-campus-cup')
+        plugin.run(['plugin://plugin.video.vrt.nu/programs/pano/allseasons', '0', ''])
+        self.assertEqual(plugin.url_for(addon.programs, program='pano', season='allseasons'), 'plugin://plugin.video.vrt.nu/programs/pano/allseasons')
 
     # Categories menu: '/categories'
     def test_categories_menu(self):
@@ -166,6 +168,11 @@ class TestRouter(unittest.TestCase):
     def test_refresh_favorites_route(self):
         plugin.run(['plugin://plugin.video.vrt.nu/favorites/refresh', '0', ''])
         self.assertEqual(plugin.url_for(addon.favorites_refresh), 'plugin://plugin.video.vrt.nu/favorites/refresh')
+
+    # Refresh resumepoints method: '/resumepoints/refresh'
+    def test_refresh_resumepoints_route(self):
+        plugin.run(['plugin://plugin.video.vrt.nu/resumepoints/refresh', '0', ''])
+        self.assertEqual(plugin.url_for(addon.resumepoints_refresh), 'plugin://plugin.video.vrt.nu/resumepoints/refresh')
 
     # Manage favorites method: '/favorites/manage'
     def test_manage_favorites_route(self):

--- a/test/test_tokenresolver.py
+++ b/test/test_tokenresolver.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+# GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# pylint: disable=invalid-name,missing-docstring
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+import unittest
+from addon import kodi
+from tokenresolver import TokenResolver
+
+xbmc = __import__('xbmc')
+xbmcaddon = __import__('xbmcaddon')
+xbmcgui = __import__('xbmcgui')
+xbmcplugin = __import__('xbmcplugin')
+xbmcvfs = __import__('xbmcvfs')
+
+
+class TokenResolverTests(unittest.TestCase):
+
+    _tokenresolver = TokenResolver(kodi)
+
+    def test_refresh_login(self):
+        self._tokenresolver.refresh_login()
+
+    def test_cleanup_userdata(self):
+        self._tokenresolver.cleanup_userdata()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/userdata/addon_settings.json
+++ b/test/userdata/addon_settings.json
@@ -24,6 +24,7 @@
         "usehttpcaching": "true", 
         "useinputstreamadaptive": "true", 
         "usemenucaching": "true", 
+        "useresumepoints": "true", 
         "username": "", 
         "version": "", 
         "vrtnws": "true", 


### PR DESCRIPTION
This PR includes:
- Translation fixes wrt. context menu
- Fix breadcrumbs for Watch later and Continue watching
- Add routing integration tests for Watch later and Continue watching
- Fix issue during testing when resumepoints is not enabled
- Add a 'Refresh watching activity' to Expert settings menu
- Simplify Favorites/ResumePoints interface
- Use total-value from resumepoints for metadata resumetime
- Fix issue causing empty 'Continue watching' listing
- Fix issue with caching of Watch later and Continue watching listings