### PR TITLE
Always preserve Up Next resumepoints

### DIFF
--- a/resources/lib/playerinfo.py
+++ b/resources/lib/playerinfo.py
@@ -53,6 +53,9 @@ class PlayerInfo(Player, object):  # pylint: disable=useless-object-inheritance
 
         log(3, '[PlayerInfo %d] Event onPlayBackStarted' % self.thread_id)
 
+        # Set property to let wait_for_resumepoints function know that update resume is busy
+        set_property('vrtnu_resumepoints', 'busy')
+
         # Update previous episode when using "Up Next"
         if self.path.startswith('plugin://plugin.video.vrt.nu/play/upnext'):
             self.push_position(position=self.last_pos, total=self.total)
@@ -70,6 +73,9 @@ class PlayerInfo(Player, object):  # pylint: disable=useless-object-inheritance
             if ep_id.get('video_id') and ep_id.get('video_id') == channel.get('live_stream_id'):
                 log(3, '[PlayerInfo %d] Avoid setting resumepoints for livestream %s' % (self.thread_id, ep_id.get('video_id')))
                 self.listen = False
+
+                # Reset vrtnu_resumepoints property before return
+                set_property('vrtnu_resumepoints', None)
                 return
 
         # Get episode data needed to update resumepoints from VRT NU Search API
@@ -77,6 +83,8 @@ class PlayerInfo(Player, object):  # pylint: disable=useless-object-inheritance
 
         # Avoid setting resumepoints without episode data
         if episode is None:
+            # Reset vrtnu_resumepoints property before return
+            set_property('vrtnu_resumepoints', None)
             return
 
         from metadata import Metadata
@@ -115,15 +123,10 @@ class PlayerInfo(Player, object):  # pylint: disable=useless-object-inheritance
         log(3, '[PlayerInfo %d] Event onPlayBackSeek time=%d offset=%d' % (self.thread_id, time, seekOffset))
         self.last_pos = time // 1000
 
-        # If we seek beyond the start or end, set property to let wait_for_resumepoints function know that update resume is busy
+        # If we seek beyond the end, exit Player
         if self.last_pos >= self.total:
-            set_property('vrtnu_resumepoints', 'busy')
-            # Exit Player faster
             self.quit.set()
             self.stop()
-
-        if self.last_pos < 0:
-            set_property('vrtnu_resumepoints', 'busy')
 
     def onPlayBackPaused(self):  # pylint: disable=invalid-name
         """Called when user pauses a playing file"""
@@ -170,6 +173,9 @@ class PlayerInfo(Player, object):  # pylint: disable=useless-object-inheritance
         self.positionthread = None
         self.push_position(position=self.last_pos, total=self.total)
 
+        # Set property to let wait_for_resumepoints function know that update resume is done
+        set_property('vrtnu_resumepoints', 'ready')
+
     def stream_position(self):
         """Get latest stream position while playing"""
         while self.isPlaying() and not self.quit.is_set():
@@ -180,6 +186,9 @@ class PlayerInfo(Player, object):  # pylint: disable=useless-object-inheritance
 
     def add_upnext(self, video_id):
         """Add Up Next url to Kodi Player"""
+        # Reset vrtnu_resumepoints property
+        set_property('vrtnu_resumepoints', None)
+
         url = 'plugin://plugin.video.vrt.nu/play/upnext/%s' % video_id
         self.update_position()
         self.update_total()
@@ -231,9 +240,6 @@ class PlayerInfo(Player, object):  # pylint: disable=useless-object-inheritance
         if not self.asset_id:
             return
 
-        # Set property to let wait_for_resumepoints function know that update resume is busy
-        set_property('vrtnu_resumepoints', 'busy')
-
         # Push resumepoint to VRT NU
         self.resumepoints.update(
             asset_id=self.asset_id,
@@ -241,8 +247,6 @@ class PlayerInfo(Player, object):  # pylint: disable=useless-object-inheritance
             url=self.url,
             position=position,
             total=total,
-            whatson_id=self.whatson_id
+            whatson_id=self.whatson_id,
+            path=self.path
         )
-
-        # Set property to let wait_for_resumepoints function know that update resume is done
-        set_property('vrtnu_resumepoints', 'ready')

--- a/resources/lib/resumepoints.py
+++ b/resources/lib/resumepoints.py
@@ -61,7 +61,7 @@ class ResumePoints:
         if resumepoints_json is not None:
             self._data = resumepoints_json
 
-    def update(self, asset_id, title, url, watch_later=None, position=None, total=None, whatson_id=None):
+    def update(self, asset_id, title, url, watch_later=None, position=None, total=None, whatson_id=None, path=None):
         """Set program resumepoint or watchLater status and update local copy"""
 
         menu_caches = []
@@ -73,7 +73,11 @@ class ResumePoints:
             total = self.get_total(asset_id)
 
         # Update
-        if self.still_watching(position, total) or watch_later is True:
+        if (self.still_watching(position, total) or watch_later is True
+                or (path and path.startswith('plugin://plugin.video.vrt.nu/play/upnext'))):
+            # Normally, VRT NU resumepoints are deleted when an episode is (un)watched and Kodi GUI automatically sets the (un)watched status when Kodi Player exits.
+            # This mechanism doesn't work with "Up Next" episodes because these episodes are not initiated from a ListItem in Kodi GUI.
+            # For "Up Next" episodes, we should never delete the VRT NU resumepoints to make sure the watched status can be forced in Kodi GUI using the playcount infolabel.
 
             log(3, "[Resumepoints] Update resumepoint '{asset_id}' {position}/{total}", asset_id=asset_id, position=position, total=total)
 


### PR DESCRIPTION
Normally, VRT NU resumepoints are deleted when an episode is (un)watched and Kodi GUI automatically sets the (un)watched status when Kodi Player exits.

This mechanism doesn't work with "Up Next" episodes because these episodes are not initiated from a ListItem in Kodi GUI. Preserving the VRT NU resumepoints for "Up Next" makes sure the watched status can be forced in Kodi GUI using the playcount infolabel.

This pull request fixes https://github.com/pietje666/plugin.video.vrt.nu/issues/661