### PR TITLE
Differentiate between Label and Title

### DIFF
--- a/resources/lib/apihelper.py
+++ b/resources/lib/apihelper.py
@@ -88,7 +88,7 @@ class ApiHelper:
             label += favorite_marker
 
         return TitleItem(
-            title=label,
+            label=label,
             path=url_for('programs', program=program),
             art_dict=self._metadata.get_art(tvshow),
             info_dict=self._metadata.get_info_labels(tvshow),
@@ -170,7 +170,7 @@ class ApiHelper:
         # Add an "* All seasons" list item
         if get_global_setting('videolibrary.showallitems') is True:
             season_items.append(TitleItem(
-                title=localize(30133),  # All seasons
+                label=localize(30133),  # All seasons
                 path=url_for('programs', program=program, season='allseasons'),
                 art_dict=self._metadata.get_art(episode, season='allseasons'),
                 info_dict=info_labels,
@@ -189,7 +189,7 @@ class ApiHelper:
 
             label = '%s %s' % (localize(30131), season_key)  # Season X
             season_items.append(TitleItem(
-                title=label,
+                label=label,
                 path=url_for('programs', program=program, season=season_key),
                 art_dict=self._metadata.get_art(episode, season=True),
                 info_dict=info_labels,
@@ -233,10 +233,11 @@ class ApiHelper:
             label += favorite_marker + watchlater_marker
 
         info_labels = self._metadata.get_info_labels(episode)
+        # FIXME: Due to a bug in Kodi, ListItem.Title is used when Sort methods are used, not ListItem.Label
         info_labels['title'] = label
 
         return TitleItem(
-            title=label,
+            label=label,
             path=url_for('play_id', video_id=episode.get('videoId'), publication_id=episode.get('publicationId')),
             art_dict=self._metadata.get_art(episode),
             info_dict=info_labels,
@@ -370,7 +371,7 @@ class ApiHelper:
         episode = self.get_single_episode_data(video_id=video_id, whatson_id=whatson_id, video_url=video_url)
         if episode:
             video_item = TitleItem(
-                title=self._metadata.get_label(episode),
+                label=self._metadata.get_label(episode),
                 art_dict=self._metadata.get_art(episode),
                 info_dict=self._metadata.get_info_labels(episode),
                 prop_dict=self._metadata.get_properties(episode),
@@ -437,7 +438,7 @@ class ApiHelper:
 
             if start_date and end_date:
                 video_item = TitleItem(
-                    title=self._metadata.get_label(episode_guess_on),
+                    label=self._metadata.get_label(episode_guess_on),
                     art_dict=self._metadata.get_art(episode_guess_on),
                     info_dict=self._metadata.get_info_labels(episode_guess_on, channel=channel, date=start_date),
                     prop_dict=self._metadata.get_properties(episode_guess_on),
@@ -463,7 +464,7 @@ class ApiHelper:
         episode = api_data[0]
         log(2, str(episode))
         video_item = TitleItem(
-            title=self._metadata.get_label(episode),
+            label=self._metadata.get_label(episode),
             art_dict=self._metadata.get_art(episode),
             info_dict=self._metadata.get_info_labels(episode),
             prop_dict=self._metadata.get_properties(episode),
@@ -658,7 +659,7 @@ class ApiHelper:
                 continue
 
             channel_items.append(TitleItem(
-                title=label,
+                label=label,
                 path=path,
                 art_dict=art_dict,
                 info_dict=info_dict,
@@ -706,7 +707,7 @@ class ApiHelper:
                 ))
 
                 youtube_items.append(TitleItem(
-                    title=label,
+                    label=label,
                     path=path,
                     art_dict=art_dict,
                     info_dict=info_dict,
@@ -724,7 +725,7 @@ class ApiHelper:
         for feature in self.localize_features(FEATURED):
             featured_name = feature.get('name')
             featured_items.append(TitleItem(
-                title=featured_name,
+                label=featured_name,
                 path=url_for('featured', feature=feature.get('id')),
                 art_dict=dict(thumb='DefaultCountry.png'),
                 info_dict=dict(plot='[B]%s[/B]' % feature.get('name'), studio='VRT'),
@@ -756,7 +757,7 @@ class ApiHelper:
             else:
                 thumbnail = 'DefaultGenre.png'
             category_items.append(TitleItem(
-                title=category.get('name'),
+                label=category.get('name'),
                 path=url_for('categories', category=category.get('id')),
                 art_dict=dict(thumb=thumbnail, icon='DefaultGenre.png'),
                 info_dict=dict(plot='[B]%s[/B]' % category.get('name'), studio='VRT'),

--- a/resources/lib/helperobjects.py
+++ b/resources/lib/helperobjects.py
@@ -32,9 +32,9 @@ class StreamURLS:
 class TitleItem:
     """This helper object holds all information to be used with Kodi xbmc's ListItem object"""
 
-    def __init__(self, title, path=None, art_dict=None, info_dict=None, stream_dict=None, prop_dict=None, context_menu=None, is_playable=False):
+    def __init__(self, label, path=None, art_dict=None, info_dict=None, stream_dict=None, prop_dict=None, context_menu=None, is_playable=False):
         """The constructor for the TitleItem class"""
-        self.title = title
+        self.label = label
         self.path = path
         self.art_dict = art_dict
         self.info_dict = info_dict

--- a/resources/lib/kodiutils.py
+++ b/resources/lib/kodiutils.py
@@ -21,6 +21,7 @@ SORT_METHODS = dict(
     # genre=xbmcplugin.SORT_METHOD_GENRE,
     # label=xbmcplugin.SORT_METHOD_LABEL_IGNORE_THE,
     label=xbmcplugin.SORT_METHOD_LABEL,
+    title=xbmcplugin.SORT_METHOD_TITLE,
     # none=xbmcplugin.SORT_METHOD_UNSORTED,
     # FIXME: We would like to be able to sort by unprefixed title (ignore date/episode prefix)
     # title=xbmcplugin.SORT_METHOD_TITLE_IGNORE_THE,
@@ -186,7 +187,7 @@ def show_listing(list_items, category=None, sort='unsorted', ascending=True, con
         is_folder = bool(not title_item.is_playable and title_item.path)
         is_playable = bool(title_item.is_playable and title_item.path)
 
-        list_item = ListItem(label=title_item.title)
+        list_item = ListItem(label=title_item.label)
 
         prop_dict = dict(
             IsInternetStream='true' if is_playable else 'false',
@@ -255,7 +256,7 @@ def play(stream, video=None):
 
     play_item = ListItem(path=stream.stream_url)
     if video and hasattr(video, 'info_dict'):
-        play_item.setProperty('subtitle', video.title)
+        play_item.setProperty('subtitle', video.label)
         play_item.setArt(video.art_dict)
         play_item.setInfo(
             type='video',

--- a/resources/lib/search.py
+++ b/resources/lib/search.py
@@ -36,7 +36,7 @@ class Search:
         from helperobjects import TitleItem
         menu_items = [
             TitleItem(
-                title=localize(30424),  # New search...
+                label=localize(30424),  # New search...
                 path=url_for('search_query'),
                 art_dict=dict(thumb='DefaultAddonsSearch.png'),
                 info_dict=dict(plot=localize(30425)),
@@ -47,7 +47,7 @@ class Search:
         history = self.read_history()
         for keywords in history:
             menu_items.append(TitleItem(
-                title=keywords,
+                label=keywords,
                 path=url_for('search_query', keywords=keywords),
                 art_dict=dict(thumb='DefaultAddonsSearch.png'),
                 is_playable=False,
@@ -59,7 +59,7 @@ class Search:
 
         if history:
             menu_items.append(TitleItem(
-                title=localize(30426),  # Clear search history
+                label=localize(30426),  # Clear search history
                 path=url_for('clear_search'),
                 info_dict=dict(plot=localize(30427)),
                 art_dict=dict(thumb='icons/infodialogs/uninstall.png'),
@@ -93,7 +93,7 @@ class Search:
         from helperobjects import TitleItem
         if len(search_items) == int(get_setting('itemsperpage', 50)):
             search_items.append(TitleItem(
-                title=localize(30300),  # More…
+                label=localize(30300),  # More…
                 path=url_for('search_query', keywords=keywords, page=page + 1),
                 art_dict=dict(thumb='DefaultAddonSearch.png'),
                 info_dict=dict(),

--- a/resources/lib/tvguide.py
+++ b/resources/lib/tvguide.py
@@ -71,7 +71,7 @@ class TVGuide:
         date_items = []
         for offset in range(7, -30, -1):
             day = epg + timedelta(days=offset)
-            title = localize_datelong(day)
+            label = localize_datelong(day)
             date = day.strftime('%Y-%m-%d')
 
             # Highlight today with context of 2 days
@@ -81,9 +81,9 @@ class TVGuide:
                 if entry.get('permalink'):
                     date = entry.get('id')
                 if offset == 0:
-                    title = '[COLOR yellow][B]{name}[/B], {date}[/COLOR]'.format(name=date_name, date=title)
+                    label = '[COLOR yellow][B]{name}[/B], {date}[/COLOR]'.format(name=date_name, date=label)
                 else:
-                    title = '[B]{name}[/B], {date}'.format(name=date_name, date=title)
+                    label = '[B]{name}[/B], {date}'.format(name=date_name, date=label)
 
             # Show channel list or channel episodes
             if channel:
@@ -93,7 +93,7 @@ class TVGuide:
 
             cache_file = 'schedule.%s.json' % date
             date_items.append(TitleItem(
-                title=title,
+                label=label,
                 path=path,
                 art_dict=dict(thumb='DefaultYear.png'),
                 info_dict=dict(plot=localize_datelong(day)),
@@ -130,16 +130,16 @@ class TVGuide:
                 art_dict['thumb'] = 'DefaultTags.png'
 
             if date:
-                title = chan.get('label')
+                label = chan.get('label')
                 path = url_for('tvguide', date=date, channel=chan.get('name'))
                 plot = '%s\n%s' % (localize(30302, **chan), datelong)
             else:
-                title = '[B]%s[/B]' % localize(30303, **chan)
+                label = '[B]%s[/B]' % localize(30303, **chan)
                 path = url_for('tvguide_channel', channel=chan.get('name'))
                 plot = '%s\n\n%s' % (localize(30302, **chan), self.live_description(chan.get('name')))
 
             channel_items.append(TitleItem(
-                title=title,
+                label=label,
                 path=path,
                 art_dict=art_dict,
                 info_dict=dict(plot=plot, studio=chan.get('studio')),
@@ -181,10 +181,11 @@ class TVGuide:
                 label += favorite_marker + watchlater_marker
 
             info_labels = self._metadata.get_info_labels(episode, date=date, channel=entry)
+            # FIXME: Due to a bug in Kodi, ListItem.Title is used when Sort methods are used, not ListItem.Label
             info_labels['title'] = label
 
             episode_items.append(TitleItem(
-                title=label,
+                label=label,
                 path=path,
                 art_dict=self._metadata.get_art(episode),
                 info_dict=info_labels,

--- a/resources/lib/vrtplayer.py
+++ b/resources/lib/vrtplayer.py
@@ -31,46 +31,46 @@ class VRTPlayer:
         # Only add 'My favorites' when it has been activated
         if self._favorites.is_activated():
             main_items.append(TitleItem(
-                title=localize(30010),  # My favorites
+                label=localize(30010),  # My favorites
                 path=url_for('favorites_menu'),
                 art_dict=dict(thumb='DefaultFavourites.png'),
                 info_dict=dict(plot=localize(30011)),
             ))
 
         main_items.extend([
-            TitleItem(title=localize(30012),  # All programs
+            TitleItem(label=localize(30012),  # All programs
                       path=url_for('programs'),
                       art_dict=dict(thumb='DefaultMovieTitle.png'),
                       info_dict=dict(plot=localize(30013))),
-            TitleItem(title=localize(30014),  # Categories
+            TitleItem(label=localize(30014),  # Categories
                       path=url_for('categories'),
                       art_dict=dict(thumb='DefaultGenre.png'),
                       info_dict=dict(plot=localize(30015))),
-            TitleItem(title=localize(30016),  # Channels
+            TitleItem(label=localize(30016),  # Channels
                       path=url_for('channels'),
                       art_dict=dict(thumb='DefaultTags.png'),
                       info_dict=dict(plot=localize(30017))),
-            TitleItem(title=localize(30018),  # Live TV
+            TitleItem(label=localize(30018),  # Live TV
                       path=url_for('livetv'),
                       art_dict=dict(thumb='DefaultTVShows.png'),
                       info_dict=dict(plot=localize(30019))),
-            TitleItem(title=localize(30020),  # Recent items
+            TitleItem(label=localize(30020),  # Recent items
                       path=url_for('recent'),
                       art_dict=dict(thumb='DefaultRecentlyAddedEpisodes.png'),
                       info_dict=dict(plot=localize(30021))),
-            TitleItem(title=localize(30022),  # Soon offline
+            TitleItem(label=localize(30022),  # Soon offline
                       path=url_for('offline'),
                       art_dict=dict(thumb='DefaultYear.png'),
                       info_dict=dict(plot=localize(30023))),
-            TitleItem(title=localize(30024),  # Featured content
+            TitleItem(label=localize(30024),  # Featured content
                       path=url_for('featured'),
                       art_dict=dict(thumb='DefaultCountry.png'),
                       info_dict=dict(plot=localize(30025))),
-            TitleItem(title=localize(30026),  # TV guide
+            TitleItem(label=localize(30026),  # TV guide
                       path=url_for('tvguide'),
                       art_dict=dict(thumb='DefaultAddonTvInfo.png'),
                       info_dict=dict(plot=localize(30027))),
-            TitleItem(title=localize(30028),  # Search
+            TitleItem(label=localize(30028),  # Search
                       path=url_for('search'),
                       art_dict=dict(thumb='DefaultAddonsSearch.png'),
                       info_dict=dict(plot=localize(30029))),
@@ -124,15 +124,15 @@ class VRTPlayer:
         """The VRT NU addon 'My programs' menu"""
         self._favorites.refresh(ttl=ttl('indirect'))
         favorites_items = [
-            TitleItem(title=localize(30040),  # My programs
+            TitleItem(label=localize(30040),  # My programs
                       path=url_for('favorites_programs'),
                       art_dict=dict(thumb='DefaultMovieTitle.png'),
                       info_dict=dict(plot=localize(30041))),
-            TitleItem(title=localize(30046),  # My recent items
+            TitleItem(label=localize(30046),  # My recent items
                       path=url_for('favorites_recent'),
                       art_dict=dict(thumb='DefaultRecentlyAddedEpisodes.png'),
                       info_dict=dict(plot=localize(30047))),
-            TitleItem(title=localize(30048),  # My soon offline
+            TitleItem(label=localize(30048),  # My soon offline
                       path=url_for('favorites_offline'),
                       art_dict=dict(thumb='DefaultYear.png'),
                       info_dict=dict(plot=localize(30049))),
@@ -141,13 +141,13 @@ class VRTPlayer:
         # Only add 'My watch later' and 'Continue watching' when it has been activated
         if self._resumepoints.is_activated():
             favorites_items.append(TitleItem(
-                title=localize(30050),  # My watch later
+                label=localize(30050),  # My watch later
                 path=url_for('resumepoints_watchlater'),
                 art_dict=dict(thumb='DefaultVideoPlaylists.png'),
                 info_dict=dict(plot=localize(30051)),
             ))
             favorites_items.append(TitleItem(
-                title=localize(30052),  # Continue Watching
+                label=localize(30052),  # Continue Watching
                 path=url_for('resumepoints_continue'),
                 art_dict=dict(thumb='DefaultInProgressShows.png'),
                 info_dict=dict(plot=localize(30053)),
@@ -155,7 +155,7 @@ class VRTPlayer:
 
         if get_setting('addmymovies', 'true') == 'true':
             favorites_items.append(
-                TitleItem(title=localize(30042),  # My movies
+                TitleItem(label=localize(30042),  # My movies
                           path=url_for('categories', category='films'),
                           art_dict=dict(thumb='DefaultAddonVideo.png'),
                           info_dict=dict(plot=localize(30043))),
@@ -163,7 +163,7 @@ class VRTPlayer:
 
         if get_setting('addmydocu', 'true') == 'true':
             favorites_items.append(
-                TitleItem(title=localize(30044),  # My documentaries
+                TitleItem(label=localize(30044),  # My documentaries
                           path=url_for('favorites_docu'),
                           art_dict=dict(thumb='DefaultMovies.png'),
                           info_dict=dict(plot=localize(30045))),
@@ -262,7 +262,7 @@ class VRTPlayer:
             else:
                 recent = 'recent'
             episode_items.append(TitleItem(
-                title=localize(30300),
+                label=localize(30300),
                 path=url_for(recent, page=page + 1),
                 art_dict=dict(thumb='DefaultRecentlyAddedEpisodes.png'),
                 info_dict=dict(),
@@ -286,7 +286,7 @@ class VRTPlayer:
             else:
                 offline = 'offline'
             episode_items.append(TitleItem(
-                title=localize(30300),
+                label=localize(30300),
                 path=url_for(offline, page=page + 1),
                 art_dict=dict(thumb='DefaultYear.png'),
                 info_dict=dict(),

--- a/test/test_apihelper.py
+++ b/test/test_apihelper.py
@@ -116,7 +116,7 @@ class TestApiHelper(unittest.TestCase):
         bogus_brands = ['lang-zullen-we-lezen', 'VRT']
         channel_studios = [c.get('studio') for c in CHANNELS] + bogus_brands
         for tvshow in tvshow_items:
-            self.assertTrue(tvshow.info_dict['studio'] in channel_studios, '%s | %s | %s' % (tvshow.title, tvshow.info_dict['studio'], channel_studios))
+            self.assertTrue(tvshow.info_dict['studio'] in channel_studios, '%s | %s | %s' % (tvshow.label, tvshow.info_dict['studio'], channel_studios))
 
     def test_get_latest_episode(self):
         """Test getting the latest episode of a program (het-journaal)"""

--- a/test/test_tvguide.py
+++ b/test/test_tvguide.py
@@ -33,24 +33,24 @@ class TestTVGuide(unittest.TestCase):
         date_items = self._tvguide.get_date_items()
         self.assertEqual(len(date_items), 37)
         date_item = random.choice(date_items)
-        print('- %s%s' % (kodi_to_ansi(date_item.title), uri_to_path(date_item.path)))
+        print('- %s%s' % (kodi_to_ansi(date_item.label), uri_to_path(date_item.path)))
         date_items = self._tvguide.get_date_items('today')
         self.assertEqual(len(date_items), 37)
         date_item = random.choice(date_items)
-        print('- %s%s' % (kodi_to_ansi(date_item.title), uri_to_path(date_item.path)))
+        print('- %s%s' % (kodi_to_ansi(date_item.label), uri_to_path(date_item.path)))
 
     def test_tvguide_channel_menu(self):
         """Test channel menu"""
         channel_items = self._tvguide.get_channel_items(channel='een')
         self.assertTrue(channel_items)
         channel_item = random.choice(channel_items)
-        print('- %s%s' % (kodi_to_ansi(channel_item.title), uri_to_path(channel_item.path)))
+        print('- %s%s' % (kodi_to_ansi(channel_item.label), uri_to_path(channel_item.path)))
 
         date = (datetime.now(dateutil.tz.tzlocal()) + timedelta(days=-10)).strftime('%Y-%m-%d')
         channel_items = self._tvguide.get_channel_items(date=date)
         self.assertTrue(channel_items)
         channel_item = random.choice(channel_items)
-        print('- %s%s' % (kodi_to_ansi(channel_item.title), uri_to_path(channel_item.path)))
+        print('- %s%s' % (kodi_to_ansi(channel_item.label), uri_to_path(channel_item.path)))
 
     def test_tvguide_episode_menu(self):
         """Test episode menu"""

--- a/test/test_vrtplayer.py
+++ b/test/test_vrtplayer.py
@@ -88,7 +88,7 @@ class TestVRTPlayer(unittest.TestCase):
             self.assertTrue(episode_items, msg=tvshow.path.split('/')[4])
             self.assertTrue(sort in ['dateadded', 'episode', 'label', 'unsorted'])
             self.assertTrue(ascending is True or ascending is False)
-            self.assertTrue(content in ['episodes', 'seasons'], "Content for '%s' is '%s'" % (tvshow.title, content))
+            self.assertTrue(content in ['episodes', 'seasons'], "Content for '%s' is '%s'" % (tvshow.label, content))
         elif tvshow.path.startswith('plugin://plugin.video.vrt.nu/play/id/'):
             # When random program is playable item
             pass


### PR DESCRIPTION
This PR includes:
- Clear distinction between Label and Title
- Add `get_title()` metadata function
- Add `get_mediatype()` metadata function
- Set proper mediatype for oneoff videos
- Add FIXMEs for a known label/title issue in Kodi/Estuary