### PR TITLE
Fix livestreams

### DIFF
--- a/resources/lib/data.py
+++ b/resources/lib/data.py
@@ -40,7 +40,7 @@ CHANNELS = [
         name='een',
         label='Eén',
         studio='Een',
-        live_stream='https://www.vrt.be/vrtnu/kanalen/een/',
+        live_stream='https://www.vrt.be/vrtnu/livestream/#epgchannel=O8',
         live_stream_id='vualto_een_geo',
         youtube=[
             dict(label='Eén', url='https://www.youtube.com/user/welkombijeen'),
@@ -53,7 +53,7 @@ CHANNELS = [
         name='canvas',
         label='Canvas',
         studio='Canvas',
-        live_stream='https://www.vrt.be/vrtnu/kanalen/canvas/',
+        live_stream='https://www.vrt.be/vrtnu/livestream/#epgchannel=1H',
         live_stream_id='vualto_canvas_geo',
         youtube=[
             dict(label='Canvas', url='https://www.youtube.com/user/CanvasTV'),

--- a/resources/lib/webscraper.py
+++ b/resources/lib/webscraper.py
@@ -92,10 +92,19 @@ def get_video_attributes(vrtnu_url):
     except HTTPError as exc:
         log_error('Web scraping video attributes failed: {error}', error=exc)
         return None
-    strainer = SoupStrainer(['section', 'div'], {'class': ['video-player', 'livestream__player']})
+    strainer = SoupStrainer(['section', 'div'], {'class': ['video-player', 'livestream__inner']})
     soup = BeautifulSoup(html_page, 'html.parser', parse_only=strainer)
+    item = None
+    epg_channel = None
+    if '#epgchannel=' in vrtnu_url:
+        epg_channel = vrtnu_url.split('#epgchannel=')[1]
+    for item in soup:
+        if epg_channel and epg_channel == item.get('data-epgchannel'):
+            break
+    if not epg_channel and len(soup) > 1:
+        return None
     try:
-        video_attrs = soup.find(lambda tag: tag.name == 'nui-media').attrs
+        video_attrs = item.find(name='nui-media').attrs
     except AttributeError as exc:
         log_error('Web scraping video attributes failed: {error}', error=exc)
         return None

--- a/test/test_webscraper.py
+++ b/test/test_webscraper.py
@@ -25,8 +25,8 @@ class TestWebScraper(unittest.TestCase):
         vrtnu_urls = [
             'https://www.vrt.be/vrtnu/a-z/girls-talk/2/girls-talk-s2-mannen-kunnen-beter-drinken/',
             'https://www.vrt.be/vrtnu/a-z/de-ideale-wereld/2019-nj/de-ideale-wereld-d20191219/',
-            'https://www.vrt.be/vrtnu/kanalen/een/',
-            'https://www.vrt.be/vrtnu/kanalen/canvas/',
+            'https://www.vrt.be/vrtnu/livestream/#epgchannel=O8',  # Eén
+            'https://www.vrt.be/vrtnu/livestream/#epgchannel=1H',  # Canvas
             'https://www.vrt.be/vrtnu/kanalen/ketnet/'
         ]
         for vrtnu_url in vrtnu_urls:


### PR DESCRIPTION
VRT removed the live stream player from the channel pages of Eén and Canvas (https://www.vrt.be/vrtnu/kanalen/een/ https://www.vrt.be/vrtnu/kanalen/canvas/) and this broke web scraping live stream attributes for Eén and Canvas.
This pull request fixes this.

This was not really a problem for existing add-on functionality, because the add-on relies on `live_stream_id` in `data.py`, but it's good to keep web scraping up to date as a fallback.
