### PR TITLE
Don't update total to 0.0

### DIFF
--- a/resources/lib/playerinfo.py
+++ b/resources/lib/playerinfo.py
@@ -193,7 +193,10 @@ class PlayerInfo(Player):
     def update_total(self):
         ''' Update the total video time '''
         try:
-            self.total = self.getTotalTime()
+            total = self.getTotalTime()
+            # Kodi Player sometimes returns a total time of 0.0 and this causes unwanted behaviour with VRT NU Resumepoints API.
+            if total > 0.0:
+                self.total = total
         except RuntimeError:
             pass
 


### PR DESCRIPTION
Another Kodi bug that came to surface, Kodi Player sometimes returns a total time of 0.0 and this causes unwanted behaviour with VRT NU Resumepoints API.
We should ignore this zero value and pass the previous value or the initial `None` value to VRT NU Resumepoints API.