### PR TITLE
Check if categories contain all necessary info

### DIFF
--- a/resources/lib/webscraper.py
+++ b/resources/lib/webscraper.py
@@ -17,6 +17,11 @@ from utils import assetpath_to_id, add_https_proto, strip_newlines
 install_opener(build_opener(ProxyHandler(get_proxies())))
 
 
+def valid_categories(categories):
+    """Check if categories contain all necessary keys and values"""
+    return bool(categories) and all(item.get('id') and item.get('name') for item in categories)
+
+
 def get_categories():
     """Return a list of categories by scraping the VRT NU website"""
 
@@ -27,7 +32,7 @@ def get_categories():
     categories = get_cache(cache_file, ttl=7 * 24 * 60 * 60)
 
     # Try to scrape from the web
-    if not categories:
+    if not valid_categories(categories):
         from bs4 import BeautifulSoup, SoupStrainer
         log(2, 'URL get: https://www.vrt.be/vrtnu/categorieen/')
         response = urlopen('https://www.vrt.be/vrtnu/categorieen/')
@@ -46,11 +51,11 @@ def get_categories():
             update_cache('categories.json', dumps(categories))
 
     # Use the cache anyway (better than hard-coded)
-    if not categories:
+    if not valid_categories(categories):
         categories = get_cache(cache_file, ttl=None)
 
     # Fall back to internal hard-coded categories if all else fails
-    if not categories:
+    if not valid_categories(categories):
         from data import CATEGORIES
         categories = CATEGORIES
     return categories

--- a/test/test_webscraper.py
+++ b/test/test_webscraper.py
@@ -7,7 +7,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 from data import CATEGORIES
-from webscraper import get_categories, get_video_attributes
+from webscraper import get_categories, get_video_attributes, valid_categories
 
 
 class TestWebScraper(unittest.TestCase):
@@ -18,6 +18,8 @@ class TestWebScraper(unittest.TestCase):
         # Remove thumbnails from scraped categories first
         categories_scraped = [dict(id=c['id'], name=c['name']) for c in get_categories()]
         categories_stored = [dict(id=c['id'], name=c['name']) for c in CATEGORIES]
+        self.assertTrue(valid_categories(categories_scraped))
+        self.assertTrue(valid_categories(categories_stored))
         self.assertEqual(categories_scraped, categories_stored)
 
     def test_get_video_attributes(self):


### PR DESCRIPTION
The previous check `if not categories` didn't detect when `name` or `id` was empty and this implies that in some cases the fallback to the internal hard-coded categories doesn't work in v2.3.1 and earlier.

When the cache expires all users will get a blanco categories listing, all new users got already a blanco categories listing when opening the categories menu:

![Screenshot at 2020-01-16 20-56-39](https://user-images.githubusercontent.com/45148099/72558324-c047a680-38a2-11ea-9699-791dbb22f682.png)


We need a 2.3.2 release as soon as possible.