### PR TITLE
Support base64 payload for Up Next communication

### DIFF
--- a/resources/lib/playerinfo.py
+++ b/resources/lib/playerinfo.py
@@ -126,9 +126,9 @@ class PlayerInfo(Player):
             )
             next_info = self.apihelper.get_upnext(info)
             if next_info:
-                from binascii import hexlify
+                from base64 import b64encode
                 from json import dumps
-                data = [to_unicode(hexlify(dumps(next_info).encode()))]
+                data = [to_unicode(b64encode(dumps(next_info).encode()))]
                 sender = '%s.SIGNAL' % addon_id()
                 notify(sender=sender, message='upnext_data', data=data)
 

--- a/resources/lib/service.py
+++ b/resources/lib/service.py
@@ -56,8 +56,8 @@ class VrtMonitor(Monitor):
                 return
 
             # NOTE: With Python 3.5 and older json.loads() does not support bytes or bytearray, so we convert to unicode
-            from binascii import unhexlify
-            data = loads(to_unicode(unhexlify(hexdata[0])))
+            from base64 import b64decode
+            data = loads(to_unicode(b64decode(hexdata[0])))
             log(2, '[Up Next notification] sender={sender}, method={method}, data={data}', sender=sender, method=method, data=to_unicode(data))
             jsonrpc(method='Player.Open', params=dict(item=dict(file='plugin://plugin.video.vrt.nu/play/upnext/%s' % data.get('video_id'))))
 


### PR DESCRIPTION
Migrate to using a base64-encoded payload for Up Next communication.

This requires Up Next v1.0.5 or newer