### PR TITLE
Use video_id for Up Next because whatson_id is not unique

### DIFF
--- a/resources/lib/addon.py
+++ b/resources/lib/addon.py
@@ -278,11 +278,11 @@ def play_latest(program):
     VRTPlayer().play_latest_episode(program=program)
 
 
-@plugin.route('/play/whatson/<whatson_id>')
-def play_whatson(whatson_id):
-    ''' The API interface to play a video by whatson_id '''
+@plugin.route('/play/upnext/<video_id>')
+def play_upnext(video_id):
+    ''' The API interface to play the next episode of a program '''
     from vrtplayer import VRTPlayer
-    VRTPlayer().play_whatson(whatson_id=whatson_id)
+    VRTPlayer().play_upnext(video_id=video_id)
 
 
 @plugin.route('/play/airdate/<channel>/<start_date>')

--- a/resources/lib/apihelper.py
+++ b/resources/lib/apihelper.py
@@ -333,7 +333,7 @@ class ApiHelper:
             )
 
             play_info = dict(
-                whatson_id=next_ep.get('whatsonId'),
+                video_id=next_ep.get('videoId'),
             )
 
             next_info = dict(
@@ -353,10 +353,14 @@ class ApiHelper:
                   program=program, season=season, episode=current_ep_no)
         return None
 
-    def get_single_episode(self, whatson_id):
-        ''' Get single episode by whatsonId '''
+    def get_single_episode(self, video_id=None, whatson_id=None):
+        ''' Get single episode by whatsonId or videoId '''
         video = None
-        api_data = self.get_episodes(whatson_id=whatson_id, variety='single')
+        api_data = list()
+        if video_id:
+            api_data = self.get_episodes(video_id=video_id, variety='single')
+        elif whatson_id:
+            api_data = self.get_episodes(whatson_id=whatson_id, variety='single')
         if len(api_data) == 1:
             episode = api_data[0]
             video_item = TitleItem(
@@ -411,7 +415,7 @@ class ApiHelper:
         offairdate_guess = dateutil.parser.parse(episode_guess_on.get('endTime'))
         if (episode_guess_off and episode_guess_on.get('vrt.whatson-id') == episode_guess_off.get('vrt.whatson-id')
                 or (not episode_guess_off and episode_guess_on)):
-            video = self.get_single_episode(episode_guess_on.get('vrt.whatson-id'))
+            video = self.get_single_episode(whatson_id=episode_guess_on.get('vrt.whatson-id'))
             if video:
                 return video
 

--- a/resources/lib/service.py
+++ b/resources/lib/service.py
@@ -68,7 +68,7 @@ class VrtMonitor(Monitor):
         from binascii import unhexlify
         data = loads(unhexlify(hexdata[0]))
         log(2, '[Up Next notification] sender={sender}, method={method}, data={data}', sender=sender, method=method, data=to_unicode(data))
-        jsonrpc(method='Player.Open', params=dict(item=dict(file='plugin://plugin.video.vrt.nu/play/whatson/%s' % data.get('whatson_id'))))
+        jsonrpc(method='Player.Open', params=dict(item=dict(file='plugin://plugin.video.vrt.nu/play/upnext/%s' % data.get('video_id'))))
 
     def onSettingsChanged(self):  # pylint: disable=invalid-name
         ''' Handler for changes to settings '''

--- a/resources/lib/statichelper.py
+++ b/resources/lib/statichelper.py
@@ -139,8 +139,8 @@ def play_url_to_id(url):
     play_id = dict()
     if 'play/id/' in url:
         play_id['video_id'] = url.split('play/id/')[1].split('/')[0]
-    elif 'play/whatson/' in url:
-        play_id['whatson_id'] = url.split('play/whatson/')[1]
+    elif 'play/upnext/' in url:
+        play_id['video_id'] = url.split('play/upnext/')[1]
     elif '/play/url/' in url:
         play_id['video_url'] = video_to_api_url(url.split('play/url/')[1])
     return play_id

--- a/resources/lib/vrtplayer.py
+++ b/resources/lib/vrtplayer.py
@@ -341,11 +341,11 @@ class VRTPlayer:
             return
         self.play(video)
 
-    def play_whatson(self, whatson_id):
-        ''' Play a video by whatson_id '''
-        video = self._apihelper.get_single_episode(whatson_id)
+    def play_upnext(self, video_id):
+        ''' Play the next episode of a program by video_id '''
+        video = self._apihelper.get_single_episode(video_id=video_id)
         if not video:
-            log_error('Play by whatson_id {id} failed', id=whatson_id)
+            log_error('Play Up Next with video_id {video_id} failed', video_id=video_id)
             ok_dialog(message=localize(30954))
             end_of_directory()
             return

--- a/test/test_routing.py
+++ b/test/test_routing.py
@@ -246,10 +246,10 @@ class TestRouting(unittest.TestCase):
                                         start_date=lastweek.strftime('%Y-%m-%dT20:00:00')),
                          lastweek.strftime('plugin://plugin.video.vrt.nu/play/airdate/canvas/%Y-%m-%dT20:00:00'))
 
-    # Play episode by whatsonid method = '/play/whatson/<whatson_id>'
-    def test_play_whatsonid_route(self):
-        addon.run(['plugin://plugin.video.vrt.nu/play/whatson/347056576527', '0', ''])
-        self.assertEqual(plugin.url_for(addon.play_whatson, whatson_id='347056576527'), 'plugin://plugin.video.vrt.nu/play/whatson/347056576527')
+    # Play Up Next episode method = '/play/upnext/<video_id>'
+    def test_play_upnext_route(self):
+        addon.run(['plugin://plugin.video.vrt.nu/play/upnext/vid-a39ab219-9598-4a79-b676-98b724cceff1', '0', ''])
+        self.assertEqual(plugin.url_for(addon.play_upnext, video_id='vid-a39ab219-9598-4a79-b676-98b724cceff1'), 'plugin://plugin.video.vrt.nu/play/upnext/vid-a39ab219-9598-4a79-b676-98b724cceff1')
 
 
 if __name__ == '__main__':

--- a/test/test_statichelper.py
+++ b/test/test_statichelper.py
@@ -63,8 +63,8 @@ class TestStaticHelper(unittest.TestCase):
         play_id = dict(video_id='vid-5b12c0f6-b8fe-426f-a600-557f501f3be9')
         self.assertEqual(play_id, statichelper.play_url_to_id(url))
 
-        url = 'plugin://plugin.video.vrt.nu/play/whatson/705308178527'
-        play_id = dict(whatson_id='705308178527')
+        url = 'plugin://plugin.video.vrt.nu/play/upnext/vid-271d7238-b7f2-4a3c-b3c7-17a5110be71a'
+        play_id = dict(video_id='vid-271d7238-b7f2-4a3c-b3c7-17a5110be71a')
         self.assertEqual(play_id, statichelper.play_url_to_id(url))
 
         url = 'plugin://plugin.video.vrt.nu/play/url/https://www.vrt.be/vrtnu/kanalen/canvas/'

--- a/test/test_vrtplayer.py
+++ b/test/test_vrtplayer.py
@@ -115,9 +115,9 @@ class TestVRTPlayer(unittest.TestCase):
         self._vrtplayer.play_episode_by_air_date(channel='een', start_date='2100-01-01T23:59:58', end_date='2100-01-01T23:59:59')
         self._vrtplayer.play_episode_by_air_date(channel='foo', start_date='2100-01-01T23:59:58', end_date='2100-01-01T23:59:59')
 
-    def test_play_unknown_whatson_id(self):
-        ''' Test playing unknown whatson id '''
-        self._vrtplayer.play_whatson(whatson_id='1234567890')
+    def test_play_unknown_video_id(self):
+        ''' Test playing unknown Up Next video_id '''
+        self._vrtplayer.play_upnext(video_id='1234567890')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
While testing I found out `whatson_id` is not unique. Some episodes have multiple versions on VRT NU, versions with or without audio description or Flemish Sign Language.
It turns out these versions have the same `whatson_id`. 
For instance: Dag Sinterklaas: https://vrtnu-api.vrt.be/search?i=video&facets[whatsonId]=762744552527

This causes Up Next to play a next episode with audio description while previous episodes were played without audio description. 