### PR TITLE
Use Container.Update instead of Container.Refresh

### DIFF
--- a/resources/lib/kodiwrapper.py
+++ b/resources/lib/kodiwrapper.py
@@ -682,6 +682,15 @@ class KodiWrapper:
             self.log(3, 'Execute: Container.Refresh')
             xbmc.executebuiltin('Container.Refresh')
 
+    def container_update(self, url=None):
+        ''' Update the current container with respect for the path history. '''
+        if url:
+            self.log(3, 'Execute: Container.Update({url})', url=url)
+            xbmc.executebuiltin('Container.Update({url})'.format(url=url))
+        else:
+            self.log(3, 'Execute: Container.Update')
+            xbmc.executebuiltin('Container.Update')
+
     def end_of_directory(self):
         ''' Close a virtual directory, required to avoid a waiting Kodi '''
         xbmcplugin.endOfDirectory(handle=self._handle, succeeded=False, updateListing=False, cacheToDisc=False)

--- a/resources/lib/service.py
+++ b/resources/lib/service.py
@@ -102,7 +102,7 @@ class VrtMonitor(Monitor):
         self._kodi.log(2, '[PlayerPosition] resumepoint update {info} {container}', info=episode.get('title'), container=current_container)
         if current_container is None or self._container == current_container:
             self._kodi.log(2, '[PlayerPosition] update container {info}', info=self._container)
-            self._kodi.container_refresh(self._container)
+            self._kodi.container_update(self._container)
 
     def push_upnext(self, info):
         ''' Push episode info to Up Next service add-on'''


### PR DESCRIPTION
This should preserve the path history, so you can return to the previous container when navigating after playing a video.