### PR TITLE
Fix webscraper and apihelper tests

### DIFF
--- a/test/test_apihelper.py
+++ b/test/test_apihelper.py
@@ -48,7 +48,7 @@ class TestApiHelper(unittest.TestCase):
     def test_get_api_data_specific_season(self):
         """Test listing episodes for a specific season (pano)"""
         title_items, sort, ascending, content = self._apihelper.list_episodes(program='pano')
-        self.assertEqual(len(title_items), 5)
+        self.assertEqual(len(title_items), 6)
         self.assertEqual(sort, 'label')
         self.assertFalse(ascending)
         self.assertEqual(content, 'seasons')

--- a/test/test_webscraper.py
+++ b/test/test_webscraper.py
@@ -29,7 +29,7 @@ class TestWebScraper(unittest.TestCase):
             'https://www.vrt.be/vrtnu/a-z/de-ideale-wereld/2019-nj/de-ideale-wereld-d20191219/',
             'https://www.vrt.be/vrtnu/livestream/#epgchannel=O8',  # Eén
             'https://www.vrt.be/vrtnu/livestream/#epgchannel=1H',  # Canvas
-            'https://www.vrt.be/vrtnu/kanalen/ketnet/'
+            'https://www.vrt.be/vrtnu/livestream/#epgchannel=O9'  # Ketnet
         ]
         for vrtnu_url in vrtnu_urls:
             video_attrs = get_video_attributes(vrtnu_url)


### PR DESCRIPTION
This fixes two unit tests:
- VRT removed the Ketnet livestream from https://www.vrt.be/vrtnu/kanalen/ketnet/, so we shouldn't look for a livestream on this url anymore.
- VRT added a 2020 Pano season, so number of items to test for should be increased with 1.