### PR TITLE
Add HTTP error to dialog

### DIFF
--- a/resources/lib/vrtplayer.py
+++ b/resources/lib/vrtplayer.py
@@ -348,8 +348,9 @@ class VRTPlayer:
         _tokenresolver = TokenResolver(self._kodi)
         _streamservice = StreamService(self._kodi, _tokenresolver)
         stream = _streamservice.get_stream(video)
-        if stream is not None:
-            self._kodi.play(stream, video.get('listitem'))
+        if stream is None:
+            return
+        self._kodi.play(stream, video.get('listitem'))
         if self._resumepoints.is_activated():
             from playerinfo import PlayerInfo
             # Get info from player


### PR DESCRIPTION
I got another HTTP Error 415: Unsupported Media Type, although we do not
report or log this error anywhere.

This change adds it to the dialog and logs it to the log. So that if it
gets reported (e.g. to VRT NU), hopefully the details will help.

PS I got this error with the HLS stream of episode 5 (season 4) of 24 hours in police custody. I reported this to VRT NU.

This PR includes:
- Put the HTTP Error in the dialog
- Log the HTTP Error to a log file
- Don't handle resumepoints if stream is None (and not played)