### PR TITLE
Rename internal representation _data

### DIFF
--- a/test/test_resumepoints.py
+++ b/test/test_resumepoints.py
@@ -53,13 +53,13 @@ class TestResumePoints(unittest.TestCase):
     def test_update_watchlater(self):
         ''' Test updating the watch later list '''
         self._resumepoints.refresh(ttl=0)
-        asset_id, first_entry = next(iter(list(self._resumepoints._resumepoints.items())))  # pylint: disable=protected-access
+        asset_id, first_entry = next(iter(list(self._resumepoints._data.items())))  # pylint: disable=protected-access
         print('%s = %s' % (asset_id, first_entry))
         url = first_entry.get('value').get('url')
         self._resumepoints.watchlater(asset_id=asset_id, title='Foo bar', url=url)
         self._resumepoints.unwatchlater(asset_id=asset_id, title='Foo bar', url=url)
         self._resumepoints.refresh(ttl=0)
-        asset_id, first_entry = next(iter(list(self._resumepoints._resumepoints.items())))  # pylint: disable=protected-access
+        asset_id, first_entry = next(iter(list(self._resumepoints._data.items())))  # pylint: disable=protected-access
         print('%s = %s' % (asset_id, first_entry))
 
     def test_assetpath_to_id(self):


### PR DESCRIPTION
Something that bothered me for some time is that the internal representation was called _favorites or _resumepoints and this is confusing as local instances would also be called _favorites or _resumepoints. Renaming it to _data.