### PR TITLE
Change the order of context menu items

### DIFF
--- a/resources/lib/apihelper.py
+++ b/resources/lib/apihelper.py
@@ -271,7 +271,9 @@ class ApiHelper:
         episodes = sorted(self.get_episodes(keywords=program), key=lambda k: (k.get('program'), k.get('seasonTitle'), k.get('episodeNumber')))
         upnext = dict()
         for episode in episodes:
-            if ep_id.get('whatson_id') == episode.get('whatsonId') or ep_id.get('video_id') == episode.get('videoId') or ep_id.get('video_url') == episode.get('url'):
+            if ep_id.get('whatson_id') == episode.get('whatsonId') or \
+               ep_id.get('video_id') == episode.get('videoId') or \
+               ep_id.get('video_url') == episode.get('url'):
                 season = episode.get('seasonTitle')
                 current_ep_no = episode.get('episodeNumber')
                 program = episode.get('program')

--- a/resources/lib/metadata.py
+++ b/resources/lib/metadata.py
@@ -136,12 +136,13 @@ class Metadata:
                     ))
 
         # GO TO PROGRAM
-        if plugin.path.startswith(('/favorites/offline', '/favorites/recent', '/offline', '/recent',
-                                   '/resumepoints/continue', '/resumepoints/watchlater', '/tvguide')):
-            context_menu.append((
-                self._kodi.localize(30417),  # Go to program
-                'Container.Update(%s)' % self._kodi.url_for('programs', program=program, season='allseasons')
-            ))
+        if api_data.get('programType') != 'oneoff':
+            if plugin.path.startswith(('/favorites/offline', '/favorites/recent', '/offline', '/recent',
+                                       '/resumepoints/continue', '/resumepoints/watchlater', '/tvguide')):
+                context_menu.append((
+                    self._kodi.localize(30417),  # Go to program
+                    'Container.Update(%s)' % self._kodi.url_for('programs', program=program, season='allseasons')
+                ))
 
         # REFRESH MENU
         context_menu.append((


### PR DESCRIPTION
Re-evaluating the context menu, I think it makes more sense to put
'Watch later' first. The rationale is that for individual video's or
episodes this it more related to the context (episode) then
program-related context menu items.

For a program, there is no 'Watch later' item, so it starts with
'Follow program' and 'Go to program'.

And only then we have 'Refresh menu' which is not related to the context
at all.

So the order is: **Episode** > **Program** > **Menu**