### PR TITLE
Fix performance regression and add profiling framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,9 @@ msbuild.wrn
 .pytest_cache/
 .tox/
 
+# Profile data
+*.bin
+
 # Packages
 *.zip
 

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ zip_dir = $(name)/
 
 languages = $(filter-out en_gb, $(patsubst resources/language/resource.language.%, %, $(wildcard resources/language/*)))
 
+path := /
+
 blue = \e[1;34m
 white = \e[1;37m
 reset = \e[0;39m
@@ -57,7 +59,11 @@ unit: clean
 run:
 	@echo -e "$(white)=$(blue) Run CLI$(reset)"
 	$(PYTHON) resources/lib/service_entry.py
-	$(PYTHON) test/run.py /
+	$(PYTHON) test/run.py $(path)
+
+profile:
+	@echo -e "$(white)=$(blue) Profiling $(white)$(path)$(reset)"
+	$(PYTHON) -m cProfile -o profiling_stats-$(git_branch)-$(git_hash).bin test/run.py $(path)
 
 zip: clean
 	@echo -e "$(white)=$(blue) Building new package$(reset)"

--- a/test/read_profiling_stats.py
+++ b/test/read_profiling_stats.py
@@ -1,0 +1,13 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2019, Dag Wieers (@dagwieers) <dag@wieers.com>
+# GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+''' Process profiling stats '''
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+import sys
+import pstats
+
+STATS = pstats.Stats(sys.argv[1])
+STATS.sort_stats('name').print_stats()
+STATS.sort_stats('cumulative').print_stats(20)

--- a/test/xbmc.py
+++ b/test/xbmc.py
@@ -34,6 +34,7 @@ REGIONS = {
 }
 
 settings = global_settings()
+LANGUAGE = import_language(language=settings.get('locale.language'))
 
 
 class Keyboard:
@@ -203,7 +204,7 @@ def getInfoLabel(key):
 
 def getLocalizedString(msgctxt):
     ''' A reimplementation of the xbmc getLocalizedString() function '''
-    for entry in import_language(language=settings.get('locale.language')):
+    for entry in LANGUAGE:
         if entry.msgctxt == '#%s' % msgctxt:
             return entry.msgstr or entry.msgid
     if int(msgctxt) >= 30000:


### PR DESCRIPTION
This PR includes:
- A global ADDON instance to be used by all kodi functions
- A profiling framework in Make and a script to read profiling data
- Reduce some complexity added to avoid instantiating Addon()
- Various additional fixes to improve performance on ListItems
- Fix a performance regression in xbmcaddon stub

The profiling framework may help in the future to find performance regressions.

You can simply do

    $ make profile path=/favorites/recent

To get profile_stats written down to your project directory with branch and commit hash included.
You can do this for different branches to get multiple stats.

Then you can read out this data using:

    $ ./test/read_profiling_stats.py <profile_stats.bin>

And you can start comparing the output from different branches.

This fixes #604 