### PR TITLE
More PlayerInfo improvements

### DIFF
--- a/resources/lib/kodiutils.py
+++ b/resources/lib/kodiutils.py
@@ -789,6 +789,15 @@ def container_update(url=None):
         container_refresh()
 
 
+def container_reload(url=None):
+    ''' Only update container if the play action was initiated from it '''
+    if url is None:
+        url = get_property('container.url')
+    if current_container_url() != url:
+        return
+    container_update(url)
+
+
 def end_of_directory():
     ''' Close a virtual directory, required to avoid a waiting Kodi '''
     from addon import plugin

--- a/resources/lib/playerinfo.py
+++ b/resources/lib/playerinfo.py
@@ -4,13 +4,12 @@
 
 from __future__ import absolute_import, division, unicode_literals
 from threading import Event, Thread
-from kodiutils import (addon_id, current_container_url, container_update, get_property, get_setting, has_addon, log, notify)
 from xbmc import getInfoLabel, Player
-from statichelper import play_url_to_id, to_unicode, url_to_episode
 from apihelper import ApiHelper
 from favorites import Favorites
 from resumepoints import ResumePoints
-from data import SECONDS_MARGIN
+from statichelper import play_url_to_id, to_unicode, url_to_episode
+from kodiutils import addon_id, container_reload, get_setting, has_addon, log, notify
 
 
 class PlayerInfo(Player):
@@ -18,21 +17,22 @@ class PlayerInfo(Player):
 
     def __init__(self):
         ''' PlayerInfo initialisation '''
-        self.path = None
-        self.listen = False
         self.resumepoints = ResumePoints()
         self.apihelper = ApiHelper(Favorites(), self.resumepoints)
-        self.paused = False
         self.last_pos = None
+        self.listen = False
+        self.paused = False
         self.total = 900
-        self.stop = Event()
+        self.quit = Event()
+
         self.asset_id = None
+        self.path = None
         self.title = None
         self.url = None
         self.whatson_id = None
         from random import randint
         self.thread_id = randint(1, 10001)
-        log(3, '[PlayerInfo] %d initialized' % self.thread_id)
+        log(3, '[PlayerInfo %d] Initialized' % self.thread_id)
         Player.__init__(self)
 
     def onPlayBackStarted(self):  # pylint: disable=invalid-name
@@ -43,6 +43,8 @@ class PlayerInfo(Player):
         else:
             self.listen = False
             return
+
+        log(3, '[PlayerInfo %d] Event onPlayBackStarted' % self.thread_id)
 
         # Get asset_id, title and url from api
         ep_id = play_url_to_id(self.path)
@@ -59,15 +61,18 @@ class PlayerInfo(Player):
         self.url = url_to_episode(episode.get('url', ''))
         self.whatson_id = episode.get('whatsonId')
 
+        self.update_position()
+        self.push_position(position=self.last_pos, total=self.total, event='onPlayBackStarted')
+
     def onAVStarted(self):  # pylint: disable=invalid-name
         ''' Called when Kodi has a video or audiostream '''
         if not self.listen:
             return
-        log(3, '[PlayerInfo] %d onAVStarted' % self.thread_id)
-        self.stop.clear()
-        self.last_pos = 0
-        self.total = self.getTotalTime()
-        self.push_upnext()
+        log(3, '[PlayerInfo %d] Event onAVStarted' % self.thread_id)
+        self.quit.clear()
+        self.update_position()
+        self.update_total()
+
         Thread(target=self.stream_position, name='StreamPosition').start()
 
     def onAVChange(self):  # pylint: disable=invalid-name
@@ -77,75 +82,84 @@ class PlayerInfo(Player):
         ''' Called when user seeks to a time '''
         if not self.listen:
             return
-        log(3, '[PlayerInfo] %d onPlayBackSeek time=%d offset=%d' % (self.thread_id, time, seekOffset))
+        log(3, '[PlayerInfo %d] Event onPlayBackSeek time=%d offset=%d' % (self.thread_id, time, seekOffset))
         self.last_pos = time // 1000
+
+        # If we seek beyond the end, quit Player
+        if self.last_pos >= self.total:
+            self.quit.set()
+            self.stop()
 
     def onPlayBackPaused(self):  # pylint: disable=invalid-name
         ''' Called when user pauses a playing file '''
         if not self.listen:
             return
-        log(3, '[PlayerInfo] %d onPlayBackPaused' % self.thread_id)
+        log(3, '[PlayerInfo %d] Event onPlayBackPaused' % self.thread_id)
+        self.update_position()
+        self.push_position(position=self.last_pos, total=self.total, event='onPlayBackPaused')
         self.paused = True
-        self.push_position(position=self.last_pos, total=self.total)
 
     def onPlayBackResumed(self):  # pylint: disable=invalid-name
         ''' Called when user resumes a paused file or a next playlist item is started '''
         if not self.listen:
             return
         suffix = 'after pausing' if self.paused else 'after playlist change'
-        log(3, '[PlayerInfo] %d onPlayBackResumed %s' % (self.thread_id, suffix))
+        log(3, '[PlayerInfo %d] Event onPlayBackResumed %s' % (self.thread_id, suffix))
         if not self.paused:
-            self.push_position(position=self.last_pos, total=self.total)
+            self.update_position()
+            self.push_position(position=self.last_pos, total=self.total, event='onPlayBackResumed')
         self.paused = False
 
     def onPlayBackEnded(self):  # pylint: disable=invalid-name
         ''' Called when Kodi has ended playing a file '''
         if not self.listen:
             return
-        log(3, '[PlayerInfo] %d onPlayBackEnded' % self.thread_id)
-        self.push_position(position=self.total, total=self.total)
-        self.stop.set()
+        self.quit.set()
+        log(3, '[PlayerInfo %d] Event onPlayBackEnded' % self.thread_id)
+        self.last_pos = self.total
+        # self.push_position(position=self.total, total=self.total, event='onPlayBackEnded')
 
     def onPlayBackError(self):  # pylint: disable=invalid-name
         ''' Called when playback stops due to an error '''
         if not self.listen:
             return
-        log(3, '[PlayerInfo] %d onPlayBackError' % self.thread_id)
-        self.push_position(position=self.last_pos, total=self.total)
-        self.stop.set()
+        self.quit.set()
+        log(3, '[PlayerInfo %d] Event onPlayBackError' % self.thread_id)
+        # self.push_position(position=self.last_pos, total=self.total, event='onPlayBackError')
 
     def onPlayBackStopped(self):  # pylint: disable=invalid-name
         ''' Called when user stops Kodi playing a file '''
         if not self.listen:
             return
-        log(3, '[PlayerInfo] %d onPlayBackStopped' % self.thread_id)
-        self.push_position(position=self.last_pos, total=self.total)
-        self.stop.set()
+        self.quit.set()
+        log(3, '[PlayerInfo %d] Event onPlayBackStopped' % self.thread_id)
+        # self.push_position(position=self.last_pos, total=self.total, event='onPlayBackStopped')
 
     def onThreadExit(self):  # pylint: disable=invalid-name
         ''' Called when player stops, before the player exited, so before the menu refresh '''
-        log(3, '[PlayerInfo] %d onThreadExit' % self.thread_id)
+        log(3, '[PlayerInfo %d] Event onThreadExit' % self.thread_id)
+        self.push_position(position=self.last_pos, total=self.total, event='onThreadExit')
 
     def stream_position(self):
         ''' Get latest stream position while playing '''
-        while self.isPlaying() and not self.stop.is_set():
-            self.last_pos = self.getTime()
-            if self.stop.wait(timeout=0.5):
+        self.push_upnext()
+        while self.isPlaying() and not self.quit.is_set():
+            self.update_position()
+            if self.quit.wait(timeout=0.2):
                 break
         self.onThreadExit()
 
     def push_upnext(self):
         ''' Push episode info to Up Next service add-on'''
         if has_addon('service.upnext') and get_setting('useupnext', 'true') == 'true':
-            tag = self.getVideoInfoTag()
-            info = dict(
-                program=to_unicode(tag.getTVShowTitle()),
-                playcount=tag.getPlayCount(),
-                rating=tag.getRating(),
+            info_tag = self.getVideoInfoTag()
+            next_info = self.apihelper.get_upnext(dict(
+                program=to_unicode(info_tag.getTVShowTitle()),
+                playcount=info_tag.getPlayCount(),
+                rating=info_tag.getRating(),
                 path=self.path,
                 runtime=self.total,
-            )
-            next_info = self.apihelper.get_upnext(info)
+            ))
             if next_info:
                 from binascii import hexlify
                 from json import dumps
@@ -153,26 +167,44 @@ class PlayerInfo(Player):
                 sender = '%s.SIGNAL' % addon_id()
                 notify(sender=sender, message='upnext_data', data=data)
 
-    def push_position(self, position=0, total=100):
+    def update_position(self):
+        ''' Update the player position, when possible '''
+        try:
+            self.last_pos = self.getTime()
+        except RuntimeError:
+            pass
+
+    def update_total(self):
+        ''' Update the total video time '''
+        try:
+            self.total = self.getTotalTime()
+        except RuntimeError:
+            pass
+
+    def push_position(self, position=0, total=100, event=None):
         ''' Push player position to VRT NU resumepoints API '''
+        # Not all content has an asset_id
+        if not self.asset_id:
+            return
+
         # Push resumepoint to VRT NU
         self.resumepoints.update(
             asset_id=self.asset_id,
             title=self.title,
             url=self.url,
-            watch_later=None,
             position=position,
             total=total,
             whatson_id=self.whatson_id,
             asynchronous=True
         )
-        # Refresh Kodi watch status only needed after playing Up Next episodes
-        # or to overwrite watched/unwatched
-        if ((self.path and self.path.startswith('plugin://plugin.video.vrt.nu/play/upnext/'))
-                or SECONDS_MARGIN > position or position > total - SECONDS_MARGIN):
-            # Only update container if the play action was initiated from it
-            original_container = get_property('container.url')
-            current_container = current_container_url()
-            if current_container is None or current_container == original_container:
-                log(3, '[PlayerInfo] %d Reload container' % self.thread_id)
-                container_update(original_container)
+
+        # Do not reload container when we are not done playing
+        if event not in ('onPlayBackEnded', 'onPlayBackError', 'onPlayBackStopped'):
+            return
+
+        # Do not reload container when playing or not stopped
+        if self.isPlaying() or not self.quit.is_set():
+            return
+
+        # Only reload if we originated from this menu
+        container_reload()

--- a/resources/lib/service.py
+++ b/resources/lib/service.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, unicode_literals
 from xbmc import Monitor
 from apihelper import ApiHelper
 from favorites import Favorites
-from kodiutils import (container_refresh, invalidate_caches, jsonrpc, log)
+from kodiutils import container_refresh, invalidate_caches, jsonrpc, log
 from playerinfo import PlayerInfo
 from resumepoints import ResumePoints
 from statichelper import to_unicode


### PR DESCRIPTION
This PR includes:
- Catch exception when getting position or totaltime
- Push upnext in thread
- A new container_reload() which only reloads the original menu
- Change conditions of when container needs to be reloaded (disable it seems to work)
- Quit player when we seek to the end (this was broken by something?)

This includes the safer/saner bits from #567 