### PR TITLE
Use same margin for resumepoints and upnext

### DIFF
--- a/resources/lib/apihelper.py
+++ b/resources/lib/apihelper.py
@@ -13,7 +13,7 @@ except ImportError:  # Python 2
     from urllib2 import build_opener, install_opener, ProxyHandler, Request, HTTPError, unquote, urlopen
 
 import statichelper
-from data import CHANNELS
+from data import CHANNELS, SECONDS_MARGIN
 from helperobjects import TitleItem
 from metadata import Metadata
 
@@ -283,7 +283,6 @@ class ApiHelper:
                     pass
 
         if upnext.get('next'):
-            notification_time = 60
             current_ep = upnext.get('current')
             next_ep = upnext.get('next')
 
@@ -341,7 +340,7 @@ class ApiHelper:
                 current_episode=current_episode,
                 next_episode=next_episode,
                 play_info=play_info,
-                notification_time=notification_time,
+                notification_time=SECONDS_MARGIN,
             )
             return next_info
 

--- a/resources/lib/data.py
+++ b/resources/lib/data.py
@@ -4,6 +4,10 @@
 
 from __future__ import absolute_import, division, unicode_literals
 
+# The margin at start/end to consider a video as watched
+# This value is used by resumepoints and upnext
+SECONDS_MARGIN = 30
+
 # Fallback list of categories so we don't depend on web scraping only
 CATEGORIES = [
     dict(name='Audiodescriptie', id='met-audiodescriptie', msgctxt=30070),

--- a/resources/lib/metadata.py
+++ b/resources/lib/metadata.py
@@ -12,7 +12,7 @@ except ImportError:  # Python 2
     from urllib import quote_plus
 
 import statichelper
-from data import CHANNELS
+from data import CHANNELS, SECONDS_MARGIN
 
 
 class Metadata:
@@ -165,10 +165,9 @@ class Metadata:
                     url = statichelper.reformat_url(api_data.get('url', ''), 'medium')
                     properties.update(assetuuid=assetuuid, url=url, title=program_title)
 
-                    seconds_margin = 30
                     position = self._resumepoints.get_position(assetuuid)
                     total = self._resumepoints.get_total(assetuuid)
-                    if position and total and seconds_margin < position < total - seconds_margin:
+                    if position and total and SECONDS_MARGIN < position < total - SECONDS_MARGIN:
                         properties['resumetime'] = position
 
                 duration = self.get_duration(api_data)

--- a/resources/lib/resumepoints.py
+++ b/resources/lib/resumepoints.py
@@ -11,6 +11,8 @@ try:  # Python 3
 except ImportError:  # Python 2
     from urllib2 import build_opener, install_opener, ProxyHandler, Request, HTTPError, urlopen
 
+from data import SECONDS_MARGIN
+
 
 class ResumePoints:
     ''' Track, cache and manage VRT resume points and watch list '''
@@ -177,8 +179,7 @@ class ResumePoints:
 
     def resumepoints_urls(self):
         ''' Return all urls that have not been finished watching '''
-        seconds_margin = 30  # Margin in seconds
-        return [self.get_url(uuid) for uuid in self._resumepoints if seconds_margin < self.get_position(uuid) < (self.get_total(uuid) - seconds_margin)]
+        return [self.get_url(uuid) for uuid in self._resumepoints if SECONDS_MARGIN < self.get_position(uuid) < (self.get_total(uuid) - SECONDS_MARGIN)]
 
     def invalidate_caches(self):
         ''' Invalidate caches that rely on favorites '''


### PR DESCRIPTION
This ensures the same margin is being used for both resumepoints and
upnext so that when moving to the next epside, the current episode is
considered watched.