### PR TITLE
Close settings when installing an add-on

### DIFF
--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -45,19 +45,19 @@
     <category label="30860"> <!--Integration -->
         <setting label="30861" type="lsep"/> <!-- Integration with other add-ons -->
         <!-- YouTube -->
-        <setting label="30863" help="30864" type="action" action="InstallAddon(plugin.video.youtube)" visible="!System.HasAddon(plugin.video.youtube)"/> <!-- Install YouTube add-on -->
+        <setting label="30863" help="30864" type="action" action="InstallAddon(plugin.video.youtube)" option="close" visible="!System.HasAddon(plugin.video.youtube)"/> <!-- Install YouTube add-on -->
         <setting label="30865" help="30866" type="bool" id="showyoutube" default="true" visible="System.HasAddon(plugin.video.youtube)"/>
         <setting label="30867" help="30868" type="action" option="close" action="Addon.OpenSettings(plugin.video.youtube)" enable="eq(-1,true)" visible="System.HasAddon(plugin.video.youtube)" subsetting="true"/> <!-- YouTube settings -->
         <!-- UpNext -->
-        <setting label="30869" help="30870" type="action" action="InstallAddon(service.upnext)" visible="!System.HasAddon(service.upnext)"/> <!-- Install Up Next add-on -->
+        <setting label="30869" help="30870" type="action" action="InstallAddon(service.upnext)" option="close" visible="!System.HasAddon(service.upnext)"/> <!-- Install Up Next add-on -->
         <setting label="30871" help="30872" type="bool" id="useupnext" default="true" visible="System.HasAddon(service.upnext)" />
         <setting label="30873" help="30874" type="action" action="Addon.OpenSettings(service.upnext)" enable="eq(-1,true)" option="close" visible="System.HasAddon(service.upnext)" subsetting="true"/> <!-- Up Next settings -->
         <!-- Twitter -->
-        <!-- setting label="30875" help="30876" type="action" action="InstallAddon(service.twitter)" visible="!System.HasAddon(service.twitter)"/ -->
+        <!-- setting label="30875" help="30876" type="action" action="InstallAddon(service.twitter)" option="close" visible="!System.HasAddon(service.twitter)"/ -->
         <setting label="30877" help="30878" type="bool" id="usetwitter" default="true" visible="System.HasAddon(service.twitter)"/>
         <setting label="30879" help="30880" type="action" option="close" action="Addon.OpenSettings(service.twitter)" enable="eq(-1,true)" visible="System.HasAddon(service.twitter)" subsetting="true"/>
         <!-- PySocks -->
-        <setting label="30881" help="30882" type="action" action="InstallAddon(script.module.pysocks)" visible="!System.HasAddon(script.module.pysocks)"/>
+        <setting label="30881" help="30882" type="action" action="InstallAddon(script.module.pysocks)" option="close" visible="!System.HasAddon(script.module.pysocks)"/>
     </category>
     <category label="30900"> <!-- Expert -->
         <setting label="30901" type="lsep"/> <!-- InputStream Adaptive -->


### PR DESCRIPTION
If you don't close the settings, the newly installed add-on does not
trigger an update of the settings. So we need to close it and hope the
user returns to see the settings have changed.