### PR TITLE
Only listen to vrt nu add-on urls

### DIFF
--- a/resources/lib/playerinfo.py
+++ b/resources/lib/playerinfo.py
@@ -45,7 +45,7 @@ class PlayerInfo(Player, object):  # pylint: disable=useless-object-inheritance
     def onPlayBackStarted(self):  # pylint: disable=invalid-name
         """Called when user starts playing a file"""
         self.path = getInfoLabel(self.path_infolabel)
-        if addon_id() == 'plugin.video.vrt.nu':
+        if self.path.startswith('plugin://plugin.video.vrt.nu/'):
             self.listen = True
         else:
             self.listen = False


### PR DESCRIPTION
I introduced this regression in https://github.com/pietje666/plugin.video.vrt.nu/commit/534687ef29268e352ec65887ba35bcfd78ca960f
This reverts this change to the previously working code, I tested this again on Kodi 17  and 18 and it works.