### PR TITLE
Assorted resumepoint fixes

### DIFF
--- a/test/test_resumepoints.py
+++ b/test/test_resumepoints.py
@@ -57,8 +57,8 @@ class TestResumePoints(unittest.TestCase):
         asset_id, first_entry = next(iter(list(self._resumepoints._data.items())))  # pylint: disable=protected-access
         print('%s = %s' % (asset_id, first_entry))
         url = first_entry.get('value').get('url')
-        self._resumepoints.watchlater(asset_id=asset_id, title='Foo bar', url=url)
         self._resumepoints.unwatchlater(asset_id=asset_id, title='Foo bar', url=url)
+        self._resumepoints.watchlater(asset_id=asset_id, title='Foo bar', url=url)
         self._resumepoints.refresh(ttl=0)
         asset_id, first_entry = next(iter(list(self._resumepoints._data.items())))  # pylint: disable=protected-access
         print('%s = %s' % (asset_id, first_entry))

--- a/test/test_routing.py
+++ b/test/test_routing.py
@@ -185,12 +185,13 @@ class TestRouting(unittest.TestCase):
         self.assertEqual(plugin.url_for(addon.favorites_manage), 'plugin://plugin.video.vrt.nu/favorites/manage')
 
     def test_watchlater_route(self):
-        """Watch later method: plugin://plugin.video.vrt.nu/watchlater/<url>/<asset_id>/<title>"""
+        """Watch and unwatch later method: plugin://plugin.video.vrt.nu/watchlater/<url>/<asset_id>/<title>"""
+
+        # Watchlater Winteruur met Lize Feryn (beschikbaar tot 26 maart 2025)
         addon.run(['plugin://plugin.video.vrt.nu/watchlater//vrtnu/a-z/winteruur/5/winteruur-s5a1//contentdamvrt20191015winteruurr005a0001depotwp00162177/Winteruur', '0', ''])
         self.assertEqual(plugin.url_for(addon.watchlater, url='/vrtnu/a-z/winteruur/5/winteruur-s5a1', asset_id='/contentdamvrt20191015winteruurr005a0001depotwp00162177', title='Winteruur'), 'plugin://plugin.video.vrt.nu/watchlater//vrtnu/a-z/winteruur/5/winteruur-s5a1//contentdamvrt20191015winteruurr005a0001depotwp00162177/Winteruur')
 
-    def test_unwatchlater_route(self):
-        """Unwatch later method: plugin://plugin.video.vrt.nu/unwatchlater/<url>/<asset_id>/<title>"""
+        # Unwatchlater Winteruur met Lize Feryn (beschikbaar tot 26 maart 2025)
         addon.run(['plugin://plugin.video.vrt.nu/unwatchlater//vrtnu/a-z/winteruur/5/winteruur-s5a1//contentdamvrt20191015winteruurr005a0001depotwp00162177/Winteruur', '0', ''])
         self.assertEqual(plugin.url_for(addon.unwatchlater, url='/vrtnu/a-z/winteruur/5/winteruur-s5a1', asset_id='/contentdamvrt20191015winteruurr005a0001depotwp00162177', title='Winteruur'), 'plugin://plugin.video.vrt.nu/unwatchlater//vrtnu/a-z/winteruur/5/winteruur-s5a1//contentdamvrt20191015winteruurr005a0001depotwp00162177/Winteruur')
 


### PR DESCRIPTION
This pull request includes:
- Avoid setting resumepoints for livestreams
- Avoid updating resumepoints with data from previous episode
- Avoid sending zero position values because this triggers unwanted resumepoint deletion
- Move local resumepoint cache updates to separate functions
- Use `update_online` json response to update local cache
- Make sure unit tests don't remove existing watchLater episodes or permanently add new watchLater episodes