### PR TITLE
Seamlessly play Up Next episodes

### DIFF
--- a/resources/lib/apihelper.py
+++ b/resources/lib/apihelper.py
@@ -356,16 +356,25 @@ class ApiHelper:
         )
         return next_info
 
-    def get_single_episode(self, video_id=None, whatson_id=None):
-        ''' Get single episode by whatsonId or videoId '''
-        video = None
+    def get_single_episode_data(self, video_id=None, whatson_id=None, video_url=None):
+        ''' Get single episode api data by videoId, whatsonId or url '''
+        episode = None
         api_data = list()
         if video_id:
             api_data = self.get_episodes(video_id=video_id, variety='single')
         elif whatson_id:
             api_data = self.get_episodes(whatson_id=whatson_id, variety='single')
+        elif video_url:
+            api_data = self.get_episodes(video_url=video_url, variety='single')
         if len(api_data) == 1:
             episode = api_data[0]
+        return episode
+
+    def get_single_episode(self, video_id=None, whatson_id=None, video_url=None):
+        ''' Get single episode by videoId, whatsonId or url '''
+        video = None
+        episode = self.get_single_episode_data(video_id=video_id, whatson_id=whatson_id, video_url=video_url)
+        if episode:
             video_item = TitleItem(
                 title=self._metadata.get_label(episode),
                 art_dict=self._metadata.get_art(episode),

--- a/resources/lib/service.py
+++ b/resources/lib/service.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, unicode_literals
 from xbmc import Monitor
 from apihelper import ApiHelper
 from favorites import Favorites
-from kodiutils import container_refresh, invalidate_caches, jsonrpc, log
+from kodiutils import container_refresh, invalidate_caches, log
 from playerinfo import PlayerInfo
 from resumepoints import ResumePoints
 from statichelper import to_unicode
@@ -42,8 +42,7 @@ class VrtMonitor(Monitor):
             if not self._apihelper:
                 self._apihelper = ApiHelper(self._favorites, self._resumepoints)
 
-    @staticmethod
-    def onNotification(sender, method, data):  # pylint: disable=invalid-name
+    def onNotification(self, sender, method, data):  # pylint: disable=invalid-name
         ''' Handler for notifications '''
         # log(2, '[Notification] sender={sender}, method={method}, data={data}', sender=sender, method=method, data=to_unicode(data))
 
@@ -59,7 +58,7 @@ class VrtMonitor(Monitor):
             from binascii import unhexlify
             data = loads(to_unicode(unhexlify(hexdata[0])))
             log(2, '[Up Next notification] sender={sender}, method={method}, data={data}', sender=sender, method=method, data=to_unicode(data))
-            jsonrpc(method='Player.Open', params=dict(item=dict(file='plugin://plugin.video.vrt.nu/play/upnext/%s' % data.get('video_id'))))
+            self._playerinfo.add_upnext(data.get('video_id'))
 
     def onSettingsChanged(self):  # pylint: disable=invalid-name
         ''' Handler for changes to settings '''

--- a/test/xbmc.py
+++ b/test/xbmc.py
@@ -127,12 +127,15 @@ class Player:
 class PlayList:
     ''' A stub implementation of the xbmc PlayList class '''
 
-    def __init__(self):
+    def __init__(self, playList):
         ''' A stub constructor for the xbmc PlayList class '''
 
     def getposition(self):
         ''' A stub implementation for the xbmc PlayList class getposition() method '''
         return 0
+
+    def add(self, url, listitem=None, index=-1):
+        ''' A stub implementation for the xbmc PlayList class add() method '''
 
     def size(self):
         ''' A stub implementation for the xbmc PlayList class size() method '''


### PR DESCRIPTION
Sometimes an "Up Next" episode fails to play because the previous episode caused an `onPlayBackEnded` event while the next episode is still setting up. I experienced this while watching Peulengaleis episodes.

This pull request fixes this problem.