### PR TITLE
support api urls with spaces

### DIFF
--- a/resources/lib/apihelper.py
+++ b/resources/lib/apihelper.py
@@ -448,7 +448,7 @@ class ApiHelper:
 
         # Construct VRT NU Search API Url and get api data
         querystring = '&'.join('{}={}'.format(key, value) for key, value in list(params.items()))
-        search_url = self._VRTNU_SEARCH_URL + '?' + querystring
+        search_url = self._VRTNU_SEARCH_URL + '?' + querystring.replace(' ', '%20')  # Only encode spaces to minimize url length
 
         import json
         if cache_file:


### PR DESCRIPTION
This fixes an issue with listing seasons that contain spaces in `seasonTitle`.
For instance: 2019 najaar, 1 compilatie, 2019 NJ, 2 compilatie

We only encode spaces to keep api urls as short as possible.
