### PR TITLE
Skip proxy test on Python 2

### DIFF
--- a/test/test_proxy.py
+++ b/test/test_proxy.py
@@ -5,6 +5,7 @@
 # pylint: disable=duplicate-code,invalid-name,missing-docstring,protected-access
 
 from __future__ import absolute_import, division, print_function, unicode_literals
+import sys
 import unittest
 import addon
 
@@ -16,6 +17,7 @@ xbmcvfs = __import__('xbmcvfs')
 plugin = addon.plugin
 
 
+@unittest.skipIf(sys.version_info[0] < 3, 'Skipping proxy tests on Python 2')
 class TestProxy(unittest.TestCase):
     def setUp(self):
         xbmc.GLOBAL_SETTINGS['network.usehttpproxy'] = True

--- a/test/xbmcvfs.py
+++ b/test/xbmcvfs.py
@@ -48,6 +48,8 @@ def listdir(path):
     ''' A reimplementation of the xbmcvfs listdir() function '''
     files = []
     dirs = []
+    if not exists(path):
+        return dirs, files
     for filename in os.listdir(path):
         if os.path.isfile(filename):
             files.append(filename)


### PR DESCRIPTION
Since the proxy implementation on Python 2 is less reliable, we trust
the results of the tests on Python 3.