### PR TITLE
Make HTTP cache ttl configurable

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -733,66 +733,74 @@ msgid "Expert"
 msgstr ""
 
 msgctxt "#30901"
-msgid "Cache"
-msgstr ""
-
-msgctxt "#30903"
-msgid "Clear VRT tokens"
-msgstr ""
-
-msgctxt "#30905"
-msgid "Refresh favorites"
-msgstr ""
-
-msgctxt "#30907"
-msgid "Refresh watching activity"
-msgstr ""
-
-msgctxt "#30909"
-msgid "Use menu caching"
-msgstr ""
-
-msgctxt "#30910"
-msgid "When enabled, menus are being cached so they work more quickly. Only in very specific use-cases this is problematic as new episodes may not appear when they are expected. You can also use [B]Refresh[/B] from the context-menu."
-msgstr ""
-
-msgctxt "#30911"
-msgid "Use local HTTP caching"
-msgstr ""
-
-msgctxt "#30913"
-msgid "Invalidate local HTTP caches"
-msgstr ""
-
-msgctxt "#30915"
 msgid "Streaming"
 msgstr ""
 
-msgctxt "#30917"
+msgctxt "#30903"
 msgid "Please install or enable InputStream Adaptive to use this setting"
 msgstr ""
 
-msgctxt "#30919"
+msgctxt "#30905"
 msgid "Use InputStream Adaptive"
 msgstr ""
 
-msgctxt "#30921"
+msgctxt "#30907"
 msgid "InputStream Adaptive settings…"
 msgstr ""
 
-msgctxt "#30923"
+msgctxt "#30909"
 msgid "InputStream Helper information"
 msgstr ""
 
-msgctxt "#30925"
+msgctxt "#30911"
 msgid "InputStream Helper settings… [COLOR gray][I](for protected content)[/I][/COLOR]"
 msgstr ""
 
+msgctxt "#30913"
+msgid "Cache"
+msgstr ""
+
+msgctxt "#30915"
+msgid "Clear VRT tokens"
+msgstr ""
+
+msgctxt "#30917"
+msgid "Refresh favorites"
+msgstr ""
+
+msgctxt "#30919"
+msgid "Refresh watching activity"
+msgstr ""
+
+msgctxt "#30921"
+msgid "Use menu caching"
+msgstr ""
+
+msgctxt "#30922"
+msgid "When enabled, menus are being cached so they work more quickly. Only in very specific use-cases this is problematic as new episodes may not appear when they are expected. You can also use [B]Refresh[/B] from the context-menu."
+msgstr ""
+
+msgctxt "#30923"
+msgid "Use local HTTP caching"
+msgstr ""
+
+msgctxt "#30925"
+msgid "Invalidate local HTTP caches"
+msgstr ""
+
 msgctxt "#30927"
-msgid "Logging"
+msgid "Direct HTTP cache time-to-live [COLOR gray](in minutes)[/COLOR]"
 msgstr ""
 
 msgctxt "#30929"
+msgid "Indirect HTTP cache time-to-live [COLOR gray](in minutes)[/COLOR]"
+msgstr ""
+
+msgctxt "#30931"
+msgid "Logging"
+msgstr ""
+
+msgctxt "#30933"
 msgid "Log level"
 msgstr ""
 

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -733,66 +733,74 @@ msgid "Expert"
 msgstr "Expert"
 
 msgctxt "#30901"
-msgid "Cache"
-msgstr "Cache"
-
-msgctxt "#30903"
-msgid "Clear VRT tokens"
-msgstr "Verwijder VRT-tokens"
-
-msgctxt "#30905"
-msgid "Refresh favorites"
-msgstr "Ververs favoriete programma's"
-
-msgctxt "#30907"
-msgid "Refresh watching activity"
-msgstr "Ververs kijkactiviteit"
-
-msgctxt "#30909"
-msgid "Use menu caching"
-msgstr "Gebruik menu caching"
-
-msgctxt "#30910"
-msgid "When enabled, menus are being cached so they work more quickly. Only in very specific use-cases this is problematic as new episodes may not appear when they are expected. You can also use [B]Refresh[/B] from the context-menu."
-msgstr "Indien geactiveerd worden Kodi menus gecached zodat ze sneller werken. Enkel in heel uitzonderlijke gevallen is het interessanter noodzakelijk om altijd nieuwe episodes te zijn als ze uitkomen. Je kan ook [B]Ververs[/B] gebruiken vanuit het context-menu."
-
-msgctxt "#30911"
-msgid "Use local HTTP caching"
-msgstr "Gebruik lokale HTTP caching"
-
-msgctxt "#30913"
-msgid "Invalidate local HTTP caches"
-msgstr "Maak lokale HTTP caches ongeldig"
-
-msgctxt "#30915"
 msgid "Streaming"
 msgstr "Streaming"
 
-msgctxt "#30917"
+msgctxt "#30903"
 msgid "Please install or enable InputStream Adaptive to use this setting"
 msgstr "Installeer of schakel InputStream Adaptive in voor deze instelling"
 
-msgctxt "#30919"
+msgctxt "#30905"
 msgid "Use InputStream Adaptive"
 msgstr "Gebruik InputStream Adaptive"
 
-msgctxt "#30921"
+msgctxt "#30907"
 msgid "InputStream Adaptive settings…"
 msgstr "InputStream Adaptive instellingen…"
 
-msgctxt "#30923"
+msgctxt "#30909"
 msgid "InputStream Helper information"
 msgstr "InputStream Helper informatie"
 
-msgctxt "#30925"
+msgctxt "#30911"
 msgid "InputStream Helper settings… [COLOR gray][I](for protected content)[/I][/COLOR]"
 msgstr "InputStream Helper instellingen…[COLOR gray][I](voor beveiligde video's)[/I][/COLOR]"
 
+msgctxt "#30913"
+msgid "Cache"
+msgstr "Cache"
+
+msgctxt "#30915"
+msgid "Clear VRT tokens"
+msgstr "Verwijder VRT-tokens"
+
+msgctxt "#30917"
+msgid "Refresh favorites"
+msgstr "Ververs favoriete programma's"
+
+msgctxt "#30919"
+msgid "Refresh watching activity"
+msgstr "Ververs kijkactiviteit"
+
+msgctxt "#30921"
+msgid "Use menu caching"
+msgstr "Gebruik menu caching"
+
+msgctxt "#30922"
+msgid "When enabled, menus are being cached so they work more quickly. Only in very specific use-cases this is problematic as new episodes may not appear when they are expected. You can also use [B]Refresh[/B] from the context-menu."
+msgstr "Indien geactiveerd worden Kodi menus gecached zodat ze sneller werken. Enkel in heel uitzonderlijke gevallen is het interessanter noodzakelijk om altijd nieuwe episodes te zijn als ze uitkomen. Je kan ook [B]Ververs[/B] gebruiken vanuit het context-menu."
+
+msgctxt "#30923"
+msgid "Use local HTTP caching"
+msgstr "Gebruik lokale HTTP caching"
+
+msgctxt "#30925"
+msgid "Invalidate local HTTP caches"
+msgstr "Maak lokale HTTP caches ongeldig"
+
 msgctxt "#30927"
+msgid "Direct HTTP cache time-to-live [COLOR gray](in minutes)[/COLOR]"
+msgstr "Directe HTTP cache time-to-live [COLOR gray](in minuten)[/COLOR]"
+
+msgctxt "#30929"
+msgid "Indirect HTTP cache time-to-live [COLOR gray](in minutes)[/COLOR]"
+msgstr "Indirecte HTTP cache time-to-live [COLOR gray](in minuten)[/COLOR]"
+
+msgctxt "#30931"
 msgid "Logging"
 msgstr "Logboek"
 
-msgctxt "#30929"
+msgctxt "#30933"
 msgid "Log level"
 msgstr "Log niveau"
 

--- a/resources/lib/apihelper.py
+++ b/resources/lib/apihelper.py
@@ -15,7 +15,7 @@ except ImportError:  # Python 2
 from data import CHANNELS
 from helperobjects import TitleItem
 from kodiutils import (delete_cached_thumbnail, get_cache, get_global_setting, get_proxies, get_setting,
-                       has_addon, localize, localize_from_data, log, log_error, ok_dialog, update_cache,
+                       has_addon, localize, localize_from_data, log, log_error, ok_dialog, ttl, update_cache,
                        url_for)
 from statichelper import (add_https_method, convert_html_to_kodilabel, find_entry, from_unicode, play_url_to_id,
                           program_to_url, realpage, to_unicode, strip_newlines, url_to_program)
@@ -57,7 +57,7 @@ class ApiHelper:
         if not category and not channel and not feature:
             params['facets[transcodingStatus]'] = 'AVAILABLE'  # Required for getting results in Suggests API
             cache_file = 'programs.json'
-        tvshows = get_cache(cache_file, ttl=60 * 60)  # Try the cache if it is fresh
+        tvshows = get_cache(cache_file, ttl=ttl('indirect'))  # Try the cache if it is fresh
         if not tvshows:
             from json import loads
             querystring = '&'.join('{}={}'.format(key, value) for key, value in list(params.items()))
@@ -508,12 +508,12 @@ class ApiHelper:
                 params['facets[programType]'] = 'oneoff'
 
             if variety == 'watchlater':
-                self._resumepoints.refresh(ttl=5 * 60)
+                self._resumepoints.refresh(ttl=ttl('direct'))
                 episode_urls = self._resumepoints.watchlater_urls()
                 params['facets[url]'] = '[%s]' % (','.join(episode_urls))
 
             if variety == 'continue':
-                self._resumepoints.refresh(ttl=5 * 60)
+                self._resumepoints.refresh(ttl=ttl('direct'))
                 episode_urls = self._resumepoints.resumepoints_urls()
                 params['facets[url]'] = '[%s]' % (','.join(episode_urls))
 
@@ -564,7 +564,7 @@ class ApiHelper:
         from json import loads
         if cache_file:
             # Get api data from cache if it is fresh
-            search_json = get_cache(cache_file, ttl=60 * 60)
+            search_json = get_cache(cache_file, ttl=ttl('indirect'))
             if not search_json:
                 log(2, 'URL get: {url}', url=unquote(search_url))
                 req = Request(search_url)

--- a/resources/lib/favorites.py
+++ b/resources/lib/favorites.py
@@ -59,7 +59,6 @@ class Favorites:
     def update(self, program, title, value=True):
         ''' Set a program as favorite, and update local copy '''
 
-        self.refresh(ttl=60)
         if value is self.is_favorite(program):
             # Already followed/unfollowed, nothing to do
             return True
@@ -70,6 +69,8 @@ class Favorites:
             log_error('Failed to get favorites token from VRT NU')
             notification(message=localize(30975))
             return False
+
+        self.refresh(ttl=0)
 
         headers = {
             'authorization': 'Bearer ' + xvrttoken,

--- a/resources/lib/kodiutils.py
+++ b/resources/lib/kodiutils.py
@@ -666,7 +666,7 @@ def human_delta(seconds):
     return '%d second%s' % (seconds, 's' if seconds != 1 else '')
 
 
-def get_cache(path, ttl=None):
+def get_cache(path, ttl=None):  # pylint: disable=redefined-outer-name
     ''' Get the content from cache, if it's still fresh '''
     if get_setting('usehttpcaching', 'true') == 'false':
         return None
@@ -723,6 +723,15 @@ def update_cache(path, data):
         from os import utime
         log(3, "Cache '{path}' has not changed, updating mtime only.", path=path)
         utime(path)
+
+
+def ttl(kind='direct'):
+    ''' Return the HTTP cache ttl in seconds based on kind of relation '''
+    if kind == 'direct':
+        return int(get_setting('httpcachettldirect', 5)) * 60
+    if kind == 'indirect':
+        return int(get_setting('httpcachettlindirect', 60)) * 60
+    return 5 * 60
 
 
 def refresh_caches(cache_file=None):

--- a/resources/lib/search.py
+++ b/resources/lib/search.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, unicode_literals
 from favorites import Favorites
 from resumepoints import ResumePoints
 from kodiutils import (addon_profile, container_refresh, end_of_directory, get_search_string,
-                       get_setting, localize, ok_dialog, open_file, show_listing, url_for)
+                       get_setting, localize, ok_dialog, open_file, show_listing, ttl, url_for)
 
 
 class Search:
@@ -103,7 +103,7 @@ class Search:
                 info_dict=dict(),
             ))
 
-        self._favorites.refresh(ttl=60 * 60)
+        self._favorites.refresh(ttl=ttl('indirect'))
         show_listing(search_items, category=30032, sort=sort, ascending=ascending, content=content, cache=False)
 
     def clear(self):

--- a/resources/lib/tvguide.py
+++ b/resources/lib/tvguide.py
@@ -20,7 +20,7 @@ from metadata import Metadata
 from resumepoints import ResumePoints
 from statichelper import find_entry, to_unicode
 from kodiutils import (get_cache, get_proxies, has_addon, localize, localize_datelong, log,
-                       show_listing, update_cache, url_for)
+                       show_listing, ttl, update_cache, url_for)
 
 
 class TVGuide:
@@ -152,12 +152,12 @@ class TVGuide:
         epg = self.parse(date, now)
         epg_url = epg.strftime(self.VRT_TVGUIDE)
 
-        self._favorites.refresh(ttl=60 * 60)
+        self._favorites.refresh(ttl=ttl('indirect'))
 
         cache_file = 'schedule.%s.json' % date
         if date in ('today', 'yesterday', 'tomorrow'):
             # Try the cache if it is fresh
-            schedule = get_cache(cache_file, ttl=60 * 60)
+            schedule = get_cache(cache_file, ttl=ttl('indirect'))
             if not schedule:
                 from json import loads
                 log(2, 'URL get: {url}', url=epg_url)
@@ -209,7 +209,7 @@ class TVGuide:
         if epg.hour < 6:
             epg += timedelta(days=-1)
         # Try the cache if it is fresh
-        schedule = get_cache('schedule.today.json', ttl=60 * 60)
+        schedule = get_cache('schedule.today.json', ttl=ttl('indirect'))
         if not schedule:
             from json import loads
             epg_url = epg.strftime(self.VRT_TVGUIDE)
@@ -247,7 +247,7 @@ class TVGuide:
         if epg.hour < 6:
             epg += timedelta(days=-1)
         # Try the cache if it is fresh
-        schedule = get_cache('schedule.today.json', ttl=60 * 60)
+        schedule = get_cache('schedule.today.json', ttl=ttl('indirect'))
         if not schedule:
             from json import loads
             epg_url = epg.strftime(self.VRT_TVGUIDE)

--- a/resources/lib/vrtplayer.py
+++ b/resources/lib/vrtplayer.py
@@ -9,7 +9,7 @@ from helperobjects import TitleItem
 from resumepoints import ResumePoints
 from statichelper import find_entry
 from kodiutils import (delete_cached_thumbnail, end_of_directory, get_addon_info, get_setting, has_credentials,
-                       localize, log_error, ok_dialog, play, set_setting, show_listing, url_for)
+                       localize, log_error, ok_dialog, play, set_setting, show_listing, ttl, url_for)
 
 
 class VRTPlayer:
@@ -23,7 +23,7 @@ class VRTPlayer:
 
     def show_main_menu(self):
         ''' The VRT NU add-on main menu '''
-        # self._favorites.refresh(ttl=60 * 60)
+        # self._favorites.refresh(ttl=ttl('indirect'))
         main_items = []
 
         # Only add 'My favorites' when it has been activated
@@ -120,7 +120,7 @@ class VRTPlayer:
 
     def show_favorites_menu(self):
         ''' The VRT NU addon 'My programs' menu '''
-        self._favorites.refresh(ttl=60 * 60)
+        self._favorites.refresh(ttl=ttl('indirect'))
         favorites_items = [
             TitleItem(title=localize(30040),  # My programs
                       path=url_for('favorites_programs'),
@@ -175,24 +175,24 @@ class VRTPlayer:
 
     def show_favorites_docu_menu(self):
         ''' The VRT NU add-on 'My documentaries' listing menu '''
-        self._favorites.refresh(ttl=60 * 60)
-        self._resumepoints.refresh(ttl=60 * 60)
+        self._favorites.refresh(ttl=ttl('indirect'))
+        self._resumepoints.refresh(ttl=ttl('indirect'))
         episode_items, sort, ascending, content = self._apihelper.list_episodes(category='docu', season='allseasons', programtype='oneoff')
         show_listing(episode_items, category=30044, sort=sort, ascending=ascending, content=content, cache=False)
 
     def show_tvshow_menu(self, use_favorites=False):
         ''' The VRT NU add-on 'All programs' listing menu '''
         # My favorites menus may need more up-to-date favorites
-        self._favorites.refresh(ttl=5 * 60 if use_favorites else 60 * 60)
-        self._resumepoints.refresh(ttl=5 * 60 if use_favorites else 60 * 60)
+        self._favorites.refresh(ttl=ttl('direct' if use_favorites else 'indirect'))
+        self._resumepoints.refresh(ttl=ttl('direct' if use_favorites else 'indirect'))
         tvshow_items = self._apihelper.list_tvshows(use_favorites=use_favorites)
         show_listing(tvshow_items, category=30440, sort='label', content='tvshows')  # A-Z
 
     def show_category_menu(self, category=None):
         ''' The VRT NU add-on 'Categories' listing menu '''
         if category:
-            self._favorites.refresh(ttl=60 * 60)
-            self._resumepoints.refresh(ttl=60 * 60)
+            self._favorites.refresh(ttl=ttl('indirect'))
+            self._resumepoints.refresh(ttl=ttl('indirect'))
             tvshow_items = self._apihelper.list_tvshows(category=category)
             from data import CATEGORIES
             category_msgctxt = find_entry(CATEGORIES, 'id', category).get('msgctxt')
@@ -205,8 +205,8 @@ class VRTPlayer:
         ''' The VRT NU add-on 'Channels' listing menu '''
         if channel:
             from tvguide import TVGuide
-            self._favorites.refresh(ttl=60 * 60)
-            self._resumepoints.refresh(ttl=60 * 60)
+            self._favorites.refresh(ttl=ttl('indirect'))
+            self._resumepoints.refresh(ttl=ttl('indirect'))
             channel_items = self._apihelper.list_channels(channels=[channel])  # Live TV
             channel_items.extend(TVGuide().get_channel_items(channel=channel))  # TV guide
             channel_items.extend(self._apihelper.list_youtube(channels=[channel]))  # YouTube
@@ -221,8 +221,8 @@ class VRTPlayer:
     def show_featured_menu(self, feature=None):
         ''' The VRT NU add-on 'Featured content' listing menu '''
         if feature:
-            self._favorites.refresh(ttl=60 * 60)
-            self._resumepoints.refresh(ttl=60 * 60)
+            self._favorites.refresh(ttl=ttl('indirect'))
+            self._resumepoints.refresh(ttl=ttl('indirect'))
             tvshow_items = self._apihelper.list_tvshows(feature=feature)
             from data import FEATURED
             feature_msgctxt = find_entry(FEATURED, 'id', feature).get('msgctxt')
@@ -238,8 +238,8 @@ class VRTPlayer:
 
     def show_episodes_menu(self, program, season=None):
         ''' The VRT NU add-on episodes listing menu '''
-        self._favorites.refresh(ttl=60 * 60)
-        self._resumepoints.refresh(ttl=60 * 60)
+        self._favorites.refresh(ttl=ttl('indirect'))
+        self._resumepoints.refresh(ttl=ttl('indirect'))
         episode_items, sort, ascending, content = self._apihelper.list_episodes(program=program, season=season)
         # FIXME: Translate program in Program Title
         show_listing(episode_items, category=program.title(), sort=sort, ascending=ascending, content=content, cache=False)
@@ -249,8 +249,8 @@ class VRTPlayer:
         from statichelper import realpage
 
         # My favorites menus may need more up-to-date favorites
-        self._favorites.refresh(ttl=5 * 60 if use_favorites else 60 * 60)
-        self._resumepoints.refresh(ttl=5 * 60 if use_favorites else 60 * 60)
+        self._favorites.refresh(ttl=ttl('direct' if use_favorites else 'indirect'))
+        self._resumepoints.refresh(ttl=ttl('direct' if use_favorites else 'indirect'))
         page = realpage(page)
         episode_items, sort, ascending, content = self._apihelper.list_episodes(page=page, use_favorites=use_favorites, variety='recent')
 
@@ -274,8 +274,8 @@ class VRTPlayer:
         from statichelper import realpage
 
         # My favorites menus may need more up-to-date favorites
-        self._favorites.refresh(ttl=5 * 60 if use_favorites else 60 * 60)
-        self._resumepoints.refresh(ttl=5 * 60 if use_favorites else 60 * 60)
+        self._favorites.refresh(ttl=ttl('direct' if use_favorites else 'indirect'))
+        self._resumepoints.refresh(ttl=ttl('direct' if use_favorites else 'indirect'))
         page = realpage(page)
         episode_items, sort, ascending, content = self._apihelper.list_episodes(page=page, use_favorites=use_favorites, variety='offline')
 
@@ -299,8 +299,8 @@ class VRTPlayer:
         from statichelper import realpage
 
         # My watch later menu may need more up-to-date favorites
-        self._favorites.refresh(ttl=5 * 60)
-        self._resumepoints.refresh(ttl=5 * 60)
+        self._favorites.refresh(ttl=ttl('direct'))
+        self._resumepoints.refresh(ttl=ttl('direct'))
         page = realpage(page)
         episode_items, sort, ascending, content = self._apihelper.list_episodes(page=page, variety='watchlater')
         show_listing(episode_items, category=30050, sort=sort, ascending=ascending, content=content, cache=False)
@@ -310,8 +310,8 @@ class VRTPlayer:
         from statichelper import realpage
 
         # Continue watching menu may need more up-to-date favorites
-        self._favorites.refresh(ttl=5 * 60)
-        self._resumepoints.refresh(ttl=5 * 60)
+        self._favorites.refresh(ttl=ttl('direct'))
+        self._resumepoints.refresh(ttl=ttl('direct'))
         page = realpage(page)
         episode_items, sort, ascending, content = self._apihelper.list_episodes(page=page, variety='continue')
         show_listing(episode_items, category=30052, sort=sort, ascending=ascending, content=content, cache=False)

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -60,20 +60,22 @@
         <setting label="30881" help="30882" type="action" action="InstallAddon(script.module.pysocks)" visible="!System.HasAddon(script.module.pysocks)"/>
     </category>
     <category label="30900"> <!-- Expert -->
-        <setting label="30901" type="lsep"/> <!-- Cache -->
-        <setting label="30903" help="30904" type="action" action="RunPlugin(plugin://plugin.video.vrt.nu/tokens/delete)"/> <!-- Delete tokens -->
-        <setting label="30905" help="30906" type="action" action="RunPlugin(plugin://plugin.video.vrt.nu/favorites/refresh)"/> <!-- Refresh favorites -->
-        <setting label="30907" help="30908" type="action" action="RunPlugin(plugin://plugin.video.vrt.nu/resumepoints/refresh)"/> <!-- Refresh resumepoints -->
-        <setting label="30909" help="30910" type="bool" id="usemenucaching" default="true"/>
-        <setting label="30911" help="30912" type="bool" id="usehttpcaching" default="true"/>
-        <setting label="30913" help="30914" type="action" action="RunPlugin(plugin://plugin.video.vrt.nu/cache/delete)" enable="eq(-1,true)" subsetting="true"/>
-        <setting label="30915" type="lsep"/> <!-- InputStream Adaptive -->
-        <setting label="30917" type="action" visible="!System.HasAddon(inputstream.adaptive)" enable="false"/>
-        <setting label="30919" help="30920" type="bool" id="useinputstreamadaptive" default="true" visible="System.HasAddon(inputstream.adaptive)"/>
-        <setting label="30921" help="30922" type="action" option="close" action="Addon.OpenSettings(inputstream.adaptive)" visible="System.HasAddon(inputstream.adaptive) + [String.StartsWith(System.BuildVersion,18) | String.StartsWith(System.BuildVersion,19)]" enable="eq(-1,true)" subsetting="true"/> <!-- InputStream Adaptive settings -->
-        <setting label="30923" help="30924" type="action" action="RunScript(script.module.inputstreamhelper, info)" enable="eq(-2,true)"/> <!-- InputStream Helper information -->
-        <setting label="30925" help="30926" type="action" option="close" action="Addon.OpenSettings(script.module.inputstreamhelper)" enable="eq(-3,true)" subsetting="true"/> <!-- InputStream Helper settings -->
-        <setting label="30927" type="lsep"/> <!-- Logging -->
-        <setting label="30929" help="30930" type="enum" id="max_log_level" lvalues="30430|30431|30432|30433" default="0"/>
+        <setting label="30901" type="lsep"/> <!-- InputStream Adaptive -->
+        <setting label="30903" type="action" visible="!System.HasAddon(inputstream.adaptive)" enable="false"/>
+        <setting label="30905" help="30906" type="bool" id="useinputstreamadaptive" default="true" visible="System.HasAddon(inputstream.adaptive)"/>
+        <setting label="30907" help="30908" type="action" option="close" action="Addon.OpenSettings(inputstream.adaptive)" visible="System.HasAddon(inputstream.adaptive) + [String.StartsWith(System.BuildVersion,18) | String.StartsWith(System.BuildVersion,19)]" enable="eq(-1,true)" subsetting="true"/> <!-- InputStream Adaptive settings -->
+        <setting label="30909" help="30910" type="action" action="RunScript(script.module.inputstreamhelper, info)" enable="eq(-2,true)"/> <!-- InputStream Helper information -->
+        <setting label="30911" help="30912" type="action" option="close" action="Addon.OpenSettings(script.module.inputstreamhelper)" enable="eq(-3,true)" subsetting="true"/> <!-- InputStream Helper settings -->
+        <setting label="30913" type="lsep"/> <!-- Cache -->
+        <setting label="30915" help="30916" type="action" action="RunPlugin(plugin://plugin.video.vrt.nu/tokens/delete)"/> <!-- Delete tokens -->
+        <setting label="30917" help="30918" type="action" action="RunPlugin(plugin://plugin.video.vrt.nu/favorites/refresh)"/> <!-- Refresh favorites -->
+        <setting label="30919" help="30920" type="action" action="RunPlugin(plugin://plugin.video.vrt.nu/resumepoints/refresh)"/> <!-- Refresh resumepoints -->
+        <setting label="30921" help="30922" type="bool" id="usemenucaching" default="true"/>
+        <setting label="30923" help="30924" type="bool" id="usehttpcaching" default="true"/>
+        <setting label="30925" help="30926" type="action" action="RunPlugin(plugin://plugin.video.vrt.nu/cache/delete)" enable="eq(-1,true)" subsetting="true"/>
+        <setting label="30927" help="30928" type="slider" id="httpcachettldirect" default="5" range="1,1,240" option="int" enable="eq(-2,true)" subsetting="true"/>
+        <setting label="30929" help="30930" type="slider" id="httpcachettlindirect" default="60" range="1,1,240" option="int" enable="eq(-3,true)" subsetting="true"/>
+        <setting label="30931" type="lsep"/> <!-- Logging -->
+        <setting label="30933" help="30934" type="enum" id="max_log_level" lvalues="30430|30431|30432|30433" default="0"/>
     </category>
 </settings>

--- a/test/userdata/addon_settings.json
+++ b/test/userdata/addon_settings.json
@@ -6,6 +6,8 @@
         "_comment": "do-not-add-username-and-password-here",
         "canvas": "true",
         "een": "true",
+        "httpcachettldirect": "5",
+        "httpcachettlindirect": "60",
         "ketnet": "false",
         "ketnet-jr": "false",
         "klara": "true",


### PR DESCRIPTION
This makes the HTTP cache ttl configurable rather than hard-coded.

We implemented a 'direct' cache ttl (5min) and an 'indirect' cache
ttl (60min)based on the relation the cache has to the listing that
requires it.

This fixes #541 