### PR TITLE
Extend jsonrpc() to support list of commands

### DIFF
--- a/resources/lib/kodiutils.py
+++ b/resources/lib/kodiutils.py
@@ -747,12 +747,28 @@ def log_error(message, **kwargs):
     xbmc.log(from_unicode(message), 4)
 
 
-def jsonrpc(**kwargs):
+def jsonrpc(*args, **kwargs):
     ''' Perform JSONRPC calls '''
     from json import dumps, loads
-    if 'id' not in kwargs:
-        kwargs.update(id=1)
-    if 'jsonrpc' not in kwargs:
+
+    # We do not accept both args and kwargs
+    if args and kwargs:
+        log_error('Wrong use of jsonrpc()')
+        return None
+
+    # Process a list of actions
+    if args:
+        for (idx, cmd) in enumerate(args):
+            if cmd.get('id') is None:
+                cmd.update(id=idx)
+            if cmd.get('jsonrpc') is None:
+                cmd.update(jsonrpc='2.0')
+        return loads(xbmc.executeJSONRPC(dumps(args)))
+
+    # Process a single action
+    if kwargs.get('id') is None:
+        kwargs.update(id=0)
+    if kwargs.get('jsonrpc') is None:
         kwargs.update(jsonrpc='2.0')
     return loads(xbmc.executeJSONRPC(dumps(kwargs)))
 

--- a/test/test_kodiutils.py
+++ b/test/test_kodiutils.py
@@ -81,6 +81,19 @@ class TestKodiUtils(unittest.TestCase):
         ''' Test if Kodi supports DRM '''
         self.assertTrue(kodiutils.supports_drm())
 
+    def test_jsonrpc(self):
+        ''' Test jsonrpc functionality '''
+        ret = kodiutils.jsonrpc(method='Input.Down')
+        self.assertTrue(isinstance(ret, dict))
+
+        ret = kodiutils.jsonrpc(dict(method='Input.Down'))
+        self.assertTrue(isinstance(ret, list))
+        self.assertEqual(len(ret), 1)
+
+        ret = kodiutils.jsonrpc(dict(method='Input.Down'), dict(method='Player.Open'))
+        self.assertTrue(isinstance(ret, list))
+        self.assertEqual(len(ret), 2)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This extends the existing interface to support more than one command.

So you can now do any of the below:
```python
jsonrpc(method='Input.Down')  # Use kwargs (as used now)
jsonrpc(dict(method='Input.Down'))  # Use dict as arg
jsonrpc(dict(method='Input.Down'), dict(method='Input.Up'))  # Use dicts as args
```