### PR TITLE
Improve tv guide range: 3 weeks past, 2 weeks future

### DIFF
--- a/resources/lib/tvguide.py
+++ b/resources/lib/tvguide.py
@@ -69,7 +69,7 @@ class TVGuide:
         if epg.hour < 6:
             epg += timedelta(days=-1)
         date_items = []
-        for offset in range(7, -30, -1):
+        for offset in range(14, -19, -1):
             day = epg + timedelta(days=offset)
             label = localize_datelong(day)
             date = day.strftime('%Y-%m-%d')

--- a/test/test_tvguide.py
+++ b/test/test_tvguide.py
@@ -31,11 +31,11 @@ class TestTVGuide(unittest.TestCase):
     def test_tvguide_date_menu(self):
         """Test TV guide main menu"""
         date_items = self._tvguide.get_date_items()
-        self.assertEqual(len(date_items), 37)
+        self.assertEqual(len(date_items), 33)
         date_item = random.choice(date_items)
         print('- %s%s' % (kodi_to_ansi(date_item.label), uri_to_path(date_item.path)))
         date_items = self._tvguide.get_date_items('today')
-        self.assertEqual(len(date_items), 37)
+        self.assertEqual(len(date_items), 33)
         date_item = random.choice(date_items)
         print('- %s%s' % (kodi_to_ansi(date_item.label), uri_to_path(date_item.path)))
 

--- a/test/xbmcextra.py
+++ b/test/xbmcextra.py
@@ -183,5 +183,6 @@ def import_language(language):
 
     return podb
 
+
 ADDON_INFO = read_addon_xml('addon.xml')
 ADDON_ID = next(iter(list(ADDON_INFO.values()))).get('id')


### PR DESCRIPTION
Apparently the range for the EPG has changed a bit.

The downside of this is that **Today** is not longer visible from the listing. I would prefer a better view for this.