### PR TITLE
Add new featured categories

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -237,72 +237,80 @@ msgid "Science and nature"
 msgstr ""
 
 ### FEATURED
-msgctxt "#30087"
+msgctxt "#30100"
 msgid "Online exclusive"
 msgstr ""
 
-msgctxt "#30088"
+msgctxt "#30101"
 msgid "Last episode"
 msgstr ""
 
-msgctxt "#30089"
+msgctxt "#30102"
 msgid "Last chance"
 msgstr ""
 
-msgctxt "#30090"
+msgctxt "#30103"
 msgid "New"
 msgstr ""
 
-msgctxt "#30091"
+msgctxt "#30104"
 msgid "Full season"
 msgstr ""
 
-msgctxt "#30092"
+msgctxt "#30105"
 msgid "Complete series"
 msgstr ""
 
-msgctxt "#30093"
+msgctxt "#30106"
+msgid "Brand new"
+msgstr ""
+
+msgctxt "#30107"
+msgid "New episodes"
+msgstr ""
+
+msgctxt "#30120"
 msgid "Short film"
 msgstr ""
 
 ### APPLICATION
-msgctxt "#30094"
+msgctxt "#30131"
 msgid "Season"
 msgstr ""
 
-msgctxt "#30095"
+msgctxt "#30132"
 msgid "Episode"
 msgstr ""
 
-msgctxt "#30096"
+msgctxt "#30133"
 msgid "* All seasons"
 msgstr ""
 
-msgctxt "#30097"
+msgctxt "#30134"
 msgid "Enter search string"
 msgstr ""
 
-msgctxt "#30098"
+msgctxt "#30135"
 msgid "Nothing found"
 msgstr ""
 
-msgctxt "#30099"
+msgctxt "#30136"
 msgid "Nothing was found when searching for: {keywords}"
 msgstr ""
 
-msgctxt "#30101"
+msgctxt "#30141"
 msgid "{label} live"
 msgstr ""
 
-msgctxt "#30102"
+msgctxt "#30142"
 msgid "Watch [B]{label}[/B] live via Internet"
 msgstr ""
 
-msgctxt "#30103"
+msgctxt "#30143"
 msgid "{label} on YouTube"
 msgstr ""
 
-msgctxt "#30104"
+msgctxt "#30144"
 msgid "Watch [B]{label}[/B] on YouTube"
 msgstr ""
 

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -237,72 +237,80 @@ msgid "Science and nature"
 msgstr "Wetenschap en natuur"
 
 ### FEATURED
-msgctxt "#30087"
+msgctxt "#30100"
 msgid "Online exclusive"
 msgstr "Exclusief online"
 
-msgctxt "#30088"
+msgctxt "#30101"
 msgid "Last episode"
 msgstr "Laatste aflevering"
 
-msgctxt "#30089"
+msgctxt "#30102"
 msgid "Last chance"
 msgstr "Laatste kans"
 
-msgctxt "#30090"
+msgctxt "#30103"
 msgid "New"
 msgstr "Nieuw"
 
-msgctxt "#30091"
+msgctxt "#30104"
 msgid "Full season"
 msgstr "Volledig seizoen"
 
-msgctxt "#30092"
+msgctxt "#30105"
 msgid "Complete series"
 msgstr "Volledige reeks"
 
-msgctxt "#30093"
+msgctxt "#30106"
+msgid "Brand new"
+msgstr "Gloednieuw"
+
+msgctxt "#30107"
+msgid "New episodes"
+msgstr "Nieuwe afleveringen"
+
+msgctxt "#30120"
 msgid "Short film"
 msgstr "Kortfilm"
 
 ### APPLICATION
-msgctxt "#30094"
+msgctxt "#30131"
 msgid "Season"
 msgstr "Seizoen"
 
-msgctxt "#30095"
+msgctxt "#30132"
 msgid "Episode"
 msgstr "Aflevering"
 
-msgctxt "#30096"
+msgctxt "#30133"
 msgid "* All seasons"
 msgstr "* Alle seizoenen"
 
-msgctxt "#30097"
+msgctxt "#30134"
 msgid "Enter search string"
 msgstr "Geef zoektermen op"
 
-msgctxt "#30098"
+msgctxt "#30135"
 msgid "Nothing found"
 msgstr "Niets gevonden"
 
-msgctxt "#30099"
+msgctxt "#30136"
 msgid "Nothing was found when searching for: {keywords}"
 msgstr "Er werd niets gevonden bij het zoeken naar: {keywords}"
 
-msgctxt "#30101"
+msgctxt "#30141"
 msgid "{label} live"
 msgstr "{label} live"
 
-msgctxt "#30102"
+msgctxt "#30142"
 msgid "Watch [B]{label}[/B] live via Internet"
 msgstr "Bekijk [B]{label}[/B] live via Internet"
 
-msgctxt "#30103"
+msgctxt "#30143"
 msgid "{label} on YouTube"
 msgstr "{label} op YouTube"
 
-msgctxt "#30104"
+msgctxt "#30144"
 msgid "Watch [B]{label}[/B] on YouTube"
 msgstr "Bekijk [B]{label}[/B] op YouTube"
 

--- a/resources/lib/apihelper.py
+++ b/resources/lib/apihelper.py
@@ -175,7 +175,7 @@ class ApiHelper:
         # Add an "* All seasons" list item
         if self._kodi.get_global_setting('videolibrary.showallitems') is True:
             season_items.append(TitleItem(
-                title=self._kodi.localize(30096),
+                title=self._kodi.localize(30133),
                 path=self._kodi.url_for('programs', program=program, season='allseasons'),
                 art_dict=self._metadata.get_art(episode, season='allseasons'),
                 info_dict=info_labels,
@@ -192,7 +192,7 @@ class ApiHelper:
             except IndexError:
                 episode = episodes[0]
 
-            label = '%s %s' % (self._kodi.localize(30094), season_key)
+            label = '%s %s' % (self._kodi.localize(30131), season_key)
             season_items.append(TitleItem(
                 title=label,
                 path=self._kodi.url_for('programs', program=program, season=season_key),
@@ -640,7 +640,7 @@ class ApiHelper:
                     path = self._kodi.url_for('play_id', video_id=channel.get('live_stream_id'))
                 elif channel.get('live_stream'):
                     path = self._kodi.url_for('play_url', video_url=channel.get('live_stream'))
-                label = self._kodi.localize(30101, **channel)
+                label = self._kodi.localize(30141, **channel)  # Channel live
                 playing_now = _tvguide.playing_now(channel.get('name'))
                 if playing_now:
                     label += ' [COLOR yellow]| %s[/COLOR]' % playing_now
@@ -651,9 +651,9 @@ class ApiHelper:
                 if channel.get('name') in ['een', 'canvas', 'ketnet']:
                     if self._kodi.get_setting('showfanart', 'true') == 'true':
                         art_dict['fanart'] = self.get_live_screenshot(channel.get('name', art_dict.get('fanart')))
-                    plot = '%s\n\n%s' % (self._kodi.localize(30102, **channel), _tvguide.live_description(channel.get('name')))
+                    plot = '%s\n\n%s' % (self._kodi.localize(30142, **channel), _tvguide.live_description(channel.get('name')))
                 else:
-                    plot = self._kodi.localize(30102, **channel)
+                    plot = self._kodi.localize(30142, **channel)  # Watch live
                 # NOTE: Playcount is required to not have live streams as "Watched"
                 info_dict = dict(title=label, plot=plot, studio=channel.get('studio'), mediatype='video', playcount=0, duration=0)
                 stream_dict = dict(duration=0)
@@ -700,11 +700,11 @@ class ApiHelper:
 
             if channel.get('youtube'):
                 path = channel.get('youtube')
-                label = self._kodi.localize(30103, **channel)
+                label = self._kodi.localize(30143, **channel)  # Channel on YouTube
                 # A single Live channel means it is the entry for channel's TV Show listing, so make it stand out
                 if channels and len(channels) == 1:
                     label = '[B]%s[/B]' % label
-                plot = self._kodi.localize(30104, **channel)
+                plot = self._kodi.localize(30144, **channel)  # Watch on YouTube
                 # NOTE: Playcount is required to not have live streams as "Watched"
                 info_dict = dict(title=label, plot=plot, studio=channel.get('studio'), mediatype='video', playcount=0)
                 context_menu.append((

--- a/resources/lib/data.py
+++ b/resources/lib/data.py
@@ -153,14 +153,16 @@ CHANNELS = [
 
 FEATURED = [
     # Tijdsgerelateerd
-    dict(name='Exclusief online', id='exclusief-online', msgctxt=30087),
-    dict(name='Laatste aflevering', id='laatste-aflevering', msgctxt=30088),
-    dict(name='Laatste kans', id='laatste-kans', msgctxt=30089),
-    dict(name='Nieuw', id='Nieuw', msgctxt=30090),
-    dict(name='Volledig seizoen', id='volledig-seizoen', msgctxt=30091),
-    dict(name='Volledige reeks', id='volledige-reeks', msgctxt=30092),
+    dict(name='Exclusief online', id='exclusief-online', msgctxt=30100),
+    dict(name='Laatste aflevering', id='laatste-aflevering', msgctxt=30101),
+    dict(name='Laatste kans', id='laatste-kans', msgctxt=30102),
+    dict(name='Nieuw', id='Nieuw', msgctxt=30103),
+    dict(name='Volledig seizoen', id='volledig-seizoen', msgctxt=30104),
+    dict(name='Volledige reeks', id='volledige-reeks', msgctxt=30105),
+    dict(name='Gloednieuw', id='gloednieuw', msgctxt=30106),
+    dict(name='Nieuwe afleveringen', id='nieuwe-afleveringen', msgctxt=30107),
     # Inhoudsgerelateerd
-    dict(name='Kortfilm', id='kortfilm', msgctxt=30093),
+    dict(name='Kortfilm', id='kortfilm', msgctxt=30120),
 ]
 
 RELATIVE_DATES = [

--- a/resources/lib/kodiwrapper.py
+++ b/resources/lib/kodiwrapper.py
@@ -274,7 +274,7 @@ class KodiWrapper:
     def get_search_string(self):
         ''' Ask the user for a search string '''
         search_string = None
-        keyboard = xbmc.Keyboard('', self.localize(30097))
+        keyboard = xbmc.Keyboard('', self.localize(30134))
         keyboard.doModal()
         if keyboard.isConfirmed():
             search_string = to_unicode(keyboard.getText())

--- a/resources/lib/metadata.py
+++ b/resources/lib/metadata.py
@@ -632,7 +632,7 @@ class Metadata:
                         sort = 'episode'
                 elif display_options.get('showEpisodeNumber') and api_data.get('episodeNumber') and ascending:
                     # NOTE: Do not prefix with "Episode X" when sorting by episode
-                    # label = '%s %s: %s' % (self._kodi.localize(30095), api_data.get('episodeNumber'), label)
+                    # label = '%s %s: %s' % (self._kodi.localize(30132), api_data.get('episodeNumber'), label)
                     sort = 'episode'
                 elif display_options.get('showBroadcastDate') and api_data.get('formattedBroadcastShortDate'):
                     label = '%s - %s' % (api_data.get('formattedBroadcastShortDate'), label)

--- a/resources/lib/search.py
+++ b/resources/lib/search.py
@@ -85,7 +85,7 @@ class Search:
         from apihelper import ApiHelper
         search_items, sort, ascending, content = ApiHelper(self._kodi, self._favorites, self._resumepoints).list_search(keywords, page=page)
         if not search_items:
-            self._kodi.show_ok_dialog(heading=self._kodi.localize(30098), message=self._kodi.localize(30099, keywords=keywords))
+            self._kodi.show_ok_dialog(heading=self._kodi.localize(30135), message=self._kodi.localize(30136, keywords=keywords))
             self._kodi.end_of_directory()
             return
 

--- a/test/test_vrtplayer.py
+++ b/test/test_vrtplayer.py
@@ -105,7 +105,7 @@ class TestVRTPlayer(unittest.TestCase):
     def test_featured(self):
         ''' Test to ensure our hardcoded categories conforms to scraped categories '''
         featured_items = self._apihelper.list_featured()
-        self.assertEqual(len(featured_items), 7)
+        self.assertEqual(len(featured_items), 9)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
In order to add new categories, I had to renumber some existing entries.

It is weird that VRT NU now also added a "Gloednieuw" section, where there already was a "Nieuw" section.

I also think we have to improve how we support "featured" content. We should add this information to the plot (lacking an alternative). And maybe add a context menu to go to the featured sub-menu to find similar featured content.