### PR TITLE
Fallback to web scraping for watching activity

### DIFF
--- a/resources/lib/playerinfo.py
+++ b/resources/lib/playerinfo.py
@@ -11,7 +11,7 @@ from data import CHANNELS
 from favorites import Favorites
 from kodiutils import addon_id, get_setting, has_addon, kodi_version, log, notify, set_property
 from resumepoints import ResumePoints
-from utils import assetpath_to_id, play_url_to_id, to_unicode, url_to_episode
+from utils import play_url_to_id, to_unicode, url_to_episode
 
 
 class PlayerInfo(Player, object):  # pylint: disable=useless-object-inheritance
@@ -79,7 +79,8 @@ class PlayerInfo(Player, object):  # pylint: disable=useless-object-inheritance
         if episode is None:
             return
 
-        self.asset_id = assetpath_to_id(episode.get('assetPath'))
+        from metadata import Metadata
+        self.asset_id = Metadata(None, None).get_asset_id(episode)
         self.title = episode.get('program')
         self.url = url_to_episode(episode.get('url', ''))
         self.whatson_id = episode.get('whatsonId') or None  # Avoid empty string

--- a/resources/lib/tvguide.py
+++ b/resources/lib/tvguide.py
@@ -153,6 +153,7 @@ class TVGuide:
         epg_url = epg.strftime(self.VRT_TVGUIDE)
 
         self._favorites.refresh(ttl=ttl('indirect'))
+        self._resumepoints.refresh(ttl=ttl('indirect'))
 
         cache_file = 'schedule.%s.json' % date
         if date in ('today', 'yesterday', 'tomorrow'):

--- a/resources/lib/utils.py
+++ b/resources/lib/utils.py
@@ -143,6 +143,9 @@ def url_to_episode(url):
     if url.startswith('//www.vrt.be/vrtnu/a-z/'):
         # medium episode url
         return url.replace('//www.vrt.be/vrtnu/a-z/', '/vrtnu/a-z/')
+    if url.startswith('/vrtnu/a-z/'):
+        # short episode url
+        return url
     return None
 
 

--- a/resources/lib/webscraper.py
+++ b/resources/lib/webscraper.py
@@ -1,0 +1,126 @@
+# -*- coding: utf-8 -*-
+# GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+"""Implements static functions for scraping the VRT NU website(https://www.vrt.be/vrtnu/)"""
+
+from __future__ import absolute_import, division, unicode_literals
+
+try:  # Python 3
+    from urllib.error import HTTPError
+    from urllib.parse import unquote
+    from urllib.request import build_opener, install_opener, urlopen, ProxyHandler
+except ImportError:  # Python 2
+    from urllib2 import build_opener, HTTPError, install_opener, ProxyHandler, unquote, urlopen
+
+from kodiutils import get_cache, get_setting, get_proxies, log, log_error, ttl, update_cache
+from utils import assetpath_to_id, add_https_proto, strip_newlines
+
+install_opener(build_opener(ProxyHandler(get_proxies())))
+
+
+def get_categories():
+    """Return a list of categories by scraping the VRT NU website"""
+
+    cache_file = 'categories.json'
+    categories = []
+
+    # Try the cache if it is fresh
+    categories = get_cache(cache_file, ttl=7 * 24 * 60 * 60)
+
+    # Try to scrape from the web
+    if not categories:
+        from bs4 import BeautifulSoup, SoupStrainer
+        log(2, 'URL get: https://www.vrt.be/vrtnu/categorieen/')
+        response = urlopen('https://www.vrt.be/vrtnu/categorieen/')
+        tiles = SoupStrainer('nui-list--content')
+        soup = BeautifulSoup(response.read(), 'html.parser', parse_only=tiles)
+
+        categories = []
+        for tile in soup.find_all('nui-tile'):
+            categories.append(dict(
+                id=tile.get('href').split('/')[-2],
+                thumbnail=get_category_thumbnail(tile),
+                name=get_category_title(tile),
+            ))
+        if categories:
+            from json import dumps
+            update_cache('categories.json', dumps(categories))
+
+    # Use the cache anyway (better than hard-coded)
+    if not categories:
+        categories = get_cache(cache_file, ttl=None)
+
+    # Fall back to internal hard-coded categories if all else fails
+    if not categories:
+        from data import CATEGORIES
+        categories = CATEGORIES
+    return categories
+
+
+def get_category_thumbnail(element):
+    """Return a category thumbnail, if available"""
+    if get_setting('showfanart', 'true') == 'true':
+        raw_thumbnail = element.find(class_='media').get('data-responsive-image', 'DefaultGenre.png')
+        return add_https_proto(raw_thumbnail)
+    return 'DefaultGenre.png'
+
+
+def get_category_title(element):
+    """Return a category title, if available"""
+    found_element = element.find('a')
+    if found_element:
+        return strip_newlines(found_element.contents[0])
+    # FIXME: We should probably fall back to something sensible here, or raise an exception instead
+    return ''
+
+
+def get_video_attributes(vrtnu_url):
+    """Return a dictionary with video attributes by scraping the VRT NU website"""
+
+    # Get cache
+    cache_file = 'web_video_attrs_multi.json'
+    video_attrs_multi = get_cache(cache_file, ttl=ttl('indirect'))
+    if not video_attrs_multi:
+        video_attrs_multi = dict()
+    if vrtnu_url in video_attrs_multi:
+        return video_attrs_multi[vrtnu_url]
+
+    # Scrape video attributes
+    from bs4 import BeautifulSoup, SoupStrainer
+    log(2, 'URL get: {url}', url=unquote(vrtnu_url))
+    try:
+        html_page = urlopen(vrtnu_url).read()
+    except HTTPError as exc:
+        log_error('Web scraping video attributes failed: {error}', error=exc)
+        return None
+    strainer = SoupStrainer(['section', 'div'], {'class': ['video-player', 'livestream__player']})
+    soup = BeautifulSoup(html_page, 'html.parser', parse_only=strainer)
+    try:
+        video_attrs = soup.find(lambda tag: tag.name == 'nui-media').attrs
+    except AttributeError as exc:
+        log_error('Web scraping video attributes failed: {error}', error=exc)
+        return None
+
+    # Update cache
+    if vrtnu_url in video_attrs_multi:
+        # Update existing
+        video_attrs_multi[vrtnu_url] = video_attrs
+    else:
+        # Create new
+        video_attrs_multi.update({vrtnu_url: video_attrs})
+    from json import dumps
+    update_cache(cache_file, dumps(video_attrs_multi))
+
+    return video_attrs
+
+
+def get_asset_path(vrtnu_url):
+    """Return an asset_path by scraping the VRT NU website"""
+    video_attrs = get_video_attributes(vrtnu_url)
+    asset_path = video_attrs.get('assetpath')
+    return asset_path
+
+
+def get_asset_id(vrtnu_url):
+    """Return an asset_id by scraping the VRT NU website"""
+    asset_id = assetpath_to_id(get_asset_path(vrtnu_url))
+    return asset_id

--- a/test/test_streamservice.py
+++ b/test/test_streamservice.py
@@ -48,7 +48,7 @@ class TestStreamService(unittest.TestCase):
         except HTTPError:
             pass
         else:
-            self.assertEqual(stream.stream_url, video['video_url'])
+            self.assertEqual(None, stream)
 
     @unittest.skipUnless(addon.settings.get('username'), 'Skipping as VRT username is missing.')
     @unittest.skipUnless(addon.settings.get('password'), 'Skipping as VRT password is missing.')

--- a/test/test_vrtplayer.py
+++ b/test/test_vrtplayer.py
@@ -8,7 +8,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import random
 import unittest
 from apihelper import ApiHelper
-from data import CATEGORIES
 from favorites import Favorites
 from resumepoints import ResumePoints
 from vrtplayer import VRTPlayer
@@ -72,16 +71,10 @@ class TestVRTPlayer(unittest.TestCase):
 
         self._vrtplayer.show_episodes_menu(program)
 
-    def test_categories_scraping(self):
-        """Test to ensure our hardcoded categories conforms to scraped categories"""
-        # Remove thumbnails from scraped categories first
-        categories_scraped = [dict(id=c['id'], name=c['name']) for c in self._apihelper.get_categories()]
-        categories_stored = [dict(id=c['id'], name=c['name']) for c in CATEGORIES]
-        self.assertEqual(categories_scraped, categories_stored)
-
     def test_random_tvshow_episodes(self):
         """Rest episode from a random tvshow in a random category"""
-        categories = self._apihelper.get_categories()
+        from webscraper import get_categories
+        categories = get_categories()
         self.assertTrue(categories)
 
         category = random.choice(categories)

--- a/test/test_webscraper.py
+++ b/test/test_webscraper.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+# GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+"""Unit tests for WebScraper functionality"""
+
+# pylint: disable=invalid-name
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+import unittest
+from data import CATEGORIES
+from webscraper import get_categories, get_video_attributes
+
+
+class TestWebScraper(unittest.TestCase):
+    """TestCase class"""
+
+    def test_get_categories(self):
+        """Test to ensure our hardcoded categories conforms to scraped categories"""
+        # Remove thumbnails from scraped categories first
+        categories_scraped = [dict(id=c['id'], name=c['name']) for c in get_categories()]
+        categories_stored = [dict(id=c['id'], name=c['name']) for c in CATEGORIES]
+        self.assertEqual(categories_scraped, categories_stored)
+
+    def test_get_video_attributes(self):
+        """Test getting video attributes"""
+        vrtnu_urls = [
+            'https://www.vrt.be/vrtnu/a-z/girls-talk/2/girls-talk-s2-mannen-kunnen-beter-drinken/',
+            'https://www.vrt.be/vrtnu/a-z/de-ideale-wereld/2019-nj/de-ideale-wereld-d20191219/',
+            'https://www.vrt.be/vrtnu/kanalen/een/',
+            'https://www.vrt.be/vrtnu/kanalen/canvas/',
+            'https://www.vrt.be/vrtnu/kanalen/ketnet/'
+        ]
+        for vrtnu_url in vrtnu_urls:
+            video_attrs = get_video_attributes(vrtnu_url)
+            self.assertTrue(isinstance(video_attrs, dict))
+            self.assertTrue(any(key in video_attrs for key in ['livestream', 'videoid']))
+
+    def test_get_video_attributes_bad_urls(self):
+        """Test getting video attributes using bad urls"""
+        bad_urls = [
+            'https://www.vrt.be/vrtnu/a-z/de-ideale-wereld/2019-nj/de-ideale-wereld-d20191218/',
+            'https://www.vrt.be/vrtnu/kanalen/studio-brussel/',
+            'https://vtm.be/vtmgo'
+        ]
+        for bad_url in bad_urls:
+            video_attrs = get_video_attributes(bad_url)
+            self.assertEqual(None, video_attrs)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This pull request fixes watching activity for programs that don't have an `assetPath` key in VRT NU Search API:
- eva-ontmoet
- een-italiaanse-reis
- vrt-nws-extra
- van-a-tot-z--luc-tuymans
- klimaatbetoog
- de-stad-van-morgen
- van-a-tot-z--piet-hoebeke
- het-koninkrijk-van-rene-heyvaert
- lang-zullen-we-lezen
- van-a-tot-z-johan-braeckman
- van-a-tot-z--edel-maex
- marathonradio
- girls-talk
- van-a-tot-z--connie-palmen
- van-a-tot-z--dirk-de-wachter
- van-a-tot-z
- 22-3-1-jaar-later---het-onderzoek
- live-op-kies19

This pull request includes:
- Move web scraping functionality to separate file
- Improve getting an `asset_id` using web scraping
- Fix for getting a short episode url from VRT Schedule API
- Fix for getting fresh resumepoints when (re)loading TV guide menus

This possibly makes https://github.com/pietje666/plugin.video.vrt.nu/pull/653 redundant.