### PR TITLE
Improve TV guide with new metadata

### DIFF
--- a/test/xbmcplugin.py
+++ b/test/xbmcplugin.py
@@ -67,7 +67,7 @@ def addSortMethod(handle, sortMethod):
 
 def endOfDirectory(handle, succeeded=True, updateListing=True, cacheToDisc=True):
     ''' A stub implementation of the xbmcplugin endOfDirectory() function '''
-    print(kodi_to_ansi('[B]-=( [COLOR cyan]--------[/COLOR] )=-[/B]'))
+    # print(kodi_to_ansi('[B]-=( [COLOR cyan]--------[/COLOR] )=-[/B]'))
 
 
 def setContent(handle, content):


### PR DESCRIPTION
Since the TV EPG schedule has now additional information we can take
this into account to follow a program, go to a program or watch an
episode later.

This PR also includes:
- Fix a bug where some EPG information was blank if it did not have a vrt.whatson-id
- Remove channel from EPG plot (since it is now in the breadcrumbs)

This fixes #524 